### PR TITLE
fix: Strava redirect URI, sync fixes, week selector & UI polish

### DIFF
--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -117,7 +117,7 @@ export default function SettingsPage() {
     const state = crypto.randomUUID();
     localStorage.setItem(STRAVA_CSRF_KEY, state);
 
-    const redirectUri = `${window.location.origin}/settings?tab=integrations`;
+    const redirectUri = `${import.meta.env.VITE_APP_URL ?? window.location.origin}/settings?tab=integrations`;
     const params = new URLSearchParams({
       client_id: import.meta.env.VITE_STRAVA_CLIENT_ID ?? '',
       redirect_uri: redirectUri,

--- a/supabase/functions/strava-auth/index.ts
+++ b/supabase/functions/strava-auth/index.ts
@@ -41,7 +41,9 @@ Deno.serve(async (req) => {
     });
 
     if (!tokenRes.ok) {
-      return json({ error: 'exchange_failed' }, 400);
+      const errBody = await tokenRes.text().catch(() => '');
+      console.error(`Strava token exchange failed (${tokenRes.status}):`, errBody);
+      return json({ error: 'exchange_failed', detail: errBody, status: tokenRes.status }, 400);
     }
 
     const tokenData = await tokenRes.json() as {


### PR DESCRIPTION
## Summary
- **Week selector**: prev/next navigation on Strava Sync button to sync any past week
- **Strava sync fixes**: resolved partial update failures (HR int coercion, session double-matching, `synced` counter accuracy), deployed all edge functions with `--no-verify-jwt`
- **Redirect URI**: use `VITE_APP_URL` env var for Strava OAuth redirect so it works consistently on localhost, Vercel preview, and production — set `VITE_APP_URL` in Vercel env vars and register the domain in Strava API settings
- **Auth deadlock fix**: made `onAuthStateChange` callback synchronous (deferred async profile load via `setTimeout`) to prevent Supabase JS v2 auth lock deadlock
- **Week Summary redesign**: two-column Plan / Performance layout with full EN + PL translations
- **UI tweaks**: performance chips collapsed by default, Strava badge dark mode colours, removed StravaDataPlaceholder, load type selector hidden in athlete (readonly) view, suppressed hydration mismatch warning

## Test plan
- [ ] Connect Strava on localhost — should redirect back correctly
- [ ] Connect Strava on Vercel preview (after setting `VITE_APP_URL`) — should redirect back correctly
- [ ] Set `VITE_APP_URL=https://your-domain.vercel.app` in Vercel environment variables
- [ ] Register that domain as "Authorization Callback Domain" in Strava API settings
- [ ] Navigate to Settings → Integrations, use `<` / `>` to pick a past week and click Sync
- [ ] Confirm all matched sessions are updated (check HR values are integers in DB)
- [ ] Week Summary shows correct completed-only time, progress, and stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)