### PR TITLE
feat: Vitest test suite, mock-data refactor, URL locale routing, changelog automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test:run
+
+  release:
+    name: Release
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec release-it --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 # Supabase seed files (contain personal accounts / credentials)
 supabase/seed.ts
 supabase/seed.sql
+
+# Test coverage
+/coverage/
+
+# Logs
+*.log

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,19 @@
+{
+  "git": {
+    "commitMessage": "chore: release v${version}",
+    "tagName": "v${version}",
+    "requireBranch": "main"
+  },
+  "github": {
+    "release": true
+  },
+  "npm": {
+    "publish": false
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": "conventionalcommits",
+      "infile": "CHANGELOG.md"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-03-09
+
+### Features
+
+- **001-sheets-data-migration**: Imported historical training data from Google Sheets into Supabase; established `week_plans` and `training_sessions` schema with ISO-week structure
+- **002**: Coach/athlete role-based access control; multi-athlete coach workspace with athlete picker and session isolation
+- **003**: Training session CRUD (create, update, delete) with optimistic UI; sport-specific type fields (run, cycling, strength, yoga, mobility, swimming, rest day, walk/hike)
+- **004-settings-strava**: Settings page with profile management and Strava OAuth integration; avatar upload via Supabase Storage; week-selector navigation
+- **005-tests-refactor**: Vitest test suite covering date utilities, week-view computation, row mappers, and data-layer integration; codebase refactor (mock-data split, SessionForm extraction); URL-based locale routing with `/pl/` and `/en/` prefixes; Polish as default language; automated changelog with release-it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ Use namespace prefix in `useTranslation`: `useTranslation('training')` → `t('k
 
 ## Mock Mode
 Mock mode activates automatically when Supabase credentials are missing/placeholder.
-- Mock data lives in `app/lib/mock-data.ts`
+- Mock data lives in `app/lib/mock-data/` (split by domain: sessions, weeks, profile, strava)
 - Both real and mock implementations live in the same query file
 - When adding new DB features: implement mock version first, then real Supabase version
 
@@ -297,6 +297,11 @@ When writing new migrations, place in `supabase/migrations/` with prefix `00N_`.
 - Supabase (PostgreSQL) — `training_sessions` and `week_plans` tables extended (001-sheets-data-migration)
 - TypeScript 5 (strict) + React 19 + React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui (New York), i18next, Zod 4, date-fns 4 (004-settings-strava)
 - PostgreSQL via Supabase; Supabase Storage for avatars; Supabase Edge Functions for Strava OAuth (004-settings-strava)
+- TypeScript 5 (strict), React 19 + React Router 7 (SPA, `ssr: false`), TanStack Query 5, Supabase JS 2, i18next + react-i18next, Zod 4, date-fns 4 (005-tests-refactor)
+- Vitest 4, @testing-library/react 16, jsdom — test suite covering unit + integration layers (005-tests-refactor)
+- release-it + @release-it/conventional-changelog — automated versioning and CHANGELOG on merge to main (005-tests-refactor)
+- URL-based locale routing (`/:locale/...`), Polish default (`pl`), English toggle (`en`) (005-tests-refactor)
+- Supabase (PostgreSQL) — mock mode used in all tests (005-tests-refactor)
 
 ## Recent Changes
 - 001-sheets-data-migration: Added TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, Zod 4, date-fns 4, papaparse (devDependency — migration script only)

--- a/app/components/calendar/WeekNavigation.tsx
+++ b/app/components/calendar/WeekNavigation.tsx
@@ -9,6 +9,7 @@ import {
   getCurrentWeekId,
   parseWeekId,
 } from '~/lib/utils/date';
+import { useLocalePath } from '~/lib/hooks/useLocalePath';
 
 interface WeekNavigationProps {
   weekId: string;
@@ -18,6 +19,7 @@ interface WeekNavigationProps {
 export function WeekNavigation({ weekId, basePath }: WeekNavigationProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const localePath = useLocalePath();
   const { weekNumber } = parseWeekId(weekId);
   const { formatted } = getWeekDateRange(weekId);
   const isCurrentWeek = weekId === getCurrentWeekId();
@@ -28,7 +30,7 @@ export function WeekNavigation({ weekId, basePath }: WeekNavigationProps) {
         variant="outline"
         size="icon"
         className="h-8 w-8 sm:h-9 sm:w-9"
-        onClick={() => navigate(`/${basePath}/week/${getPrevWeekId(weekId)}`)}
+        onClick={() => navigate(localePath(`/${basePath}/week/${getPrevWeekId(weekId)}`))}
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
@@ -44,7 +46,7 @@ export function WeekNavigation({ weekId, basePath }: WeekNavigationProps) {
         variant="outline"
         size="icon"
         className="h-8 w-8 sm:h-9 sm:w-9"
-        onClick={() => navigate(`/${basePath}/week/${getNextWeekId(weekId)}`)}
+        onClick={() => navigate(localePath(`/${basePath}/week/${getNextWeekId(weekId)}`))}
       >
         <ChevronRight className="h-4 w-4" />
       </Button>
@@ -53,9 +55,7 @@ export function WeekNavigation({ weekId, basePath }: WeekNavigationProps) {
         <Button
           variant="ghost"
           size="sm"
-          onClick={() =>
-            navigate(`/${basePath}/week/${getCurrentWeekId()}`)
-          }
+          onClick={() => navigate(localePath(`/${basePath}/week/${getCurrentWeekId()}`))}
           className="ml-1 sm:ml-2 text-xs"
         >
           {t('common:today', 'Today')}

--- a/app/components/layout/LanguageToggle.tsx
+++ b/app/components/layout/LanguageToggle.tsx
@@ -1,14 +1,27 @@
+import { useNavigate, useParams, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Button } from '~/components/ui/button';
 import { Languages } from 'lucide-react';
 
 export function LanguageToggle() {
+  const navigate = useNavigate();
+  const { locale } = useParams<{ locale?: string }>();
+  const { pathname } = useLocation();
   const { i18n } = useTranslation();
 
+  const currentLocale = locale ?? (localStorage.getItem('locale') ?? 'pl');
+  const newLocale = currentLocale === 'en' ? 'pl' : 'en';
+
   const toggleLanguage = () => {
-    const newLang = i18n.language === 'en' ? 'pl' : 'en';
-    i18n.changeLanguage(newLang);
-    localStorage.setItem('language', newLang);
+    localStorage.setItem('locale', newLocale);
+    if (locale) {
+      // Inside a locale route — navigate by replacing the locale segment
+      const newPath = pathname.replace(/^\/[^/]+/, `/${newLocale}`);
+      navigate(newPath);
+    } else {
+      // Outside locale routes (e.g. login page) — just change i18n language
+      i18n.changeLanguage(newLocale);
+    }
   };
 
   return (
@@ -19,7 +32,7 @@ export function LanguageToggle() {
       className="gap-1.5"
     >
       <Languages className="h-4 w-4" />
-      {i18n.language === 'en' ? 'PL' : 'EN'}
+      {currentLocale === 'en' ? 'PL' : 'EN'}
     </Button>
   );
 }

--- a/app/components/layout/UserMenu.tsx
+++ b/app/components/layout/UserMenu.tsx
@@ -2,6 +2,7 @@ import { LogOut, Settings, User } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
+import { useLocalePath } from '~/lib/hooks/useLocalePath';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,6 +17,7 @@ export function UserMenu() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const localePath = useLocalePath();
 
   if (!user) return null;
 
@@ -47,7 +49,7 @@ export function UserMenu() {
           <p className="text-xs text-muted-foreground">{user.email}</p>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => navigate('/settings')}>
+        <DropdownMenuItem onClick={() => navigate(localePath('/settings'))}>
           <Settings className="mr-2 h-4 w-4" />
           {t('settings.title')}
         </DropdownMenuItem>

--- a/app/components/training/SessionForm.tsx
+++ b/app/components/training/SessionForm.tsx
@@ -8,20 +8,8 @@ import {
   SheetFooter,
 } from '~/components/ui/sheet';
 import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
-import { Textarea } from '~/components/ui/textarea';
-import { Badge } from '~/components/ui/badge';
-import { Separator } from '~/components/ui/separator';
-import { trainingTypeConfig } from '~/lib/utils/training-types';
-import { RunFields } from './type-fields/RunFields';
-import { CyclingFields } from './type-fields/CyclingFields';
-import { StrengthFields } from './type-fields/StrengthFields';
-import { YogaMobilityFields } from './type-fields/YogaMobilityFields';
-import { SwimmingFields } from './type-fields/SwimmingFields';
-import { RestDayFields } from './type-fields/RestDayFields';
-import { WalkHikeFields } from './type-fields/WalkHikeFields';
+import { SessionFormFields } from './SessionFormFields';
 import {
-  TRAINING_TYPES,
   type TrainingType,
   type DayOfWeek,
   type TrainingSession,
@@ -47,16 +35,14 @@ export function SessionForm({
   session,
   onSubmit,
 }: SessionFormProps) {
-  const { t } = useTranslation(['coach', 'common', 'training']);
+  const { t } = useTranslation(['coach', 'common']);
   const isEditing = !!session;
 
   const [trainingType, setTrainingType] = useState<TrainingType>(
     session?.trainingType ?? 'run'
   );
   const [description, setDescription] = useState(session?.description ?? '');
-  const [coachComments, setCoachComments] = useState(
-    session?.coachComments ?? ''
-  );
+  const [coachComments, setCoachComments] = useState(session?.coachComments ?? '');
   const [durationMinutes, setDurationMinutes] = useState(
     session?.plannedDurationMinutes?.toString() ?? ''
   );
@@ -114,17 +100,11 @@ export function SessionForm({
 
   const handleTypeChange = (newType: TrainingType) => {
     setTrainingType(newType);
-    // Reset type-specific data when type changes, but handle yoga/mobility sharing
-    if (newType === 'yoga' || newType === 'mobility') {
-      setTypeData({ type: newType });
-    } else {
-      setTypeData({ type: newType } as TypeSpecificData);
-    }
+    setTypeData({ type: newType } as TypeSpecificData);
   };
 
   const handleSubmit = () => {
     const typeSpecificData = { ...typeData, type: trainingType } as TypeSpecificData;
-
     const actualFields = {
       actualDurationMinutes: actualDuration ? parseInt(actualDuration) : null,
       actualDistanceKm: actualDistance ? parseFloat(actualDistance) : null,
@@ -164,29 +144,6 @@ export function SessionForm({
     onClose();
   };
 
-  const renderTypeFields = () => {
-    switch (trainingType) {
-      case 'run':
-        return <RunFields data={typeData as Partial<import('~/types/training').RunData>} onChange={setTypeData} />;
-      case 'cycling':
-        return <CyclingFields data={typeData as Partial<import('~/types/training').CyclingData>} onChange={setTypeData} />;
-      case 'strength':
-        return <StrengthFields data={typeData as Partial<import('~/types/training').StrengthData>} onChange={setTypeData} />;
-      case 'yoga':
-      case 'mobility':
-        return <YogaMobilityFields data={typeData as Partial<import('~/types/training').YogaMobilityData>} onChange={setTypeData} />;
-      case 'swimming':
-        return <SwimmingFields data={typeData as Partial<import('~/types/training').SwimmingData>} onChange={setTypeData} />;
-      case 'walk':
-      case 'hike':
-        return <WalkHikeFields data={typeData as Partial<import('~/types/training').WalkData>} onChange={setTypeData} />;
-      case 'rest_day':
-        return <RestDayFields data={typeData as Partial<import('~/types/training').RestDayData>} onChange={setTypeData} />;
-      default:
-        return null;
-    }
-  };
-
   return (
     <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
       <SheetContent className="overflow-y-auto sm:max-w-md">
@@ -196,193 +153,34 @@ export function SessionForm({
           </SheetTitle>
         </SheetHeader>
 
-        <div className="space-y-4 py-4">
-          {/* Training Type Selector */}
-          <div>
-            <label className="text-sm font-medium mb-2 block">
-              {t('coach:session.type')}
-            </label>
-            <div className="flex flex-wrap gap-1.5">
-              {TRAINING_TYPES.map((tt) => {
-                const config = trainingTypeConfig[tt];
-                const isSelected = trainingType === tt;
-                return (
-                  <Badge
-                    key={tt}
-                    variant={isSelected ? 'default' : 'outline'}
-                    className={`cursor-pointer transition-colors ${
-                      isSelected
-                        ? `${config.bgColor} ${config.color} border-0`
-                        : 'hover:bg-muted'
-                    }`}
-                    onClick={() => handleTypeChange(tt)}
-                  >
-                    {t(`common:trainingTypes.${tt}`)}
-                  </Badge>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Common Fields */}
-          <div>
-            <label className="text-sm font-medium">
-              {t('coach:session.description')}
-            </label>
-            <Textarea
-              placeholder={t('coach:session.descriptionPlaceholder')}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-sm font-medium">
-                {t('coach:session.duration')}
-              </label>
-              <Input
-                type="number"
-                placeholder="0"
-                value={durationMinutes}
-                onChange={(e) => setDurationMinutes(e.target.value)}
-              />
-            </div>
-            <div>
-              <label className="text-sm font-medium">
-                {t('coach:session.distance')}
-              </label>
-              <Input
-                type="number"
-                step="0.1"
-                placeholder="0"
-                value={distanceKm}
-                onChange={(e) => setDistanceKm(e.target.value)}
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">
-              {t('coach:session.coachComments')}
-            </label>
-            <Textarea
-              placeholder={t('coach:session.coachCommentsPlaceholder')}
-              value={coachComments}
-              onChange={(e) => setCoachComments(e.target.value)}
-              rows={2}
-            />
-          </div>
-
-          {/* Type-specific fields */}
-          {trainingType !== 'rest_day' || true ? (
-            <>
-              <Separator />
-              <div>
-                <h4 className="text-sm font-semibold mb-3">
-                  {t(`common:trainingTypes.${trainingType}`)} details
-                </h4>
-                {renderTypeFields()}
-              </div>
-            </>
-          ) : null}
-
-          {/* Actual Performance */}
-          <Separator />
-          <div className="space-y-3">
-            <h4 className="text-sm font-semibold">
-              {t('training:actualPerformance.title')}
-            </h4>
-
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="text-sm font-medium">
-                  {t('training:actualPerformance.duration')} ({t('training:units.min')})
-                </label>
-                <Input
-                  type="number"
-                  placeholder="0"
-                  value={actualDuration}
-                  onChange={(e) => setActualDuration(e.target.value)}
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium">
-                  {t('training:actualPerformance.distance')} ({t('training:units.km')})
-                </label>
-                <Input
-                  type="number"
-                  step="0.01"
-                  placeholder="0"
-                  value={actualDistance}
-                  onChange={(e) => setActualDistance(e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="text-sm font-medium">
-                {t('training:actualPerformance.pace')} ({t('training:units.perKm')})
-              </label>
-              <Input
-                placeholder="5:30"
-                value={actualPace}
-                onChange={(e) => setActualPace(e.target.value)}
-              />
-            </div>
-
-            <div className="grid grid-cols-3 gap-3">
-              <div>
-                <label className="text-sm font-medium">
-                  {t('training:actualPerformance.avgHr')} ({t('training:units.bpm')})
-                </label>
-                <Input
-                  type="number"
-                  placeholder="0"
-                  value={avgHr}
-                  onChange={(e) => setAvgHr(e.target.value)}
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium">
-                  {t('training:actualPerformance.maxHr')} ({t('training:units.bpm')})
-                </label>
-                <Input
-                  type="number"
-                  placeholder="0"
-                  value={maxHr}
-                  onChange={(e) => setMaxHr(e.target.value)}
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium">
-                  {t('training:actualPerformance.rpe')} (1–10)
-                </label>
-                <Input
-                  type="number"
-                  min="1"
-                  max="10"
-                  placeholder="–"
-                  value={rpe}
-                  onChange={(e) => setRpe(e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="text-sm font-medium">
-                {t('training:coachPostFeedback.label')}
-              </label>
-              <Textarea
-                placeholder={t('training:coachPostFeedback.placeholder')}
-                value={coachPostFeedback}
-                onChange={(e) => setCoachPostFeedback(e.target.value)}
-                rows={2}
-              />
-            </div>
-          </div>
-        </div>
+        <SessionFormFields
+          trainingType={trainingType}
+          onTypeChange={handleTypeChange}
+          description={description}
+          onDescriptionChange={setDescription}
+          coachComments={coachComments}
+          onCoachCommentsChange={setCoachComments}
+          durationMinutes={durationMinutes}
+          onDurationChange={setDurationMinutes}
+          distanceKm={distanceKm}
+          onDistanceChange={setDistanceKm}
+          typeData={typeData}
+          onTypeDataChange={setTypeData}
+          actualDuration={actualDuration}
+          onActualDurationChange={setActualDuration}
+          actualDistance={actualDistance}
+          onActualDistanceChange={setActualDistance}
+          actualPace={actualPace}
+          onActualPaceChange={setActualPace}
+          avgHr={avgHr}
+          onAvgHrChange={setAvgHr}
+          maxHr={maxHr}
+          onMaxHrChange={setMaxHr}
+          rpe={rpe}
+          onRpeChange={setRpe}
+          coachPostFeedback={coachPostFeedback}
+          onCoachPostFeedbackChange={setCoachPostFeedback}
+        />
 
         <SheetFooter>
           <Button variant="outline" onClick={onClose}>

--- a/app/components/training/SessionFormFields.tsx
+++ b/app/components/training/SessionFormFields.tsx
@@ -1,0 +1,296 @@
+import { useTranslation } from 'react-i18next';
+import { Input } from '~/components/ui/input';
+import { Textarea } from '~/components/ui/textarea';
+import { Badge } from '~/components/ui/badge';
+import { Separator } from '~/components/ui/separator';
+import { trainingTypeConfig } from '~/lib/utils/training-types';
+import { RunFields } from './type-fields/RunFields';
+import { CyclingFields } from './type-fields/CyclingFields';
+import { StrengthFields } from './type-fields/StrengthFields';
+import { YogaMobilityFields } from './type-fields/YogaMobilityFields';
+import { SwimmingFields } from './type-fields/SwimmingFields';
+import { RestDayFields } from './type-fields/RestDayFields';
+import { WalkHikeFields } from './type-fields/WalkHikeFields';
+import {
+  TRAINING_TYPES,
+  type TrainingType,
+  type TypeSpecificData,
+  type RunData,
+  type CyclingData,
+  type StrengthData,
+  type YogaMobilityData,
+  type SwimmingData,
+  type WalkData,
+  type RestDayData,
+} from '~/types/training';
+
+interface SessionFormFieldsProps {
+  trainingType: TrainingType;
+  onTypeChange: (type: TrainingType) => void;
+  description: string;
+  onDescriptionChange: (v: string) => void;
+  coachComments: string;
+  onCoachCommentsChange: (v: string) => void;
+  durationMinutes: string;
+  onDurationChange: (v: string) => void;
+  distanceKm: string;
+  onDistanceChange: (v: string) => void;
+  typeData: Partial<TypeSpecificData>;
+  onTypeDataChange: (v: Partial<TypeSpecificData>) => void;
+  actualDuration: string;
+  onActualDurationChange: (v: string) => void;
+  actualDistance: string;
+  onActualDistanceChange: (v: string) => void;
+  actualPace: string;
+  onActualPaceChange: (v: string) => void;
+  avgHr: string;
+  onAvgHrChange: (v: string) => void;
+  maxHr: string;
+  onMaxHrChange: (v: string) => void;
+  rpe: string;
+  onRpeChange: (v: string) => void;
+  coachPostFeedback: string;
+  onCoachPostFeedbackChange: (v: string) => void;
+}
+
+export function SessionFormFields({
+  trainingType,
+  onTypeChange,
+  description,
+  onDescriptionChange,
+  coachComments,
+  onCoachCommentsChange,
+  durationMinutes,
+  onDurationChange,
+  distanceKm,
+  onDistanceChange,
+  typeData,
+  onTypeDataChange,
+  actualDuration,
+  onActualDurationChange,
+  actualDistance,
+  onActualDistanceChange,
+  actualPace,
+  onActualPaceChange,
+  avgHr,
+  onAvgHrChange,
+  maxHr,
+  onMaxHrChange,
+  rpe,
+  onRpeChange,
+  coachPostFeedback,
+  onCoachPostFeedbackChange,
+}: SessionFormFieldsProps) {
+  const { t } = useTranslation(['coach', 'common', 'training']);
+
+  const renderTypeFields = () => {
+    switch (trainingType) {
+      case 'run':
+        return <RunFields data={typeData as Partial<RunData>} onChange={onTypeDataChange} />;
+      case 'cycling':
+        return <CyclingFields data={typeData as Partial<CyclingData>} onChange={onTypeDataChange} />;
+      case 'strength':
+        return <StrengthFields data={typeData as Partial<StrengthData>} onChange={onTypeDataChange} />;
+      case 'yoga':
+      case 'mobility':
+        return <YogaMobilityFields data={typeData as Partial<YogaMobilityData>} onChange={onTypeDataChange} />;
+      case 'swimming':
+        return <SwimmingFields data={typeData as Partial<SwimmingData>} onChange={onTypeDataChange} />;
+      case 'walk':
+      case 'hike':
+        return <WalkHikeFields data={typeData as Partial<WalkData>} onChange={onTypeDataChange} />;
+      case 'rest_day':
+        return <RestDayFields data={typeData as Partial<RestDayData>} onChange={onTypeDataChange} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-4 py-4">
+      {/* Training Type Selector */}
+      <div>
+        <label className="text-sm font-medium mb-2 block">
+          {t('coach:session.type')}
+        </label>
+        <div className="flex flex-wrap gap-1.5">
+          {TRAINING_TYPES.map((tt) => {
+            const config = trainingTypeConfig[tt];
+            const isSelected = trainingType === tt;
+            return (
+              <Badge
+                key={tt}
+                variant={isSelected ? 'default' : 'outline'}
+                className={`cursor-pointer transition-colors ${
+                  isSelected
+                    ? `${config.bgColor} ${config.color} border-0`
+                    : 'hover:bg-muted'
+                }`}
+                onClick={() => onTypeChange(tt)}
+              >
+                {t(`common:trainingTypes.${tt}`)}
+              </Badge>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Common Fields */}
+      <div>
+        <label className="text-sm font-medium">
+          {t('coach:session.description')}
+        </label>
+        <Textarea
+          placeholder={t('coach:session.descriptionPlaceholder')}
+          value={description}
+          onChange={(e) => onDescriptionChange(e.target.value)}
+          rows={2}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-sm font-medium">
+            {t('coach:session.duration')}
+          </label>
+          <Input
+            type="number"
+            placeholder="0"
+            value={durationMinutes}
+            onChange={(e) => onDurationChange(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-sm font-medium">
+            {t('coach:session.distance')}
+          </label>
+          <Input
+            type="number"
+            step="0.1"
+            placeholder="0"
+            value={distanceKm}
+            onChange={(e) => onDistanceChange(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="text-sm font-medium">
+          {t('coach:session.coachComments')}
+        </label>
+        <Textarea
+          placeholder={t('coach:session.coachCommentsPlaceholder')}
+          value={coachComments}
+          onChange={(e) => onCoachCommentsChange(e.target.value)}
+          rows={2}
+        />
+      </div>
+
+      {/* Type-specific fields */}
+      <>
+        <Separator />
+        <div>
+          <h4 className="text-sm font-semibold mb-3">
+            {t(`common:trainingTypes.${trainingType}`)} details
+          </h4>
+          {renderTypeFields()}
+        </div>
+      </>
+
+      {/* Actual Performance */}
+      <Separator />
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold">
+          {t('training:actualPerformance.title')}
+        </h4>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-sm font-medium">
+              {t('training:actualPerformance.duration')} ({t('training:units.min')})
+            </label>
+            <Input
+              type="number"
+              placeholder="0"
+              value={actualDuration}
+              onChange={(e) => onActualDurationChange(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium">
+              {t('training:actualPerformance.distance')} ({t('training:units.km')})
+            </label>
+            <Input
+              type="number"
+              step="0.01"
+              placeholder="0"
+              value={actualDistance}
+              onChange={(e) => onActualDistanceChange(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="text-sm font-medium">
+            {t('training:actualPerformance.pace')} ({t('training:units.perKm')})
+          </label>
+          <Input
+            placeholder="5:30"
+            value={actualPace}
+            onChange={(e) => onActualPaceChange(e.target.value)}
+          />
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="text-sm font-medium">
+              {t('training:actualPerformance.avgHr')} ({t('training:units.bpm')})
+            </label>
+            <Input
+              type="number"
+              placeholder="0"
+              value={avgHr}
+              onChange={(e) => onAvgHrChange(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium">
+              {t('training:actualPerformance.maxHr')} ({t('training:units.bpm')})
+            </label>
+            <Input
+              type="number"
+              placeholder="0"
+              value={maxHr}
+              onChange={(e) => onMaxHrChange(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium">
+              {t('training:actualPerformance.rpe')} (1–10)
+            </label>
+            <Input
+              type="number"
+              min="1"
+              max="10"
+              placeholder="–"
+              value={rpe}
+              onChange={(e) => onRpeChange(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="text-sm font-medium">
+            {t('training:coachPostFeedback.label')}
+          </label>
+          <Textarea
+            placeholder={t('training:coachPostFeedback.placeholder')}
+            value={coachPostFeedback}
+            onChange={(e) => onCoachPostFeedbackChange(e.target.value)}
+            rows={2}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -27,9 +27,7 @@ const resources = {
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: typeof window !== 'undefined'
-    ? localStorage.getItem('language') || 'en'
-    : 'en',
+  lng: 'pl',
   fallbackLng: 'en',
   defaultNS: 'common',
   ns: ['common', 'coach', 'athlete', 'training'],

--- a/app/lib/hooks/useLocalePath.ts
+++ b/app/lib/hooks/useLocalePath.ts
@@ -1,0 +1,10 @@
+import { useParams } from 'react-router';
+
+/**
+ * Returns a helper that prefixes a path with the current locale segment.
+ * Falls back to 'pl' when used outside a locale route (e.g. on /login).
+ */
+export function useLocalePath() {
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
+  return (path: string) => `/${locale}${path}`;
+}

--- a/app/lib/mock-data/_shared.ts
+++ b/app/lib/mock-data/_shared.ts
@@ -1,31 +1,30 @@
-import type {
-  WeekPlan,
-  TrainingSession,
-  CreateWeekPlanInput,
-  UpdateWeekPlanInput,
-  CreateSessionInput,
-  UpdateSessionInput,
-  AthleteSessionUpdate,
-  TypeSpecificData,
-} from '~/types/training';
+/**
+ * Private shared state for mock data modules.
+ * Not exported from the barrel — import directly within mock-data/ only.
+ */
+import type { WeekPlan, TrainingSession } from '~/types/training';
 
 // ---------------------------------------------------------------------------
 // In-memory data stores (keyed by athleteId → weekStart → WeekPlan)
 // ---------------------------------------------------------------------------
 
-const weekPlans = new Map<string, Map<string, WeekPlan>>();
-const sessions = new Map<string, TrainingSession>();
+export const weekPlans = new Map<string, Map<string, WeekPlan>>();
+export const sessions = new Map<string, TrainingSession>();
 
 let idCounter = 100;
-function nextId() {
+export function nextId() {
   return `mock-${++idCounter}`;
 }
 
-function getAthleteMap(athleteId: string): Map<string, WeekPlan> {
+export function getAthleteMap(athleteId: string): Map<string, WeekPlan> {
   if (!weekPlans.has(athleteId)) {
     weekPlans.set(athleteId, new Map());
   }
   return weekPlans.get(athleteId)!;
+}
+
+export function delay(ms = 150): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
 }
 
 // ---------------------------------------------------------------------------
@@ -239,7 +238,6 @@ function seedAlice() {
       stravaSyncedAt: null,
     },
   ];
-
   for (const s of w09Sessions) {
     sessions.set(s.id, { ...s, createdAt: w09.createdAt, updatedAt: w09.updatedAt } as TrainingSession);
   }
@@ -456,7 +454,6 @@ function seedAlice() {
       stravaSyncedAt: null,
     },
   ];
-
   for (const s of w10Sessions) {
     sessions.set(s.id, { ...s, createdAt: w10.createdAt, updatedAt: w10.updatedAt } as TrainingSession);
   }
@@ -656,7 +653,6 @@ function seedAlice() {
       stravaSyncedAt: null,
     },
   ];
-
   for (const s of w11Sessions) {
     sessions.set(s.id, { ...s, createdAt: w11.createdAt, updatedAt: w11.updatedAt } as TrainingSession);
   }
@@ -792,221 +788,11 @@ function seedBob() {
       stravaSyncedAt: null,
     },
   ];
-
   for (const s of w10Sessions) {
     sessions.set(s.id, { ...s, createdAt: w10.createdAt, updatedAt: w10.updatedAt } as TrainingSession);
   }
 }
 
-// Run seed once
+// Run seed once at module load
 seedAlice();
 seedBob();
-
-// ---------------------------------------------------------------------------
-// Mock query implementations
-// ---------------------------------------------------------------------------
-
-function delay(ms = 150): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-// --- Week Plans ---
-
-export async function mockFetchWeekPlanByDate(
-  weekStart: string,
-  athleteId: string
-): Promise<WeekPlan | null> {
-  await delay();
-  return weekPlans.get(athleteId)?.get(weekStart) ?? null;
-}
-
-export async function mockCreateWeekPlan(
-  input: CreateWeekPlanInput
-): Promise<WeekPlan> {
-  await delay();
-  const plan: WeekPlan = {
-    id: nextId(),
-    athleteId: input.athleteId,
-    weekStart: input.weekStart,
-    year: input.year,
-    weekNumber: input.weekNumber,
-    loadType: input.loadType ?? null,
-    totalPlannedKm: input.totalPlannedKm ?? null,
-    description: input.description ?? null,
-    coachComments: input.coachComments ?? null,
-    actualTotalKm: null,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
-  const map = getAthleteMap(input.athleteId);
-  map.set(plan.weekStart, plan);
-  return plan;
-}
-
-export async function mockUpdateWeekPlan(
-  input: UpdateWeekPlanInput
-): Promise<WeekPlan> {
-  await delay();
-  // Find the plan across all athletes
-  let found: WeekPlan | undefined;
-  for (const athleteMap of weekPlans.values()) {
-    for (const wp of athleteMap.values()) {
-      if (wp.id === input.id) {
-        found = wp;
-        break;
-      }
-    }
-    if (found) break;
-  }
-  if (!found) throw new Error(`Week plan ${input.id} not found`);
-
-  const updated: WeekPlan = {
-    ...found,
-    ...(input.loadType !== undefined && { loadType: input.loadType }),
-    ...(input.totalPlannedKm !== undefined && {
-      totalPlannedKm: input.totalPlannedKm,
-    }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.coachComments !== undefined && {
-      coachComments: input.coachComments,
-    }),
-    ...(input.actualTotalKm !== undefined && {
-      actualTotalKm: input.actualTotalKm,
-    }),
-    updatedAt: new Date().toISOString(),
-  };
-  const map = getAthleteMap(updated.athleteId);
-  map.set(updated.weekStart, updated);
-  return updated;
-}
-
-export async function mockGetOrCreateWeekPlan(
-  weekStart: string,
-  year: number,
-  weekNumber: number,
-  athleteId: string
-): Promise<WeekPlan> {
-  const existing = await mockFetchWeekPlanByDate(weekStart, athleteId);
-  if (existing) return existing;
-  return mockCreateWeekPlan({ weekStart, year, weekNumber, athleteId });
-}
-
-// --- Sessions ---
-
-export async function mockFetchSessionsByWeekPlan(
-  weekPlanId: string
-): Promise<TrainingSession[]> {
-  await delay();
-  const result: TrainingSession[] = [];
-  for (const s of sessions.values()) {
-    if (s.weekPlanId === weekPlanId) result.push(s);
-  }
-  return result.sort((a, b) => a.sortOrder - b.sortOrder);
-}
-
-export async function mockCreateSession(
-  input: CreateSessionInput
-): Promise<TrainingSession> {
-  await delay();
-  const session: TrainingSession = {
-    id: nextId(),
-    weekPlanId: input.weekPlanId,
-    dayOfWeek: input.dayOfWeek,
-    sortOrder: input.sortOrder ?? 0,
-    trainingType: input.trainingType,
-    description: input.description ?? null,
-    coachComments: input.coachComments ?? null,
-    plannedDurationMinutes: input.plannedDurationMinutes ?? null,
-    plannedDistanceKm: input.plannedDistanceKm ?? null,
-    typeSpecificData:
-      input.typeSpecificData ?? ({ type: input.trainingType } as TypeSpecificData),
-    isCompleted: input.isCompleted ?? false,
-    completedAt: input.completedAt ?? null,
-    actualDurationMinutes: input.actualDurationMinutes ?? null,
-    actualDistanceKm: input.actualDistanceKm ?? null,
-    actualPace: input.actualPace ?? null,
-    avgHeartRate: input.avgHeartRate ?? null,
-    maxHeartRate: input.maxHeartRate ?? null,
-    rpe: input.rpe ?? null,
-    coachPostFeedback: input.coachPostFeedback ?? null,
-    athleteNotes: input.athleteNotes ?? null,
-    stravaActivityId: null,
-    stravaSyncedAt: null,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
-  sessions.set(session.id, session);
-  return session;
-}
-
-export async function mockUpdateSession(
-  input: UpdateSessionInput
-): Promise<TrainingSession> {
-  await delay();
-  const existing = sessions.get(input.id);
-  if (!existing) throw new Error(`Session ${input.id} not found`);
-
-  const updated: TrainingSession = {
-    ...existing,
-    ...(input.trainingType !== undefined && { trainingType: input.trainingType }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.coachComments !== undefined && { coachComments: input.coachComments }),
-    ...(input.plannedDurationMinutes !== undefined && {
-      plannedDurationMinutes: input.plannedDurationMinutes,
-    }),
-    ...(input.plannedDistanceKm !== undefined && {
-      plannedDistanceKm: input.plannedDistanceKm,
-    }),
-    ...(input.typeSpecificData !== undefined && {
-      typeSpecificData: input.typeSpecificData,
-    }),
-    ...(input.sortOrder !== undefined && { sortOrder: input.sortOrder }),
-    ...(input.actualDurationMinutes !== undefined && {
-      actualDurationMinutes: input.actualDurationMinutes,
-    }),
-    ...(input.actualDistanceKm !== undefined && {
-      actualDistanceKm: input.actualDistanceKm,
-    }),
-    ...(input.actualPace !== undefined && { actualPace: input.actualPace }),
-    ...(input.avgHeartRate !== undefined && { avgHeartRate: input.avgHeartRate }),
-    ...(input.maxHeartRate !== undefined && { maxHeartRate: input.maxHeartRate }),
-    ...(input.rpe !== undefined && { rpe: input.rpe }),
-    ...(input.coachPostFeedback !== undefined && {
-      coachPostFeedback: input.coachPostFeedback,
-    }),
-    updatedAt: new Date().toISOString(),
-  };
-  sessions.set(updated.id, updated);
-  return updated;
-}
-
-export async function mockDeleteSession(sessionId: string): Promise<void> {
-  await delay();
-  sessions.delete(sessionId);
-}
-
-export async function mockUpdateAthleteSession(
-  input: AthleteSessionUpdate
-): Promise<TrainingSession> {
-  await delay();
-  const existing = sessions.get(input.id);
-  if (!existing) throw new Error(`Session ${input.id} not found`);
-
-  const updated: TrainingSession = {
-    ...existing,
-    ...(input.isCompleted !== undefined && {
-      isCompleted: input.isCompleted,
-      completedAt: input.isCompleted ? new Date().toISOString() : null,
-    }),
-    ...(input.athleteNotes !== undefined && { athleteNotes: input.athleteNotes }),
-    ...(input.actualDurationMinutes !== undefined && { actualDurationMinutes: input.actualDurationMinutes }),
-    ...(input.actualDistanceKm !== undefined && { actualDistanceKm: input.actualDistanceKm }),
-    ...(input.actualPace !== undefined && { actualPace: input.actualPace }),
-    ...(input.avgHeartRate !== undefined && { avgHeartRate: input.avgHeartRate }),
-    ...(input.maxHeartRate !== undefined && { maxHeartRate: input.maxHeartRate }),
-    ...(input.rpe !== undefined && { rpe: input.rpe }),
-    updatedAt: new Date().toISOString(),
-  };
-  sessions.set(updated.id, updated);
-  return updated;
-}

--- a/app/lib/mock-data/index.ts
+++ b/app/lib/mock-data/index.ts
@@ -1,0 +1,2 @@
+export * from './weeks';
+export * from './sessions';

--- a/app/lib/mock-data/profile.ts
+++ b/app/lib/mock-data/profile.ts
@@ -1,0 +1,2 @@
+// Profile mock functions — placeholder for future profile query mocks
+// Add mockFetchProfile, mockUpdateProfile, etc. here when needed

--- a/app/lib/mock-data/sessions.ts
+++ b/app/lib/mock-data/sessions.ts
@@ -1,0 +1,114 @@
+import type {
+  TrainingSession,
+  CreateSessionInput,
+  UpdateSessionInput,
+  AthleteSessionUpdate,
+  TypeSpecificData,
+} from '~/types/training';
+import { sessions, delay, nextId } from './_shared';
+
+export async function mockFetchSessionsByWeekPlan(weekPlanId: string): Promise<TrainingSession[]> {
+  await delay();
+  const result: TrainingSession[] = [];
+  for (const s of sessions.values()) {
+    if (s.weekPlanId === weekPlanId) result.push(s);
+  }
+  return result.sort((a, b) => a.sortOrder - b.sortOrder);
+}
+
+export async function mockCreateSession(input: CreateSessionInput): Promise<TrainingSession> {
+  await delay();
+  const session: TrainingSession = {
+    id: nextId(),
+    weekPlanId: input.weekPlanId,
+    dayOfWeek: input.dayOfWeek,
+    sortOrder: input.sortOrder ?? 0,
+    trainingType: input.trainingType,
+    description: input.description ?? null,
+    coachComments: input.coachComments ?? null,
+    plannedDurationMinutes: input.plannedDurationMinutes ?? null,
+    plannedDistanceKm: input.plannedDistanceKm ?? null,
+    typeSpecificData:
+      input.typeSpecificData ?? ({ type: input.trainingType } as TypeSpecificData),
+    isCompleted: input.isCompleted ?? false,
+    completedAt: input.completedAt ?? null,
+    actualDurationMinutes: input.actualDurationMinutes ?? null,
+    actualDistanceKm: input.actualDistanceKm ?? null,
+    actualPace: input.actualPace ?? null,
+    avgHeartRate: input.avgHeartRate ?? null,
+    maxHeartRate: input.maxHeartRate ?? null,
+    rpe: input.rpe ?? null,
+    coachPostFeedback: input.coachPostFeedback ?? null,
+    athleteNotes: input.athleteNotes ?? null,
+    stravaActivityId: null,
+    stravaSyncedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  sessions.set(session.id, session);
+  return session;
+}
+
+export async function mockUpdateSession(input: UpdateSessionInput): Promise<TrainingSession> {
+  await delay();
+  const existing = sessions.get(input.id);
+  if (!existing) throw new Error(`Session ${input.id} not found`);
+
+  const updated: TrainingSession = {
+    ...existing,
+    ...(input.trainingType !== undefined && { trainingType: input.trainingType }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.coachComments !== undefined && { coachComments: input.coachComments }),
+    ...(input.plannedDurationMinutes !== undefined && {
+      plannedDurationMinutes: input.plannedDurationMinutes,
+    }),
+    ...(input.plannedDistanceKm !== undefined && { plannedDistanceKm: input.plannedDistanceKm }),
+    ...(input.typeSpecificData !== undefined && { typeSpecificData: input.typeSpecificData }),
+    ...(input.sortOrder !== undefined && { sortOrder: input.sortOrder }),
+    ...(input.actualDurationMinutes !== undefined && {
+      actualDurationMinutes: input.actualDurationMinutes,
+    }),
+    ...(input.actualDistanceKm !== undefined && { actualDistanceKm: input.actualDistanceKm }),
+    ...(input.actualPace !== undefined && { actualPace: input.actualPace }),
+    ...(input.avgHeartRate !== undefined && { avgHeartRate: input.avgHeartRate }),
+    ...(input.maxHeartRate !== undefined && { maxHeartRate: input.maxHeartRate }),
+    ...(input.rpe !== undefined && { rpe: input.rpe }),
+    ...(input.coachPostFeedback !== undefined && { coachPostFeedback: input.coachPostFeedback }),
+    updatedAt: new Date().toISOString(),
+  };
+  sessions.set(updated.id, updated);
+  return updated;
+}
+
+export async function mockDeleteSession(sessionId: string): Promise<void> {
+  await delay();
+  sessions.delete(sessionId);
+}
+
+export async function mockUpdateAthleteSession(
+  input: AthleteSessionUpdate
+): Promise<TrainingSession> {
+  await delay();
+  const existing = sessions.get(input.id);
+  if (!existing) throw new Error(`Session ${input.id} not found`);
+
+  const updated: TrainingSession = {
+    ...existing,
+    ...(input.isCompleted !== undefined && {
+      isCompleted: input.isCompleted,
+      completedAt: input.isCompleted ? new Date().toISOString() : null,
+    }),
+    ...(input.athleteNotes !== undefined && { athleteNotes: input.athleteNotes }),
+    ...(input.actualDurationMinutes !== undefined && {
+      actualDurationMinutes: input.actualDurationMinutes,
+    }),
+    ...(input.actualDistanceKm !== undefined && { actualDistanceKm: input.actualDistanceKm }),
+    ...(input.actualPace !== undefined && { actualPace: input.actualPace }),
+    ...(input.avgHeartRate !== undefined && { avgHeartRate: input.avgHeartRate }),
+    ...(input.maxHeartRate !== undefined && { maxHeartRate: input.maxHeartRate }),
+    ...(input.rpe !== undefined && { rpe: input.rpe }),
+    updatedAt: new Date().toISOString(),
+  };
+  sessions.set(updated.id, updated);
+  return updated;
+}

--- a/app/lib/mock-data/strava.ts
+++ b/app/lib/mock-data/strava.ts
@@ -1,0 +1,2 @@
+// Strava mock functions — placeholder for future Strava query mocks
+// Add mockFetchStravaConnection, mockSyncStravaActivities, etc. here when needed

--- a/app/lib/mock-data/weeks.ts
+++ b/app/lib/mock-data/weeks.ts
@@ -1,0 +1,70 @@
+import type { WeekPlan, CreateWeekPlanInput, UpdateWeekPlanInput } from '~/types/training';
+import { weekPlans, getAthleteMap, delay, nextId } from './_shared';
+
+export async function mockFetchWeekPlanByDate(
+  weekStart: string,
+  athleteId: string
+): Promise<WeekPlan | null> {
+  await delay();
+  return weekPlans.get(athleteId)?.get(weekStart) ?? null;
+}
+
+export async function mockCreateWeekPlan(input: CreateWeekPlanInput): Promise<WeekPlan> {
+  await delay();
+  const plan: WeekPlan = {
+    id: nextId(),
+    athleteId: input.athleteId,
+    weekStart: input.weekStart,
+    year: input.year,
+    weekNumber: input.weekNumber,
+    loadType: input.loadType ?? null,
+    totalPlannedKm: input.totalPlannedKm ?? null,
+    description: input.description ?? null,
+    coachComments: input.coachComments ?? null,
+    actualTotalKm: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const map = getAthleteMap(input.athleteId);
+  map.set(plan.weekStart, plan);
+  return plan;
+}
+
+export async function mockUpdateWeekPlan(input: UpdateWeekPlanInput): Promise<WeekPlan> {
+  await delay();
+  let found: WeekPlan | undefined;
+  for (const athleteMap of weekPlans.values()) {
+    for (const wp of athleteMap.values()) {
+      if (wp.id === input.id) {
+        found = wp;
+        break;
+      }
+    }
+    if (found) break;
+  }
+  if (!found) throw new Error(`Week plan ${input.id} not found`);
+
+  const updated: WeekPlan = {
+    ...found,
+    ...(input.loadType !== undefined && { loadType: input.loadType }),
+    ...(input.totalPlannedKm !== undefined && { totalPlannedKm: input.totalPlannedKm }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.coachComments !== undefined && { coachComments: input.coachComments }),
+    ...(input.actualTotalKm !== undefined && { actualTotalKm: input.actualTotalKm }),
+    updatedAt: new Date().toISOString(),
+  };
+  const map = getAthleteMap(updated.athleteId);
+  map.set(updated.weekStart, updated);
+  return updated;
+}
+
+export async function mockGetOrCreateWeekPlan(
+  weekStart: string,
+  year: number,
+  weekNumber: number,
+  athleteId: string
+): Promise<WeekPlan> {
+  const existing = await mockFetchWeekPlanByDate(weekStart, athleteId);
+  if (existing) return existing;
+  return mockCreateWeekPlan({ weekStart, year, weekNumber, athleteId });
+}

--- a/app/lib/queries/sessions.ts
+++ b/app/lib/queries/sessions.ts
@@ -14,7 +14,7 @@ import type {
   TypeSpecificData,
 } from '~/types/training';
 
-function toSession(row: Record<string, unknown>): TrainingSession {
+export function toSession(row: Record<string, unknown>): TrainingSession {
   return {
     id: row.id as string,
     weekPlanId: row.week_plan_id as string,

--- a/app/lib/queries/weeks.ts
+++ b/app/lib/queries/weeks.ts
@@ -12,7 +12,7 @@ import type {
 } from '~/types/training';
 
 // DB row → app type mapper
-function toWeekPlan(row: Record<string, unknown>): WeekPlan {
+export function toWeekPlan(row: Record<string, unknown>): WeekPlan {
   return {
     id: row.id as string,
     athleteId: row.athlete_id as string,

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -7,23 +7,30 @@ import {
 } from '@react-router/dev/routes';
 
 export default [
+  // Bare / redirects to /${locale} using stored preference
+  index('routes/root-redirect.tsx'),
+
+  // Login is public and outside the locale wrapper
   route('login', 'routes/login.tsx'),
 
-  index('routes/home.tsx'),
+  // All authenticated routes live under /:locale (pl or en)
+  route(':locale', 'routes/locale-layout.tsx', [
+    index('routes/home.tsx'),
 
-  ...prefix('coach', [
-    layout('routes/coach/layout.tsx', [
-      index('routes/coach/week.tsx'),
-      route('week/:weekId', 'routes/coach/week.$weekId.tsx'),
+    ...prefix('coach', [
+      layout('routes/coach/layout.tsx', [
+        index('routes/coach/week.tsx'),
+        route('week/:weekId', 'routes/coach/week.$weekId.tsx'),
+      ]),
     ]),
-  ]),
 
-  ...prefix('athlete', [
-    layout('routes/athlete/layout.tsx', [
-      index('routes/athlete/week.tsx'),
-      route('week/:weekId', 'routes/athlete/week.$weekId.tsx'),
+    ...prefix('athlete', [
+      layout('routes/athlete/layout.tsx', [
+        index('routes/athlete/week.tsx'),
+        route('week/:weekId', 'routes/athlete/week.$weekId.tsx'),
+      ]),
     ]),
-  ]),
 
-  route('settings', 'routes/settings.tsx'),
+    route('settings', 'routes/settings.tsx'),
+  ]),
 ] satisfies RouteConfig;

--- a/app/routes/athlete/layout.tsx
+++ b/app/routes/athlete/layout.tsx
@@ -1,8 +1,9 @@
-import { Navigate, Outlet } from 'react-router';
+import { Navigate, Outlet, useParams } from 'react-router';
 import { useAuth } from '~/lib/context/AuthContext';
 
 export default function AthleteLayout() {
   const { user, isLoading } = useAuth();
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
 
   if (isLoading) return null;
 
@@ -10,7 +11,7 @@ export default function AthleteLayout() {
   if (!user) return <Navigate to="/login" replace />;
 
   // FR-005: Coaches cannot access athlete routes
-  if (user.role !== 'athlete') return <Navigate to="/coach" replace />;
+  if (user.role !== 'athlete') return <Navigate to={`/${locale}/coach`} replace />;
 
   return <Outlet />;
 }

--- a/app/routes/athlete/week.tsx
+++ b/app/routes/athlete/week.tsx
@@ -1,6 +1,7 @@
-import { Navigate } from 'react-router';
+import { Navigate, useParams } from 'react-router';
 import { getCurrentWeekId } from '~/lib/utils/date';
 
 export default function AthleteWeekIndex() {
-  return <Navigate to={`/athlete/week/${getCurrentWeekId()}`} replace />;
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
+  return <Navigate to={`/${locale}/athlete/week/${getCurrentWeekId()}`} replace />;
 }

--- a/app/routes/coach/layout.tsx
+++ b/app/routes/coach/layout.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router';
+import { Navigate, Outlet, useParams } from 'react-router';
 import { Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
@@ -9,6 +9,7 @@ export default function CoachLayout() {
   const { user, isLoading, selectedAthleteId, athletes, clearSelectedAthlete } =
     useAuth();
   const { t } = useTranslation('coach');
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
 
   if (isLoading) return null;
 
@@ -16,7 +17,7 @@ export default function CoachLayout() {
   if (!user) return <Navigate to="/login" replace />;
 
   // FR-005: Athletes cannot access coach routes
-  if (user.role !== 'coach') return <Navigate to="/athlete" replace />;
+  if (user.role !== 'coach') return <Navigate to={`/${locale}/athlete`} replace />;
 
   // FR-007: Coach must select an athlete before seeing the workspace
   if (!selectedAthleteId) {

--- a/app/routes/coach/week.tsx
+++ b/app/routes/coach/week.tsx
@@ -1,6 +1,7 @@
-import { Navigate } from 'react-router';
+import { Navigate, useParams } from 'react-router';
 import { getCurrentWeekId } from '~/lib/utils/date';
 
 export default function CoachWeekIndex() {
-  return <Navigate to={`/coach/week/${getCurrentWeekId()}`} replace />;
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
+  return <Navigate to={`/${locale}/coach/week/${getCurrentWeekId()}`} replace />;
 }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router';
+import { Navigate, useParams } from 'react-router';
 import { useAuth } from '~/lib/context/AuthContext';
 
 export function meta() {
@@ -10,11 +10,12 @@ export function meta() {
 
 export default function Home() {
   const { user, isLoading } = useAuth();
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
 
   if (isLoading) return null;
 
   if (!user) return <Navigate to="/login" replace />;
 
-  const target = user.role === 'coach' ? '/coach' : '/athlete';
+  const target = user.role === 'coach' ? `/${locale}/coach` : `/${locale}/athlete`;
   return <Navigate to={target} replace />;
 }

--- a/app/routes/locale-layout.tsx
+++ b/app/routes/locale-layout.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { Navigate, Outlet, useLocation, useParams } from 'react-router';
+import { useTranslation } from 'react-i18next';
+
+const SUPPORTED_LOCALES = ['pl', 'en'] as const;
+type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+function isSupportedLocale(v: string): v is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(v);
+}
+
+export default function LocaleLayout() {
+  const { locale } = useParams<{ locale: string }>();
+  const { pathname } = useLocation();
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    if (locale && isSupportedLocale(locale)) {
+      i18n.changeLanguage(locale);
+      localStorage.setItem('locale', locale);
+    }
+  }, [locale, i18n]);
+
+  if (!locale || !isSupportedLocale(locale)) {
+    // Strip the unsupported locale segment and redirect to /pl/...
+    const pathAfterLocale = pathname.replace(/^\/[^/]*/, '');
+    return <Navigate to={`/pl${pathAfterLocale}`} replace />;
+  }
+
+  return <Outlet />;
+}

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -24,7 +24,8 @@ export default function LoginPage() {
   // Redirect when user becomes authenticated
   useEffect(() => {
     if (user) {
-      const target = user.role === 'coach' ? '/coach' : '/athlete';
+      const locale = localStorage.getItem('locale') ?? 'pl';
+      const target = user.role === 'coach' ? `/${locale}/coach` : `/${locale}/athlete`;
       navigate(target, { replace: true });
     }
   }, [user, navigate]);

--- a/app/routes/root-redirect.tsx
+++ b/app/routes/root-redirect.tsx
@@ -1,0 +1,6 @@
+import { Navigate } from 'react-router';
+
+export default function RootRedirect() {
+  const locale = localStorage.getItem('locale') ?? 'pl';
+  return <Navigate to={`/${locale}`} replace />;
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useSearchParams, Link } from 'react-router';
+import { useNavigate, useSearchParams, useParams, Link } from 'react-router';
 import { ArrowLeft } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
@@ -20,6 +20,7 @@ export default function SettingsPage() {
   const { t } = useTranslation('common');
   const { user, isLoading: authLoading } = useAuth();
   const navigate = useNavigate();
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const qc = useQueryClient();
 
@@ -117,7 +118,7 @@ export default function SettingsPage() {
     const state = crypto.randomUUID();
     localStorage.setItem(STRAVA_CSRF_KEY, state);
 
-    const redirectUri = `${import.meta.env.VITE_APP_URL ?? window.location.origin}/settings?tab=integrations`;
+    const redirectUri = `${import.meta.env.VITE_APP_URL ?? window.location.origin}/${locale}/settings?tab=integrations`;
     const params = new URLSearchParams({
       client_id: import.meta.env.VITE_STRAVA_CLIENT_ID ?? '',
       redirect_uri: redirectUri,
@@ -135,7 +136,7 @@ export default function SettingsPage() {
 
   const currentWeekStart = weekIdToMonday(getCurrentWeekId());
 
-  const backHref = user.role === 'coach' ? '/coach' : '/athlete';
+  const backHref = user.role === 'coach' ? `/${locale}/coach` : `/${locale}/athlete`;
 
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">

--- a/app/test/integration/athlete-week-view.test.tsx
+++ b/app/test/integration/athlete-week-view.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useSessions, useUpdateAthleteSession } from '~/lib/hooks/useSessions';
+import {
+  mockFetchSessionsByWeekPlan,
+  mockUpdateAthleteSession,
+} from '~/lib/mock-data';
+import { createTestQueryClient } from '~/test/utils/query-client';
+
+/**
+ * Athlete week view integration test.
+ *
+ * Tests the data layer powering the athlete's read-only week view:
+ * - Sessions are loaded correctly for the athlete's week plan
+ * - Completion toggle optimistically updates isCompleted in the cache
+ * - Rollback occurs on error
+ */
+
+vi.mock('~/lib/queries/sessions', async () => {
+  const m = await import('~/lib/mock-data');
+  return {
+    fetchSessionsByWeekPlan: m.mockFetchSessionsByWeekPlan,
+    updateAthleteSession: m.mockUpdateAthleteSession,
+    createSession: vi.fn(),
+    updateSession: vi.fn(),
+    deleteSession: vi.fn(),
+  };
+});
+
+vi.mock('~/lib/context/AuthContext', () => ({
+  useAuth: () => ({
+    effectiveAthleteId: 'athlete-1',
+    user: { id: 'athlete-1', role: 'athlete', name: 'Alice', email: 'alice@synek.app' },
+    selectedAthleteId: null,
+    athletes: [],
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    selectAthlete: vi.fn(),
+    clearSelectedAthlete: vi.fn(),
+    updateProfile: vi.fn(),
+  }),
+}));
+
+const ALICE_W10_PLAN_ID = 'wp-w10-a1';
+
+function makeWrapper() {
+  const queryClient = createTestQueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return { queryClient, Wrapper };
+}
+
+describe('Athlete week view — data layer', () => {
+  it('loads sessions for the athlete\'s week plan', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSessions(ALICE_W10_PLAN_ID), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.length).toBeGreaterThan(0);
+    expect(result.current.data!.every((s) => s.weekPlanId === ALICE_W10_PLAN_ID)).toBe(true);
+  });
+
+  it('optimistically marks a session as completed in the cache', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const sessions = await mockFetchSessionsByWeekPlan(ALICE_W10_PLAN_ID);
+    // Find a session that is NOT completed to toggle
+    const target = sessions.find((s) => !s.isCompleted);
+    if (!target) throw new Error('Test data: no incomplete session found in Alice W10');
+
+    queryClient.setQueryData(['sessions', 'week', ALICE_W10_PLAN_ID], sessions);
+
+    const { result } = renderHook(() => useUpdateAthleteSession(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      result.current.mutate({ id: target.id, isCompleted: true });
+    });
+
+    // Optimistic update should be immediately reflected
+    const cached = queryClient.getQueryData<typeof sessions>([
+      'sessions',
+      'week',
+      ALICE_W10_PLAN_ID,
+    ]);
+    const updated = cached?.find((s) => s.id === target.id);
+    expect(updated?.isCompleted).toBe(true);
+    expect(updated?.completedAt).toBeTruthy();
+  });
+
+  it('optimistically clears completion on toggle off', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const sessions = await mockFetchSessionsByWeekPlan(ALICE_W10_PLAN_ID);
+    // Find a session that IS completed to un-toggle
+    const target = sessions.find((s) => s.isCompleted);
+    if (!target) throw new Error('Test data: no completed session found in Alice W10');
+
+    queryClient.setQueryData(['sessions', 'week', ALICE_W10_PLAN_ID], sessions);
+
+    const { result } = renderHook(() => useUpdateAthleteSession(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      result.current.mutate({ id: target.id, isCompleted: false });
+    });
+
+    const cached = queryClient.getQueryData<typeof sessions>([
+      'sessions',
+      'week',
+      ALICE_W10_PLAN_ID,
+    ]);
+    const updated = cached?.find((s) => s.id === target.id);
+    expect(updated?.isCompleted).toBe(false);
+    expect(updated?.completedAt).toBeNull();
+  });
+});

--- a/app/test/integration/coach-week-view.test.tsx
+++ b/app/test/integration/coach-week-view.test.tsx
@@ -1,0 +1,152 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useSessions, useDeleteSession } from '~/lib/hooks/useSessions';
+import { useWeekPlan } from '~/lib/hooks/useWeekPlan';
+import {
+  mockFetchSessionsByWeekPlan,
+  mockFetchWeekPlanByDate,
+  mockDeleteSession,
+  mockCreateSession,
+  mockUpdateSession,
+} from '~/lib/mock-data';
+import { createTestQueryClient } from '~/test/utils/query-client';
+
+/**
+ * Coach week view integration test.
+ *
+ * Tests the data-loading layer that powers the coach week page:
+ * - The coach's effectiveAthleteId scopes data to the correct athlete
+ * - Switching athlete produces a different week plan (different query key)
+ * - Session delete is reflected in the cache immediately (optimistic)
+ */
+
+vi.mock('~/lib/queries/sessions', async () => {
+  const m = await import('~/lib/mock-data');
+  return {
+    fetchSessionsByWeekPlan: m.mockFetchSessionsByWeekPlan,
+    createSession: m.mockCreateSession,
+    deleteSession: m.mockDeleteSession,
+    updateSession: m.mockUpdateSession,
+    updateAthleteSession: vi.fn(),
+  };
+});
+
+vi.mock('~/lib/queries/weeks', async () => {
+  const m = await import('~/lib/mock-data');
+  return {
+    fetchWeekPlanByDate: m.mockFetchWeekPlanByDate,
+    getOrCreateWeekPlan: vi.fn(),
+    updateWeekPlan: vi.fn(),
+    createWeekPlan: vi.fn(),
+  };
+});
+
+// Default: coach with athlete-1 selected
+let mockEffectiveAthleteId = 'athlete-1';
+
+vi.mock('~/lib/context/AuthContext', () => ({
+  useAuth: () => ({
+    effectiveAthleteId: mockEffectiveAthleteId,
+    user: { id: 'coach-1', role: 'coach', name: 'Coach', email: 'coach@synek.app' },
+    selectedAthleteId: mockEffectiveAthleteId,
+    athletes: [],
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    selectAthlete: vi.fn(),
+    clearSelectedAthlete: vi.fn(),
+    updateProfile: vi.fn(),
+  }),
+}));
+
+const WEEK_START = '2026-03-02'; // W10
+const ALICE_W10_PLAN_ID = 'wp-w10-a1';
+const BOB_W10_PLAN_ID = 'wp-w10-a2';
+
+function makeWrapper() {
+  const queryClient = createTestQueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return { queryClient, Wrapper };
+}
+
+describe('Coach week view — data layer', () => {
+  beforeEach(() => {
+    mockEffectiveAthleteId = 'athlete-1';
+  });
+
+  it('loads Alice\'s week plan when she is the selected athlete', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWeekPlan(WEEK_START), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.athleteId).toBe('athlete-1');
+    expect(result.current.data?.id).toBe(ALICE_W10_PLAN_ID);
+  });
+
+  it('loads sessions for the selected athlete\'s week plan', async () => {
+    const { Wrapper } = makeWrapper();
+    const alicePlan = await mockFetchWeekPlanByDate(WEEK_START, 'athlete-1');
+
+    const { result } = renderHook(() => useSessions(alicePlan?.id), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data!.length).toBeGreaterThan(0);
+    expect(result.current.data!.every((s) => s.weekPlanId === ALICE_W10_PLAN_ID)).toBe(true);
+  });
+
+  it('uses different query keys for different athletes (data isolation)', async () => {
+    // Alice loads with athlete-1
+    const { queryClient: qcAlice, Wrapper: WrapperAlice } = makeWrapper();
+    mockEffectiveAthleteId = 'athlete-1';
+    const { result: aliceResult } = renderHook(() => useWeekPlan(WEEK_START), {
+      wrapper: WrapperAlice,
+    });
+    await waitFor(() => expect(aliceResult.current.isSuccess).toBe(true));
+    const aliceKey = qcAlice
+      .getQueryCache()
+      .findAll()
+      .find((q) => (q.queryKey as string[]).includes('athlete-1'));
+    expect(aliceKey).toBeDefined();
+
+    // Bob loads with athlete-2 — separate client to avoid cache pollution
+    const { queryClient: qcBob, Wrapper: WrapperBob } = makeWrapper();
+    mockEffectiveAthleteId = 'athlete-2';
+    const { result: bobResult } = renderHook(() => useWeekPlan(WEEK_START), {
+      wrapper: WrapperBob,
+    });
+    await waitFor(() => expect(bobResult.current.isSuccess).toBe(true));
+
+    // Alice's plan and Bob's plan have different IDs
+    expect(aliceResult.current.data?.id).toBe(ALICE_W10_PLAN_ID);
+    expect(bobResult.current.data?.id).toBe(BOB_W10_PLAN_ID);
+  });
+
+  it('optimistically removes a session from the cache on delete', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const sessions = await mockFetchSessionsByWeekPlan(ALICE_W10_PLAN_ID);
+    queryClient.setQueryData(['sessions', 'week', ALICE_W10_PLAN_ID], sessions);
+    const targetId = sessions[0].id;
+
+    const { result } = renderHook(() => useDeleteSession(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate(targetId);
+    });
+
+    const cached = queryClient.getQueryData<typeof sessions>([
+      'sessions',
+      'week',
+      ALICE_W10_PLAN_ID,
+    ]);
+    expect(cached?.find((s) => s.id === targetId)).toBeUndefined();
+  });
+});

--- a/app/test/integration/login.test.tsx
+++ b/app/test/integration/login.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import LoginPage from '~/routes/login';
+import { createTestQueryClient } from '~/test/utils/query-client';
+
+// ---------------------------------------------------------------------------
+// Auth mock — track login calls and simulate success/failure
+// ---------------------------------------------------------------------------
+
+const mockLoginFn = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('~/lib/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    login: mockLoginFn,
+    effectiveAthleteId: null,
+    selectedAthleteId: null,
+    athletes: [],
+    isLoading: false,
+    logout: vi.fn(),
+    selectAthlete: vi.fn(),
+    clearSelectedAthlete: vi.fn(),
+    updateProfile: vi.fn(),
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderLogin() {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/login']}>
+        <LoginPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockLoginFn.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it('renders the login form with email and password fields', () => {
+    renderLogin();
+    // Use placeholders (hardcoded, not i18n keys) as stable selectors
+    expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('••••••••')).toBeInTheDocument();
+  });
+
+  it('calls login() with the entered credentials on valid form submit', async () => {
+    mockLoginFn.mockResolvedValueOnce(undefined);
+    renderLogin();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'coach@synek.app');
+    await user.type(screen.getByPlaceholderText('••••••••'), 'coach123');
+    // In tests, t('auth.signIn') returns the key 'auth.signIn'
+    await user.click(screen.getByRole('button', { name: 'auth.signIn' }));
+
+    await waitFor(() =>
+      expect(mockLoginFn).toHaveBeenCalledWith('coach@synek.app', 'coach123')
+    );
+  });
+
+  it('shows an error message when login() throws', async () => {
+    mockLoginFn.mockRejectedValueOnce(new Error('Invalid credentials'));
+    renderLogin();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'wrong@example.com');
+    await user.type(screen.getByPlaceholderText('••••••••'), 'badpassword');
+    await user.click(screen.getByRole('button', { name: 'auth.signIn' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials')
+    );
+  });
+
+  it('does not show an error initially', () => {
+    renderLogin();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/app/test/integration/useSessions.test.tsx
+++ b/app/test/integration/useSessions.test.tsx
@@ -1,0 +1,149 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import {
+  useSessions,
+  useCreateSession,
+  useDeleteSession,
+  useUpdateSession,
+} from '~/lib/hooks/useSessions';
+import {
+  mockFetchSessionsByWeekPlan,
+  mockCreateSession,
+  mockDeleteSession,
+  mockUpdateSession,
+} from '~/lib/mock-data';
+import { createTestQueryClient } from '~/test/utils/query-client';
+
+// Mock the query module — async factory avoids vi.mock hoisting issues
+vi.mock('~/lib/queries/sessions', async () => {
+  const m = await import('~/lib/mock-data');
+  return {
+    fetchSessionsByWeekPlan: m.mockFetchSessionsByWeekPlan,
+    createSession: m.mockCreateSession,
+    deleteSession: m.mockDeleteSession,
+    updateSession: m.mockUpdateSession,
+    updateAthleteSession: vi.fn(),
+  };
+});
+
+// Alice's W10 plan ID (from seed data in mock-data.ts)
+const ALICE_W10_PLAN_ID = 'wp-w10-a1';
+
+function makeWrapper() {
+  const queryClient = createTestQueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return { queryClient, Wrapper };
+}
+
+describe('useSessions', () => {
+  it('starts in loading state and transitions to success with data', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSessions(ALICE_W10_PLAN_ID), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeDefined();
+    expect(Array.isArray(result.current.data)).toBe(true);
+    expect(result.current.data!.length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty array for an unknown weekPlanId', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSessions('non-existent-plan'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fetch when weekPlanId is undefined', () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSessions(undefined), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useCreateSession', () => {
+  it('calls createSession and invalidates the sessions cache on success', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useCreateSession(), {
+      wrapper: Wrapper,
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await act(async () => {
+      result.current.mutate({
+        weekPlanId: ALICE_W10_PLAN_ID,
+        dayOfWeek: 'friday',
+        trainingType: 'strength',
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteSession', () => {
+  it('optimistically removes the session from the cache before deletion completes', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    // Pre-seed the cache with sessions for Alice's W10
+    const sessions = await mockFetchSessionsByWeekPlan(ALICE_W10_PLAN_ID);
+    queryClient.setQueryData(['sessions', 'week', ALICE_W10_PLAN_ID], sessions);
+    const targetId = sessions[0].id;
+
+    const { result } = renderHook(() => useDeleteSession(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate(targetId);
+    });
+
+    // Optimistic update should have removed the session immediately
+    const cached = queryClient.getQueryData<typeof sessions>([
+      'sessions',
+      'week',
+      ALICE_W10_PLAN_ID,
+    ]);
+    expect(cached?.find((s) => s.id === targetId)).toBeUndefined();
+  });
+});
+
+describe('useUpdateSession', () => {
+  it('optimistically updates a session description in the cache', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const sessions = await mockFetchSessionsByWeekPlan(ALICE_W10_PLAN_ID);
+    queryClient.setQueryData(['sessions', 'week', ALICE_W10_PLAN_ID], sessions);
+    const target = sessions[0];
+
+    const { result } = renderHook(() => useUpdateSession(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ id: target.id, description: 'Updated description' });
+    });
+
+    const cached = queryClient.getQueryData<typeof sessions>([
+      'sessions',
+      'week',
+      ALICE_W10_PLAN_ID,
+    ]);
+    const updated = cached?.find((s) => s.id === target.id);
+    expect(updated?.description).toBe('Updated description');
+  });
+});

--- a/app/test/integration/useWeekPlan.test.tsx
+++ b/app/test/integration/useWeekPlan.test.tsx
@@ -1,0 +1,136 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useWeekPlan, useGetOrCreateWeekPlan, useUpdateWeekPlan } from '~/lib/hooks/useWeekPlan';
+import {
+  mockFetchWeekPlanByDate,
+  mockGetOrCreateWeekPlan,
+  mockUpdateWeekPlan,
+} from '~/lib/mock-data';
+import { createTestQueryClient } from '~/test/utils/query-client';
+
+// Mock auth — provide effectiveAthleteId without a real AuthProvider
+vi.mock('~/lib/context/AuthContext', () => ({
+  useAuth: () => ({
+    effectiveAthleteId: 'athlete-1',
+    user: { id: 'athlete-1', role: 'athlete', name: 'Alice', email: 'alice@test.com' },
+    selectedAthleteId: null,
+    athletes: [],
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    selectAthlete: vi.fn(),
+    clearSelectedAthlete: vi.fn(),
+    updateProfile: vi.fn(),
+  }),
+}));
+
+// Mock query module — async factory avoids vi.mock hoisting issues
+vi.mock('~/lib/queries/weeks', async () => {
+  const m = await import('~/lib/mock-data');
+  return {
+    fetchWeekPlanByDate: m.mockFetchWeekPlanByDate,
+    getOrCreateWeekPlan: m.mockGetOrCreateWeekPlan,
+    updateWeekPlan: m.mockUpdateWeekPlan,
+    createWeekPlan: vi.fn(),
+  };
+});
+
+function makeWrapper() {
+  const queryClient = createTestQueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return { queryClient, Wrapper };
+}
+
+describe('useWeekPlan', () => {
+  it('fetches Alice\'s W10 plan by weekStart', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWeekPlan('2026-03-02'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data?.weekStart).toBe('2026-03-02');
+    expect(result.current.data?.athleteId).toBe('athlete-1');
+  });
+
+  it('returns null for a week with no plan', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWeekPlan('2026-01-05'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('does not fetch when weekStart is empty', () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWeekPlan(''), { wrapper: Wrapper });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useGetOrCreateWeekPlan', () => {
+  it('seeds the QueryClient cache with the returned plan on success', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGetOrCreateWeekPlan(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        weekStart: '2026-03-02',
+        year: 2026,
+        weekNumber: 10,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const plan = result.current.data;
+    expect(plan).toBeDefined();
+    expect(plan?.weekStart).toBe('2026-03-02');
+
+    // The onSuccess handler should have seeded the cache
+    const cached = queryClient.getQueryData([
+      'weeks',
+      plan!.weekStart,
+      plan!.athleteId,
+    ]);
+    expect(cached).toBeDefined();
+  });
+});
+
+describe('useUpdateWeekPlan', () => {
+  it('optimistically updates the week description in the cache', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    // Pre-seed the cache
+    const existing = await mockFetchWeekPlanByDate('2026-03-02', 'athlete-1');
+    if (!existing) throw new Error('Test data missing: Alice W10 plan');
+    queryClient.setQueryData(['weeks', '2026-03-02', 'athlete-1'], existing);
+
+    const { result } = renderHook(() => useUpdateWeekPlan(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ id: existing.id, description: 'Updated description' });
+    });
+
+    // Optimistic update should be visible before the mutation settles
+    const cached = queryClient.getQueryData<typeof existing>([
+      'weeks',
+      '2026-03-02',
+      'athlete-1',
+    ]);
+    expect(cached?.description).toBe('Updated description');
+  });
+});

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -1,0 +1,22 @@
+import '@testing-library/jest-dom';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+// Initialise a minimal i18n instance for tests.
+// Components using useTranslation will resolve keys without throwing.
+// Using empty resource bundles means t('key') returns 'key' — predictable in assertions.
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: {
+      en: {
+        common: {},
+        coach: {},
+        athlete: {},
+        training: {},
+      },
+    },
+    interpolation: { escapeValue: false },
+  });
+}

--- a/app/test/unit/date.test.ts
+++ b/app/test/unit/date.test.ts
@@ -1,0 +1,120 @@
+import {
+  getCurrentWeekId,
+  weekIdToMonday,
+  mondayToWeekId,
+  getNextWeekId,
+  getPrevWeekId,
+  getWeekDateRange,
+  parseWeekId,
+} from '~/lib/utils/date';
+
+describe('getCurrentWeekId', () => {
+  it('returns a string matching YYYY-WNN format', () => {
+    const result = getCurrentWeekId();
+    expect(result).toMatch(/^\d{4}-W\d{2}$/);
+  });
+
+  it('contains a valid week number (01–53)', () => {
+    const result = getCurrentWeekId();
+    const week = parseInt(result.split('-W')[1], 10);
+    expect(week).toBeGreaterThanOrEqual(1);
+    expect(week).toBeLessThanOrEqual(53);
+  });
+});
+
+describe('weekIdToMonday', () => {
+  it('returns the correct Monday for a known week', () => {
+    // 2026-W10 starts on Monday 2026-03-02
+    expect(weekIdToMonday('2026-W10')).toBe('2026-03-02');
+  });
+
+  it('returns correct Monday for week 1', () => {
+    // ISO week 1 of 2026 starts on Monday 2025-12-29
+    expect(weekIdToMonday('2026-W01')).toBe('2025-12-29');
+  });
+
+  it('handles zero-padded week numbers', () => {
+    expect(weekIdToMonday('2026-W09')).toBe('2026-02-23');
+  });
+
+  it('throws on invalid week ID format', () => {
+    expect(() => weekIdToMonday('2026-10')).toThrow('Invalid week ID');
+    expect(() => weekIdToMonday('bad-input')).toThrow('Invalid week ID');
+    expect(() => weekIdToMonday('')).toThrow('Invalid week ID');
+  });
+});
+
+describe('mondayToWeekId', () => {
+  it('converts a known Monday date string to the correct week ID', () => {
+    expect(mondayToWeekId('2026-03-02')).toBe('2026-W10');
+  });
+
+  it('is the inverse of weekIdToMonday', () => {
+    const weekId = '2026-W23';
+    expect(mondayToWeekId(weekIdToMonday(weekId))).toBe(weekId);
+  });
+
+  it('handles the year-boundary ISO week (week 1 starting in prev year)', () => {
+    // 2025-12-29 is the Monday of 2026-W01
+    expect(mondayToWeekId('2025-12-29')).toBe('2026-W01');
+  });
+});
+
+describe('getNextWeekId', () => {
+  it('returns the following week ID', () => {
+    expect(getNextWeekId('2026-W10')).toBe('2026-W11');
+  });
+
+  it('crosses year boundary correctly (last week → week 1 of next year)', () => {
+    // 2026-W53 does not exist; last week of 2026 is W52 or W53
+    // Use a known boundary: 2015 has 53 weeks
+    expect(getNextWeekId('2015-W53')).toBe('2016-W01');
+  });
+});
+
+describe('getPrevWeekId', () => {
+  it('returns the previous week ID', () => {
+    expect(getPrevWeekId('2026-W10')).toBe('2026-W09');
+  });
+
+  it('crosses year boundary correctly (week 1 → last week of previous year)', () => {
+    expect(getPrevWeekId('2026-W01')).toBe('2025-W52');
+  });
+});
+
+describe('getWeekDateRange', () => {
+  it('returns the correct start (Monday) and end (Sunday) for a known week', () => {
+    const result = getWeekDateRange('2026-W10');
+    // 2026-W10: Mon 2026-03-02 → Sun 2026-03-08
+    expect(result.start.getFullYear()).toBe(2026);
+    expect(result.start.getMonth()).toBe(2); // March (0-indexed)
+    expect(result.start.getDate()).toBe(2);
+    expect(result.end.getDate()).toBe(8);
+  });
+
+  it('returns a non-empty formatted string', () => {
+    const result = getWeekDateRange('2026-W10');
+    expect(result.formatted).toBeTruthy();
+    expect(typeof result.formatted).toBe('string');
+  });
+
+  it('end falls on Sunday (day 0 in getDay())', () => {
+    // endOfISOWeek returns end-of-Sunday (23:59:59.999) so we check the day index
+    const result = getWeekDateRange('2026-W10');
+    expect(result.end.getDay()).toBe(0); // 0 = Sunday
+  });
+});
+
+describe('parseWeekId', () => {
+  it('returns correct year and weekNumber', () => {
+    expect(parseWeekId('2026-W10')).toEqual({ year: 2026, weekNumber: 10 });
+  });
+
+  it('parses single-digit weeks with leading zero', () => {
+    expect(parseWeekId('2026-W01')).toEqual({ year: 2026, weekNumber: 1 });
+  });
+
+  it('throws on invalid format', () => {
+    expect(() => parseWeekId('bad')).toThrow('Invalid week ID');
+  });
+});

--- a/app/test/unit/sessions-mapper.test.ts
+++ b/app/test/unit/sessions-mapper.test.ts
@@ -1,0 +1,112 @@
+import { toSession } from '~/lib/queries/sessions';
+
+// A representative DB row matching the training_sessions table shape
+const baseRow: Record<string, unknown> = {
+  id: 'session-abc',
+  week_plan_id: 'plan-xyz',
+  day_of_week: 'wednesday',
+  sort_order: 3,
+  training_type: 'run',
+  description: 'Easy 10k',
+  coach_comments: 'Stay in zone 2',
+  planned_duration_minutes: 60,
+  planned_distance_km: 10,
+  type_specific_data: { type: 'run', pace_target: '5:30/km' },
+  is_completed: true,
+  completed_at: '2026-03-04T08:00:00Z',
+  actual_duration_minutes: 65,
+  actual_distance_km: 10.2,
+  actual_pace: '5:22/km',
+  avg_heart_rate: 148,
+  max_heart_rate: 162,
+  rpe: 6,
+  coach_post_feedback: 'Good effort',
+  trainee_notes: 'Felt strong',
+  strava_activity_id: 12345,
+  strava_synced_at: '2026-03-04T09:00:00Z',
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-04T09:00:00Z',
+};
+
+describe('toSession (row mapper)', () => {
+  it('maps snake_case DB fields to camelCase application fields', () => {
+    const session = toSession(baseRow);
+    expect(session.id).toBe('session-abc');
+    expect(session.weekPlanId).toBe('plan-xyz');
+    expect(session.dayOfWeek).toBe('wednesday');
+    expect(session.sortOrder).toBe(3);
+    expect(session.trainingType).toBe('run');
+    expect(session.description).toBe('Easy 10k');
+    expect(session.coachComments).toBe('Stay in zone 2');
+    expect(session.plannedDurationMinutes).toBe(60);
+    expect(session.plannedDistanceKm).toBe(10);
+    expect(session.isCompleted).toBe(true);
+    expect(session.completedAt).toBe('2026-03-04T08:00:00Z');
+    expect(session.actualDurationMinutes).toBe(65);
+    expect(session.actualDistanceKm).toBe(10.2);
+    expect(session.actualPace).toBe('5:22/km');
+    expect(session.avgHeartRate).toBe(148);
+    expect(session.maxHeartRate).toBe(162);
+    expect(session.rpe).toBe(6);
+    expect(session.coachPostFeedback).toBe('Good effort');
+    expect(session.stravaActivityId).toBe(12345);
+    expect(session.stravaSyncedAt).toBe('2026-03-04T09:00:00Z');
+    expect(session.createdAt).toBe('2026-03-01T00:00:00Z');
+    expect(session.updatedAt).toBe('2026-03-04T09:00:00Z');
+  });
+
+  it('maps trainee_notes to athleteNotes (field rename)', () => {
+    const session = toSession(baseRow);
+    expect(session.athleteNotes).toBe('Felt strong');
+  });
+
+  it('preserves typeSpecificData from the row', () => {
+    const session = toSession(baseRow);
+    expect(session.typeSpecificData).toEqual({ type: 'run', pace_target: '5:30/km' });
+  });
+
+  it('defaults typeSpecificData to { type: training_type } when absent', () => {
+    const row = { ...baseRow, type_specific_data: null };
+    const session = toSession(row);
+    expect(session.typeSpecificData).toEqual({ type: 'run' });
+  });
+
+  it('preserves null values for nullable fields', () => {
+    const nullRow: Record<string, unknown> = {
+      ...baseRow,
+      description: null,
+      coach_comments: null,
+      planned_duration_minutes: null,
+      planned_distance_km: null,
+      is_completed: false,
+      completed_at: null,
+      actual_duration_minutes: null,
+      actual_distance_km: null,
+      actual_pace: null,
+      avg_heart_rate: null,
+      max_heart_rate: null,
+      rpe: null,
+      coach_post_feedback: null,
+      trainee_notes: null,
+      strava_activity_id: null,
+      strava_synced_at: null,
+    };
+    const session = toSession(nullRow);
+    expect(session.description).toBeNull();
+    expect(session.coachComments).toBeNull();
+    expect(session.plannedDurationMinutes).toBeNull();
+    expect(session.plannedDistanceKm).toBeNull();
+    expect(session.isCompleted).toBe(false);
+    expect(session.completedAt).toBeNull();
+    expect(session.actualDurationMinutes).toBeNull();
+    expect(session.actualDistanceKm).toBeNull();
+    expect(session.actualPace).toBeNull();
+    expect(session.avgHeartRate).toBeNull();
+    expect(session.maxHeartRate).toBeNull();
+    expect(session.rpe).toBeNull();
+    expect(session.coachPostFeedback).toBeNull();
+    expect(session.athleteNotes).toBeNull();
+    expect(session.stravaActivityId).toBeNull();
+    expect(session.stravaSyncedAt).toBeNull();
+  });
+});

--- a/app/test/unit/week-view.test.ts
+++ b/app/test/unit/week-view.test.ts
@@ -1,0 +1,154 @@
+import { groupSessionsByDay, computeWeekStats } from '~/lib/utils/week-view';
+import { DAYS_OF_WEEK, type TrainingSession } from '~/types/training';
+
+// ---------------------------------------------------------------------------
+// Minimal session factory
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<TrainingSession> = {}): TrainingSession {
+  return {
+    id: 'session-1',
+    weekPlanId: 'plan-1',
+    dayOfWeek: 'monday',
+    sortOrder: 0,
+    trainingType: 'run',
+    description: null,
+    coachComments: null,
+    plannedDurationMinutes: 60,
+    plannedDistanceKm: 10,
+    typeSpecificData: { type: 'run' },
+    isCompleted: false,
+    completedAt: null,
+    actualDurationMinutes: null,
+    actualDistanceKm: null,
+    actualPace: null,
+    avgHeartRate: null,
+    maxHeartRate: null,
+    rpe: null,
+    coachPostFeedback: null,
+    athleteNotes: null,
+    stravaActivityId: null,
+    stravaSyncedAt: null,
+    createdAt: '2026-03-02T00:00:00Z',
+    updatedAt: '2026-03-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// groupSessionsByDay
+// ---------------------------------------------------------------------------
+
+describe('groupSessionsByDay', () => {
+  it('initialises all 7 days as empty arrays even with no sessions', () => {
+    const result = groupSessionsByDay([]);
+    for (const day of DAYS_OF_WEEK) {
+      expect(result[day]).toEqual([]);
+    }
+  });
+
+  it('places sessions in the correct day bucket', () => {
+    const session = makeSession({ dayOfWeek: 'wednesday' });
+    const result = groupSessionsByDay([session]);
+    expect(result.wednesday).toHaveLength(1);
+    expect(result.wednesday[0].id).toBe('session-1');
+    expect(result.monday).toHaveLength(0);
+  });
+
+  it('sorts sessions within a day by sortOrder ascending', () => {
+    const sessions = [
+      makeSession({ id: 'b', dayOfWeek: 'tuesday', sortOrder: 2 }),
+      makeSession({ id: 'a', dayOfWeek: 'tuesday', sortOrder: 1 }),
+      makeSession({ id: 'c', dayOfWeek: 'tuesday', sortOrder: 0 }),
+    ];
+    const result = groupSessionsByDay(sessions);
+    expect(result.tuesday.map((s) => s.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('handles multiple sessions across different days', () => {
+    const sessions = [
+      makeSession({ id: 'mon1', dayOfWeek: 'monday' }),
+      makeSession({ id: 'wed1', dayOfWeek: 'wednesday' }),
+      makeSession({ id: 'mon2', dayOfWeek: 'monday', sortOrder: 1 }),
+    ];
+    const result = groupSessionsByDay(sessions);
+    expect(result.monday).toHaveLength(2);
+    expect(result.wednesday).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeWeekStats
+// ---------------------------------------------------------------------------
+
+describe('computeWeekStats', () => {
+  it('returns all-zero stats for an empty session list', () => {
+    const stats = computeWeekStats([]);
+    expect(stats.totalSessions).toBe(0);
+    expect(stats.completedSessions).toBe(0);
+    expect(stats.totalPlannedKm).toBe(0);
+    expect(stats.completionPercentage).toBe(0);
+  });
+
+  it('counts totalSessions excluding rest_day type', () => {
+    const sessions = [
+      makeSession({ trainingType: 'run' }),
+      makeSession({ id: 's2', trainingType: 'cycling' }),
+      makeSession({ id: 's3', trainingType: 'rest_day' }),
+    ];
+    expect(computeWeekStats(sessions).totalSessions).toBe(2);
+  });
+
+  it('counts completedSessions excluding rest_day type', () => {
+    const sessions = [
+      makeSession({ trainingType: 'run', isCompleted: true }),
+      makeSession({ id: 's2', trainingType: 'rest_day', isCompleted: true }),
+    ];
+    const stats = computeWeekStats(sessions);
+    expect(stats.completedSessions).toBe(1);
+  });
+
+  it('computes completionPercentage as 100 when all non-rest sessions complete', () => {
+    const sessions = [
+      makeSession({ isCompleted: true }),
+      makeSession({ id: 's2', trainingType: 'cycling', isCompleted: true }),
+    ];
+    expect(computeWeekStats(sessions).completionPercentage).toBe(100);
+  });
+
+  it('computes completionPercentage as 50 for half completed', () => {
+    const sessions = [
+      makeSession({ isCompleted: true }),
+      makeSession({ id: 's2', isCompleted: false }),
+    ];
+    expect(computeWeekStats(sessions).completionPercentage).toBe(50);
+  });
+
+  it('sums totalPlannedKm across all sessions (including rest_day)', () => {
+    const sessions = [
+      makeSession({ plannedDistanceKm: 10 }),
+      makeSession({ id: 's2', plannedDistanceKm: 5, trainingType: 'rest_day' }),
+    ];
+    expect(computeWeekStats(sessions).totalPlannedKm).toBe(15);
+  });
+
+  it('sums totalActualRunKm only for run type sessions', () => {
+    const sessions = [
+      makeSession({ trainingType: 'run', actualDistanceKm: 9 }),
+      makeSession({
+        id: 's2',
+        trainingType: 'cycling',
+        actualDistanceKm: 30,
+      }),
+    ];
+    expect(computeWeekStats(sessions).totalActualRunKm).toBe(9);
+  });
+
+  it('treats null plannedDistanceKm as 0 in totals', () => {
+    const sessions = [
+      makeSession({ plannedDistanceKm: null }),
+      makeSession({ id: 's2', plannedDistanceKm: 10 }),
+    ];
+    expect(computeWeekStats(sessions).totalPlannedKm).toBe(10);
+  });
+});

--- a/app/test/unit/weeks-mapper.test.ts
+++ b/app/test/unit/weeks-mapper.test.ts
@@ -1,0 +1,58 @@
+import { toWeekPlan } from '~/lib/queries/weeks';
+
+const baseRow: Record<string, unknown> = {
+  id: 'plan-123',
+  athlete_id: 'athlete-1',
+  week_start: '2026-03-02',
+  year: 2026,
+  week_number: 10,
+  load_type: 'medium',
+  total_planned_km: 65.5,
+  description: 'Build week',
+  coach_comments: 'Focus on aerobic base',
+  actual_total_km: 63.0,
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-08T00:00:00Z',
+};
+
+describe('toWeekPlan (row mapper)', () => {
+  it('maps snake_case DB fields to camelCase application fields', () => {
+    const plan = toWeekPlan(baseRow);
+    expect(plan.id).toBe('plan-123');
+    expect(plan.athleteId).toBe('athlete-1');
+    expect(plan.weekStart).toBe('2026-03-02');
+    expect(plan.year).toBe(2026);
+    expect(plan.weekNumber).toBe(10);
+    expect(plan.loadType).toBe('medium');
+    expect(plan.totalPlannedKm).toBe(65.5);
+    expect(plan.description).toBe('Build week');
+    expect(plan.coachComments).toBe('Focus on aerobic base');
+    expect(plan.actualTotalKm).toBe(63.0);
+    expect(plan.createdAt).toBe('2026-03-01T00:00:00Z');
+    expect(plan.updatedAt).toBe('2026-03-08T00:00:00Z');
+  });
+
+  it('preserves null for optional numeric fields', () => {
+    const row = {
+      ...baseRow,
+      total_planned_km: null,
+      actual_total_km: null,
+      load_type: null,
+      description: null,
+      coach_comments: null,
+    };
+    const plan = toWeekPlan(row);
+    expect(plan.totalPlannedKm).toBeNull();
+    expect(plan.actualTotalKm).toBeNull();
+    expect(plan.loadType).toBeNull();
+    expect(plan.description).toBeNull();
+    expect(plan.coachComments).toBeNull();
+  });
+
+  it('correctly maps week_number to weekNumber (not weekId)', () => {
+    // Ensures the field name doesn't get conflated with the ISO weekId string
+    const plan = toWeekPlan(baseRow);
+    expect(plan.weekNumber).toBe(10);
+    expect(typeof plan.weekNumber).toBe('number');
+  });
+});

--- a/app/test/utils/query-client.ts
+++ b/app/test/utils/query-client.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Creates a fresh QueryClient for each test.
+ * - retry: false — fail fast without retry loops
+ * - staleTime / gcTime: Infinity — no background refetches or cache evictions during assertions
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        gcTime: Infinity,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}

--- a/app/test/utils/render.tsx
+++ b/app/test/utils/render.tsx
@@ -1,0 +1,107 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react';
+import { createContext, useContext, type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { createTestQueryClient } from './query-client';
+
+// ---------------------------------------------------------------------------
+// Minimal mock AuthContext — mirrors AuthContextValue from AuthContext.tsx
+// ---------------------------------------------------------------------------
+
+interface MockUser {
+  id: string;
+  role: 'coach' | 'athlete';
+  name: string;
+  email: string;
+  avatarUrl?: string | null;
+}
+
+interface MockAuthContextValue {
+  user: MockUser | null;
+  selectedAthleteId: string | null;
+  effectiveAthleteId: string | null;
+  athletes: Array<{ id: string; name: string; email: string }>;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  selectAthlete: (athleteId: string) => void;
+  clearSelectedAthlete: () => void;
+  updateProfile: (name: string, avatarUrl: string | null) => void;
+}
+
+const MockAuthContext = createContext<MockAuthContextValue | null>(null);
+
+export function useMockAuth(): MockAuthContextValue {
+  const ctx = useContext(MockAuthContext);
+  if (!ctx) throw new Error('useMockAuth must be used within renderWithProviders');
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// renderWithProviders
+// ---------------------------------------------------------------------------
+
+interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  /** Pre-seed an authenticated user. Omit for unauthenticated state. */
+  mockUser?: MockUser & { selectedAthleteId?: string | null };
+  /** Start the MemoryRouter at this path. Omit to skip routing wrapper. */
+  initialRoute?: string;
+}
+
+export function renderWithProviders(
+  ui: ReactNode,
+  options: RenderWithProvidersOptions = {}
+) {
+  const { mockUser, initialRoute, ...renderOptions } = options;
+  const queryClient = createTestQueryClient();
+
+  const effectiveAthleteId =
+    mockUser?.role === 'athlete'
+      ? mockUser.id
+      : (mockUser?.selectedAthleteId ?? null);
+
+  const authValue: MockAuthContextValue = {
+    user: mockUser
+      ? {
+          id: mockUser.id,
+          role: mockUser.role,
+          name: mockUser.name,
+          email: mockUser.email,
+          avatarUrl: mockUser.avatarUrl ?? null,
+        }
+      : null,
+    selectedAthleteId: mockUser?.selectedAthleteId ?? null,
+    effectiveAthleteId,
+    athletes: [],
+    isLoading: false,
+    login: async () => {},
+    logout: () => {},
+    selectAthlete: () => {},
+    clearSelectedAthlete: () => {},
+    updateProfile: () => {},
+  };
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    const content = (
+      <QueryClientProvider client={queryClient}>
+        <MockAuthContext.Provider value={authValue}>
+          {children}
+        </MockAuthContext.Provider>
+      </QueryClientProvider>
+    );
+
+    if (initialRoute !== undefined) {
+      return (
+        <MemoryRouter initialEntries={[initialRoute]}>{content}</MemoryRouter>
+      );
+    }
+
+    return content;
+  }
+
+  return {
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    queryClient,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "synek",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -7,7 +8,11 @@
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc",
-    "seed": "tsx supabase/seed.ts"
+    "seed": "tsx supabase/seed.ts",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "release": "release-it"
   },
   "dependencies": {
     "@react-router/node": "7.12.0",
@@ -32,19 +37,28 @@
   },
   "devDependencies": {
     "@react-router/dev": "7.12.0",
+    "@release-it/conventional-changelog": "^10.0.5",
     "@tailwindcss/vite": "^4.1.13",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "@vitest/coverage-v8": "^4.0.18",
+    "jsdom": "^28.1.0",
     "papaparse": "^5.5.3",
+    "release-it": "^19.2.4",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4.1.13",
     "tsx": "^4.19.3",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.2",
     "vite": "^7.1.7",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.0.18"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,21 @@ importers:
       '@react-router/dev':
         specifier: 7.12.0
         version: 7.12.0(@react-router/serve@7.12.0(react-router@7.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3))(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(react-router@7.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@release-it/conventional-changelog':
+        specifier: ^10.0.5
+        version: 10.0.5(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)(release-it@19.2.4(@types/node@22.19.13)(magicast@0.5.2))
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.2.1(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22
         version: 22.19.13
@@ -84,9 +96,21 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.4
+        version: 5.1.4(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@22.19.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(tsx@4.21.0))
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
+      release-it:
+        specifier: ^19.2.4
+        version: 19.2.4(@types/node@22.19.13)(magicast@0.5.2)
       shadcn:
         specifier: ^3.8.5
         version: 3.8.5(@types/node@22.19.13)(typescript@5.9.3)
@@ -108,12 +132,31 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(tsx@4.21.0)
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@antfu/ni@25.0.0':
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -220,6 +263,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-typescript@7.28.6':
     resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
     engines: {node: '>=6.9.0'}
@@ -247,6 +302,57 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@conventional-changelog/git-client@2.6.0':
+    resolution: {integrity: sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.3.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.0':
+    resolution: {integrity: sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dotenvx/dotenvx@1.52.0':
     resolution: {integrity: sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w==}
@@ -414,6 +520,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -439,6 +554,15 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@5.1.21':
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
@@ -457,9 +581,99 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
@@ -527,6 +741,61 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@nodeutils/defaults-deep@1.1.0':
+    resolution: {integrity: sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -535,6 +804,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@phun-ky/typeof@2.0.3':
+    resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
+    engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1278,8 +1551,17 @@ packages:
     peerDependencies:
       react-router: 7.12.0
 
+  '@release-it/conventional-changelog@10.0.5':
+    resolution: {integrity: sha512-Dxul3YlUsDLbIg+aR6T0QR/VyKwuJNR3GZM8mKVEwFO8GpH2H5vgnN7kacEvq/Qk5puDadOVbhbUq/KBjraemQ==}
+    engines: {node: ^20.12.0 || >=22.0.0}
+    peerDependencies:
+      release-it: ^18.0.0 || ^19.0.0
+
   '@remix-run/node-fetch-server@0.9.0':
     resolution: {integrity: sha512-SoLMv7dbH+njWzXnOY6fI08dFMI5+/dQ+vY3n8RnnbdG7MdJEgiP28Xj/xWlnRnED/aB6SFw56Zop+LbmaaKqA==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -1422,9 +1704,24 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/hosted-git-info@1.0.2':
+    resolution: {integrity: sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@supabase/auth-js@2.98.0':
     resolution: {integrity: sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==}
@@ -1552,8 +1849,61 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1561,8 +1911,15 @@ packages:
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
 
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
   '@types/papaparse@5.5.2':
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
+
+  '@types/parse-path@7.1.0':
+    resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
+    deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
 
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
@@ -1583,6 +1940,50 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitejs/plugin-react@5.1.4':
+    resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@4.0.18':
+    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.18
+      vitest: 4.0.18
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1619,6 +2020,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
@@ -1633,12 +2038,36 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -1655,6 +2084,16 @@ packages:
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
+
+  basic-ftp@5.2.0:
+    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+    engines: {node: '>=10.0.0'}
+
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
@@ -1688,6 +2127,14 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  c12@3.3.3:
+    resolution: {integrity: sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1707,13 +2154,34 @@ packages:
   caniuse-lite@1.0.30001775:
     resolution: {integrity: sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.1:
+    resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1725,6 +2193,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -1756,6 +2228,9 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -1764,8 +2239,16 @@ packages:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -1778,6 +2261,42 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  conventional-changelog-angular@8.3.0:
+    resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.3.0:
+    resolution: {integrity: sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-preset-loader@5.0.0:
+    resolution: {integrity: sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-writer@8.4.0:
+    resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  conventional-changelog@7.2.0:
+    resolution: {integrity: sha512-BEdgG+vPl53EVlTTk9sZ96aagFp0AQ5pw/ggiQMy2SClLbTo1r0l+8dSg79gkLOO5DS1Lswuhp5fWn6RwE+ivg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  conventional-commits-filter@5.0.0:
+    resolution: {integrity: sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==}
+    engines: {node: '>=18'}
+
+  conventional-commits-parser@6.3.0:
+    resolution: {integrity: sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  conventional-recommended-bump@11.2.0:
+    resolution: {integrity: sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1814,10 +2333,21 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@6.2.0:
+    resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
+    engines: {node: '>=20'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1825,6 +2355,14 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -1845,6 +2383,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -1870,9 +2411,23 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -1888,6 +2443,16 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -1920,6 +2485,10 @@ packages:
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1955,10 +2524,30 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  eta@4.5.0:
+    resolution: {integrity: sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==}
+    engines: {node: '>=20'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1976,6 +2565,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -1983,6 +2576,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.2.1:
     resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
@@ -2001,6 +2598,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2013,6 +2613,9 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2113,12 +2716,30 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  git-up@8.1.1:
+    resolution: {integrity: sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==}
+
+  git-url-parse@16.1.0:
+    resolution: {integrity: sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2138,6 +2759,15 @@ packages:
     resolution: {integrity: sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2153,12 +2783,27 @@ packages:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
     engines: {node: '>=16.9.0'}
 
+  hosted-git-info@8.1.0:
+    resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2167,6 +2812,10 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -2200,8 +2849,21 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inquirer@12.11.1:
+    resolution: {integrity: sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   ip-address@10.0.1:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
@@ -2251,6 +2913,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
   is-obj@3.0.0:
     resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
     engines: {node: '>=12'}
@@ -2259,6 +2925,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2266,9 +2935,16 @@ packages:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
 
+  is-ssh@1.4.1:
+    resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
@@ -2297,6 +2973,22 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  issue-parser@7.0.1:
+    resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
+    engines: {node: ^18.17 || >=20.6.1}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2304,12 +2996,24 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -2324,6 +3028,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-with-bigint@3.5.7:
+    resolution: {integrity: sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2418,6 +3125,24 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lodash.capitalize@4.2.1:
+    resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.uniqby@4.7.0:
+    resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -2425,20 +3150,53 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
 
   lucide-react@0.575.0:
     resolution: {integrity: sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  macos-release@3.4.0:
+    resolution: {integrity: sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -2447,6 +3205,10 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -2495,9 +3257,17 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -2547,6 +3317,17 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  netmask@2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
+
+  new-github-release-url@2.0.0:
+    resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -2558,6 +3339,9 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2565,13 +3349,26 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  normalize-package-data@7.0.1:
+    resolution: {integrity: sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nypm@0.6.5:
+    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2584,6 +3381,12 @@ packages:
   object-treeify@1.1.33:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -2604,8 +3407,16 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
   open@11.0.0:
@@ -2616,12 +3427,28 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  ora@9.0.0:
+    resolution: {integrity: sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==}
+    engines: {node: '>=20'}
+
+  os-name@6.1.0:
+    resolution: {integrity: sha512-zBd1G8HkewNd2A8oQ8c6BN/f/c9EId7rSUueOLGu28govmUctXmM+3765GwsByv9nYUdrLqHphXlYIc86saYsg==}
+    engines: {node: '>=18'}
+
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
@@ -2640,6 +3467,16 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse-path@7.1.0:
+    resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
+
+  parse-url@9.2.0:
+    resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
+    engines: {node: '>=14.13.0'}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2670,6 +3507,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2706,6 +3546,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -2714,9 +3558,23 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  protocols@2.0.2:
+    resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -2754,6 +3612,9 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -2775,8 +3636,15 @@ packages:
       typescript:
         optional: true
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
@@ -2823,13 +3691,30 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  release-it@19.2.4:
+    resolution: {integrity: sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==}
+    engines: {node: ^20.12.0 || >=22.0.0}
+    hasBin: true
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2849,6 +3734,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
@@ -2870,8 +3759,15 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -2882,11 +3778,20 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.4:
@@ -2944,6 +3849,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2953,6 +3861,18 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -2971,9 +3891,27 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -2989,6 +3927,13 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -3010,9 +3955,24 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -3031,6 +3991,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -3038,6 +4001,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
@@ -3057,6 +4024,10 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -3086,6 +4057,10 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@5.4.4:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
@@ -3098,17 +4073,36 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.23.0:
+    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+    engines: {node: '>=18.17'}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3126,6 +4120,10 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  url-join@5.0.0:
+    resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -3166,6 +4164,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -3228,13 +4229,67 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3245,6 +4300,21 @@ packages:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wildcard-match@5.1.4:
+    resolution: {integrity: sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==}
+
+  windows-release@6.1.0:
+    resolution: {integrity: sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA==}
+    engines: {node: '>=18'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -3269,9 +4339,20 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3309,12 +4390,34 @@ packages:
 
 snapshots:
 
+  '@acemir/cssom@0.9.31': {}
+
+  '@adobe/css-tools@4.4.4': {}
+
   '@antfu/ni@25.0.0':
     dependencies:
       ansis: 4.2.0
       fzf: 0.5.2
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3457,6 +4560,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -3503,6 +4616,43 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@conventional-changelog/git-client@2.6.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.3.0
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.0': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dotenvx/dotenvx@1.52.0':
     dependencies:
@@ -3598,6 +4748,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
+
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -3621,6 +4775,16 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.13
+
   '@inquirer/confirm@5.1.21(@types/node@22.19.13)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@22.19.13)
@@ -3641,7 +4805,94 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
 
+  '@inquirer/editor@4.2.23(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/expand@4.0.23(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.13)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.13
+
   '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/number@3.0.23(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/password@4.0.23(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.13)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.13)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.13)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.13)
+      '@inquirer/input': 4.3.1(@types/node@22.19.13)
+      '@inquirer/number': 3.0.23(@types/node@22.19.13)
+      '@inquirer/password': 4.0.23(@types/node@22.19.13)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.13)
+      '@inquirer/search': 3.2.2(@types/node@22.19.13)
+      '@inquirer/select': 4.4.2(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/search@3.2.2(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/select@4.4.2(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.13
 
   '@inquirer/type@3.0.10(@types/node@22.19.13)':
     optionalDependencies:
@@ -3719,6 +4970,73 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@nodeutils/defaults-deep@1.1.0':
+    dependencies:
+      lodash: 4.17.23
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.8':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.7
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
@@ -3727,6 +5045,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@phun-ky/typeof@2.0.3': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4555,7 +5875,23 @@ snapshots:
       - supports-color
       - typescript
 
+  '@release-it/conventional-changelog@10.0.5(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)(release-it@19.2.4(@types/node@22.19.13)(magicast@0.5.2))':
+    dependencies:
+      '@conventional-changelog/git-client': 2.6.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)
+      concat-stream: 2.0.0
+      conventional-changelog: 7.2.0(conventional-commits-filter@5.0.0)
+      conventional-changelog-angular: 8.3.0
+      conventional-changelog-conventionalcommits: 9.3.0
+      conventional-recommended-bump: 11.2.0
+      release-it: 19.2.4(@types/node@22.19.13)(magicast@0.5.2)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
   '@remix-run/node-fetch-server@0.9.0': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -4634,7 +5970,17 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/hosted-git-info@1.0.2': {}
+
+  '@simple-libs/stream-utils@1.2.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.98.0':
     dependencies:
@@ -4749,11 +6095,77 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
       minimatch: 10.2.4
       path-browserify: 1.0.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -4761,9 +6173,15 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/normalize-package-data@2.4.4': {}
+
   '@types/papaparse@5.5.2':
     dependencies:
       '@types/node': 22.19.13
+
+  '@types/parse-path@7.1.0':
+    dependencies:
+      parse-path: 7.1.0
 
   '@types/phoenix@1.6.7': {}
 
@@ -4782,6 +6200,72 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.13
+
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@22.19.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(tsx@4.21.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.12
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@22.19.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(tsx@4.21.0)
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@22.19.13)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   accepts@1.3.8:
     dependencies:
@@ -4814,6 +6298,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansis@4.2.0: {}
 
   arg@5.0.2: {}
@@ -4824,11 +6310,35 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-flatten@1.1.1: {}
+
+  array-ify@1.0.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -4846,6 +6356,14 @@ snapshots:
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  basic-ftp@5.2.0: {}
+
+  before-after-hook@4.0.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   body-parser@1.20.4:
     dependencies:
@@ -4902,6 +6420,23 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  c12@3.3.3(magicast@0.5.2):
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.4
+      dotenv: 17.3.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.5.2
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -4918,11 +6453,27 @@ snapshots:
 
   caniuse-lite@1.0.30001775: {}
 
+  chai@6.2.2: {}
+
   chalk@5.6.2: {}
+
+  chardet@2.1.1: {}
 
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  ci-info@4.4.0: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.1: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -4933,6 +6484,8 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-spinners@3.4.0: {}
 
   cli-width@4.1.0: {}
 
@@ -4956,6 +6509,11 @@ snapshots:
 
   commander@14.0.3: {}
 
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
@@ -4972,7 +6530,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
   confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -4981,6 +6548,53 @@ snapshots:
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  conventional-changelog-angular@8.3.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-preset-loader@5.0.0: {}
+
+  conventional-changelog-writer@8.4.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      conventional-commits-filter: 5.0.0
+      handlebars: 4.7.8
+      meow: 13.2.0
+      semver: 7.7.4
+
+  conventional-changelog@7.2.0(conventional-commits-filter@5.0.0):
+    dependencies:
+      '@conventional-changelog/git-client': 2.6.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)
+      '@simple-libs/hosted-git-info': 1.0.2
+      '@types/normalize-package-data': 2.4.4
+      conventional-changelog-preset-loader: 5.0.0
+      conventional-changelog-writer: 8.4.0
+      conventional-commits-parser: 6.3.0
+      fd-package-json: 2.0.0
+      meow: 13.2.0
+      normalize-package-data: 7.0.1
+    transitivePeerDependencies:
+      - conventional-commits-filter
+
+  conventional-commits-filter@5.0.0: {}
+
+  conventional-commits-parser@6.3.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      meow: 13.2.0
+
+  conventional-recommended-bump@11.2.0:
+    dependencies:
+      '@conventional-changelog/git-client': 2.6.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)
+      conventional-changelog-preset-loader: 5.0.0
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.3.0
+      meow: 13.2.0
 
   convert-source-map@2.0.0: {}
 
@@ -5012,11 +6626,34 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@6.2.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@csstools/css-syntax-patches-for-csstree': 1.1.0
+      css-tree: 3.2.1
+      lru-cache: 11.2.6
 
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2: {}
+
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-fns@4.1.0: {}
 
@@ -5027,6 +6664,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   dedent@1.7.2: {}
 
@@ -5041,7 +6680,19 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  defu@6.1.4: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   destroy@1.2.0: {}
 
@@ -5050,6 +6701,14 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   diff@8.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dotenv@17.3.1: {}
 
@@ -5080,6 +6739,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -5130,7 +6791,25 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   esprima@4.0.1: {}
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
+
+  eta@4.5.0: {}
 
   etag@1.8.1: {}
 
@@ -5152,6 +6831,18 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -5168,6 +6859,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
@@ -5245,6 +6938,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-content-type-parse@3.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -5260,6 +6955,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -5358,6 +7057,8 @@ snapshots:
 
   get-stream@6.0.1: {}
 
+  get-stream@8.0.1: {}
+
   get-stream@9.0.1:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
@@ -5366,6 +7067,32 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.2.0
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.5
+      pathe: 2.0.3
+
+  git-up@8.1.1:
+    dependencies:
+      is-ssh: 1.4.1
+      parse-url: 9.2.0
+
+  git-url-parse@16.1.0:
+    dependencies:
+      git-up: 8.1.1
 
   glob-parent@5.1.2:
     dependencies:
@@ -5379,6 +7106,17 @@ snapshots:
 
   graphql@16.13.0: {}
 
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -5388,6 +7126,18 @@ snapshots:
   headers-polyfill@4.0.3: {}
 
   hono@4.12.3: {}
+
+  hosted-git-info@8.1.0:
+    dependencies:
+      lru-cache: 10.4.3
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-parse-stringify@3.0.1:
     dependencies:
@@ -5401,6 +7151,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -5409,6 +7166,8 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
 
@@ -5435,7 +7194,21 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
+
+  inquirer@12.11.1(@types/node@22.19.13):
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.13)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.13)
+      '@inquirer/type': 3.0.10(@types/node@22.19.13)
+      mute-stream: 2.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.19.13
 
   ip-address@10.0.1: {}
 
@@ -5465,15 +7238,25 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@2.0.0: {}
+
   is-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
 
+  is-ssh@1.4.1:
+    dependencies:
+      protocols: 2.0.2
+
   is-stream@2.0.1: {}
+
+  is-stream@3.0.0: {}
 
   is-stream@4.0.1: {}
 
@@ -5491,15 +7274,65 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  issue-parser@7.0.1:
+    dependencies:
+      lodash.capitalize: 4.2.1
+      lodash.escaperegexp: 4.1.2
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.uniqby: 4.7.0
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@28.1.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      cssstyle: 6.2.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      undici: 7.22.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   jsesc@3.0.2: {}
 
@@ -5508,6 +7341,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-with-bigint@3.5.7: {}
 
   json5@2.2.3: {}
 
@@ -5572,6 +7407,18 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lodash.capitalize@4.2.1: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash.uniqby@4.7.0: {}
+
   lodash@4.17.23: {}
 
   log-symbols@6.0.0:
@@ -5579,23 +7426,52 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@11.2.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@7.18.3: {}
 
   lucide-react@0.575.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
+  macos-release@3.4.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
+
+  meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -5628,7 +7504,11 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-fn@4.0.0: {}
+
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -5685,12 +7565,22 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo-async@2.6.2: {}
+
+  netmask@2.0.2: {}
+
+  new-github-release-url@2.0.0:
+    dependencies:
+      type-fest: 2.19.0
+
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   node-domexception@1.0.0: {}
+
+  node-fetch-native@1.6.7: {}
 
   node-fetch@3.3.2:
     dependencies:
@@ -5700,20 +7590,40 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  normalize-package-data@7.0.1:
+    dependencies:
+      hosted-git-info: 8.1.0
+      semver: 7.7.4
+      validate-npm-package-license: 3.0.4
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
+  nypm@0.6.5:
+    dependencies:
+      citty: 0.2.1
+      pathe: 2.0.3
+      tinyexec: 1.0.2
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
   object-treeify@1.1.33: {}
+
+  obug@2.1.1: {}
+
+  ohash@2.0.11: {}
 
   on-finished@2.3.0:
     dependencies:
@@ -5733,9 +7643,20 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   open@11.0.0:
     dependencies:
@@ -5758,9 +7679,44 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  ora@9.0.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.2.2
+      string-width: 8.2.0
+      strip-ansi: 7.2.0
+
+  os-name@6.1.0:
+    dependencies:
+      macos-release: 3.4.0
+      windows-release: 6.1.0
+
   outvariant@1.4.3: {}
 
   p-map@7.0.4: {}
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.0.2
 
   package-manager-detector@1.6.0: {}
 
@@ -5779,6 +7735,19 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse-path@7.1.0:
+    dependencies:
+      protocols: 2.0.2
+
+  parse-url@9.2.0:
+    dependencies:
+      '@types/parse-path': 7.1.0
+      parse-path: 7.1.0
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -5796,6 +7765,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
@@ -5826,6 +7797,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -5835,10 +7812,29 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  protocols@2.0.2: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  punycode@2.3.1: {}
 
   qs@6.14.2:
     dependencies:
@@ -5929,6 +7925,11 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -5945,7 +7946,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       typescript: 5.9.3
 
+  react-is@17.0.2: {}
+
   react-refresh@0.14.2: {}
+
+  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -5984,7 +7989,15 @@ snapshots:
 
   react@19.2.4: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   recast@0.23.11:
     dependencies:
@@ -5993,6 +8006,41 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  release-it@19.2.4(@types/node@22.19.13)(magicast@0.5.2):
+    dependencies:
+      '@nodeutils/defaults-deep': 1.1.0
+      '@octokit/rest': 22.0.1
+      '@phun-ky/typeof': 2.0.3
+      async-retry: 1.3.3
+      c12: 3.3.3(magicast@0.5.2)
+      ci-info: 4.4.0
+      eta: 4.5.0
+      git-url-parse: 16.1.0
+      inquirer: 12.11.1(@types/node@22.19.13)
+      issue-parser: 7.0.1
+      lodash.merge: 4.6.2
+      mime-types: 3.0.2
+      new-github-release-url: 2.0.0
+      open: 10.2.0
+      ora: 9.0.0
+      os-name: 6.1.0
+      proxy-agent: 6.5.0
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      undici: 6.23.0
+      url-join: 5.0.0
+      wildcard-match: 5.1.4
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - magicast
+      - supports-color
 
   require-directory@2.1.1: {}
 
@@ -6006,6 +8054,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry@0.13.1: {}
 
   rettime@0.10.1: {}
 
@@ -6054,9 +8104,15 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-async@4.0.6: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-buffer@5.1.2: {}
 
@@ -6064,9 +8120,15 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.7.3: {}
 
   semver@7.7.4: {}
 
@@ -6204,11 +8266,28 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.0.1
+      smart-buffer: 4.2.0
 
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -6224,7 +8303,25 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -6241,6 +8338,15 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-object@5.0.0:
     dependencies:
@@ -6260,7 +8366,19 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-final-newline@4.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
 
@@ -6272,12 +8390,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   tldts-core@7.0.23: {}
 
@@ -6294,6 +8416,10 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.23
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-morph@26.0.0:
     dependencies:
@@ -6321,6 +8447,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  type-fest@2.19.0: {}
+
   type-fest@5.4.4:
     dependencies:
       tagged-tag: 1.0.0
@@ -6336,11 +8464,22 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typedarray@0.0.6: {}
+
   typescript@5.9.3: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   undici-types@6.21.0: {}
 
+  undici@6.23.0: {}
+
+  undici@7.22.0: {}
+
   unicorn-magic@0.3.0: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
 
@@ -6353,6 +8492,8 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  url-join@5.0.0: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -6380,6 +8521,11 @@ snapshots:
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@7.0.2: {}
 
@@ -6432,9 +8578,65 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
+  vitest@4.0.18(@types/node@22.19.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.13
+      jsdom: 28.1.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   void-elements@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  walk-up-path@4.0.0: {}
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -6443,6 +8645,19 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wildcard-match@5.1.4: {}
+
+  windows-release@6.1.0:
+    dependencies:
+      execa: 8.0.1
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -6460,10 +8675,18 @@ snapshots:
 
   ws@8.19.0: {}
 
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/specs/005-tests-refactor/checklists/requirements.md
+++ b/specs/005-tests-refactor/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Test Suite, Codebase Refactor, URL-Based Locale & Versioning
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Visual regression tests are explicitly excluded from scope (per user requirement — app redesign in progress)
+- FR-009 sets a 60% coverage floor as an achievable starting point; this can be raised in subsequent features
+- The test framework choice is deferred to the planning phase to avoid premature implementation constraints
+- The 200-line file limit excludes `app/components/ui/` (shadcn-managed) files per industry standard
+- FR-024–FR-030 cover versioning and changelog; conventional commits are adopted from this feature forward only (no history rewrite)
+- SC-010–SC-012 add measurable outcomes for the changelog workflow
+- All checklist items pass; spec is ready for `/speckit.clarify` or `/speckit.plan`

--- a/specs/005-tests-refactor/contracts/locale-routing.md
+++ b/specs/005-tests-refactor/contracts/locale-routing.md
@@ -1,0 +1,82 @@
+# Contract: Locale Routing
+
+## URL Scheme
+
+All application routes include a locale prefix as the first path segment:
+
+| Locale | Pattern | Example |
+|--------|---------|---------|
+| Polish (default) | `/pl/<route>` | `/pl/coach/week/2026-W10` |
+| English | `/en/<route>` | `/en/athlete/week/2026-W09` |
+
+## Route Structure
+
+```
+/:locale                     → LocaleLayout (validates locale, sets i18n language)
+  /                          → home.tsx (redirects to /:locale/coach or /:locale/athlete based on role)
+  /coach                     → coach/layout.tsx (auth guard: role=coach)
+    /                        → coach/week.tsx (redirects to current week)
+    /week/:weekId            → coach/week.$weekId.tsx
+  /athlete                   → athlete/layout.tsx (auth guard: role=athlete)
+    /                        → athlete/week.tsx (redirects to current week)
+    /week/:weekId            → athlete/week.$weekId.tsx
+  /settings                  → settings.tsx
+/login                       → login.tsx (no locale prefix — public)
+```
+
+## Redirect Rules
+
+| Input URL | Redirect Target | Condition |
+|-----------|----------------|-----------|
+| `/` | `/pl/` or `/[stored-locale]/` | Always (no locale segment) |
+| `/coach/week` | `/pl/coach/week` | Legacy URL without locale |
+| `/de/coach/week` | `/pl/coach/week` | Unsupported locale |
+| `/pl/coach/week` | No redirect | Valid |
+
+## LocaleLayout Behaviour
+
+```typescript
+// app/routes/locale-layout.tsx
+const SUPPORTED_LOCALES = ['pl', 'en'] as const
+type SupportedLocale = typeof SUPPORTED_LOCALES[number]
+
+export default function LocaleLayout() {
+  const { locale } = useParams()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  if (!SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
+    // Replace unsupported locale segment with 'pl'
+    const redirectPath = location.pathname.replace(`/${locale}/`, '/pl/')
+    return <Navigate to={redirectPath} replace />
+  }
+
+  i18n.changeLanguage(locale)
+  localStorage.setItem('locale', locale)
+
+  return <Outlet />
+}
+```
+
+## Language Toggle Contract
+
+The `LanguageToggle` component:
+- Reads current locale from `useParams().locale`
+- On switch: constructs new URL by replacing locale segment
+- Navigates with `useNavigate()` (no full page reload)
+- Persists new locale to `localStorage`
+
+```typescript
+function handleLocaleSwitch(newLocale: string) {
+  const currentPath = location.pathname
+  const newPath = currentPath.replace(new RegExp(`^/${locale}/`), `/${newLocale}/`)
+  navigate(newPath, { replace: false })
+  localStorage.setItem('locale', newLocale)
+}
+```
+
+## Locale Persistence Priority
+
+1. URL param (highest priority — always respected)
+2. `localStorage.getItem('locale')` (used for initial redirect at `/`)
+3. `'pl'` (hardcoded fallback default)

--- a/specs/005-tests-refactor/contracts/test-utilities.md
+++ b/specs/005-tests-refactor/contracts/test-utilities.md
@@ -1,0 +1,71 @@
+# Contract: Test Utilities
+
+**File**: `app/test/utils/render.tsx` + `app/test/utils/query-client.ts`
+
+---
+
+## createTestQueryClient()
+
+```typescript
+function createTestQueryClient(): QueryClient
+```
+
+Returns a fresh `QueryClient` configured for test isolation:
+- `queries.retry: false` — no retry loops in tests
+- `queries.staleTime: 0` — no stale-while-revalidate cache hiding
+- `mutations.retry: false`
+- `gcTime: Infinity` — cache entries persist for the test duration (prevents unexpected refetches)
+
+**Usage**: Create one per `describe` block (or per test for full isolation). Never share a client across test files.
+
+---
+
+## renderWithProviders(ui, options?)
+
+```typescript
+interface RenderWithProvidersOptions {
+  mockUser?: {
+    id: string
+    role: 'coach' | 'athlete'
+    name: string
+    email: string
+    avatarUrl?: string | null
+    selectedAthleteId?: string | null
+  }
+  initialRoute?: string           // default: '/'
+  routerConfig?: Parameters<typeof createMemoryRouter>[0]  // override route config
+}
+
+function renderWithProviders(
+  ui: ReactNode,
+  options?: RenderWithProvidersOptions
+): ReturnType<typeof render> & { queryClient: QueryClient }
+```
+
+Wraps `ui` in:
+1. `QueryClientProvider` (fresh `createTestQueryClient()`)
+2. `AuthContext` with `mockUser` pre-seeded (or null/unauthenticated if omitted)
+3. `RouterProvider` with `createMemoryRouter` if `initialRoute` is provided
+
+**Returns**: All standard `@testing-library/react` render result properties + `queryClient` for direct cache inspection in assertions.
+
+**Examples**:
+
+```tsx
+// Unauthenticated — login page test
+const { getByRole } = renderWithProviders(<LoginPage />)
+
+// Authenticated athlete
+const { getByText } = renderWithProviders(<AthleteWeekPage />, {
+  mockUser: { id: 'athlete-1', role: 'athlete', name: 'Alice', email: 'alice@test.com' },
+  initialRoute: '/pl/athlete/week/2026-W10',
+})
+
+// Authenticated coach with selected athlete
+const { getByText, queryClient } = renderWithProviders(<CoachWeekPage />, {
+  mockUser: { id: 'coach-1', role: 'coach', name: 'Coach', email: 'coach@test.com', selectedAthleteId: 'athlete-1' },
+  initialRoute: '/pl/coach/week/2026-W10',
+})
+// Inspect cache after mutation:
+const sessions = queryClient.getQueryData(['sessions', 'week', 'week-plan-1'])
+```

--- a/specs/005-tests-refactor/data-model.md
+++ b/specs/005-tests-refactor/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Test Suite, Refactor, Locale & Versioning
+
+**Branch**: `005-tests-refactor` | **Date**: 2026-03-09
+
+---
+
+## Overview
+
+This feature introduces no new database tables or columns. The data model changes are:
+
+1. **Route params**: `locale` added as a URL segment
+2. **Version field**: `package.json#version` promoted from `0.0.0` to `0.1.0`
+3. **Mock data re-organisation**: no new fixture data; existing mock-data.ts is split into focused modules
+
+---
+
+## Route Param: `locale`
+
+| Property | Value |
+|----------|-------|
+| Source | URL path segment (`:locale`) |
+| Valid values | `'pl'`, `'en'` |
+| Default | `'pl'` |
+| Persistence | `localStorage.getItem('locale')` for returning users |
+| Invalid value behaviour | Redirect to `/pl/<rest-of-path>` |
+
+**Not stored in database.** The locale is a session/URL concern only.
+
+---
+
+## Test Fixture Shape
+
+Tests reuse the existing mock-data layer. No new fixture objects are introduced. The mock data contract (unchanged):
+
+### MockWeekPlan
+
+Already defined in `app/lib/mock-data.ts` (to be split to `app/lib/mock-data/weeks.ts`):
+
+```typescript
+{
+  id: string,                // e.g. 'week-plan-1'
+  weekStart: string,         // e.g. '2026-02-23'
+  year: number,
+  weekNumber: number,
+  athleteId: string,
+  loadType: LoadType | null,
+  totalPlannedKm: number | null,
+  description: string | null,
+  coachComments: string | null,
+  createdAt: string,
+  updatedAt: string,
+}
+```
+
+### MockTrainingSession
+
+Already defined (to be split to `app/lib/mock-data/sessions.ts`):
+
+```typescript
+{
+  id: string,
+  weekPlanId: string,
+  dayOfWeek: DayOfWeek,
+  sortOrder: number,
+  trainingType: TrainingType,
+  description: string | null,
+  coachComments: string | null,
+  plannedDurationMinutes: number | null,
+  plannedDistanceKm: number | null,
+  typeSpecificData: TypeSpecificData,
+  isCompleted: boolean,
+  completedAt: string | null,
+  // ... actual performance fields
+}
+```
+
+---
+
+## Mock Data Module Split
+
+Current: `app/lib/mock-data.ts` (1012 lines, one file)
+
+Target structure:
+
+```
+app/lib/mock-data/
+├── index.ts          # Re-exports everything; all existing import sites continue to work
+├── sessions.ts       # mockFetchSessionsByWeekPlan, mockCreateSession, mockUpdateSession,
+│                     # mockDeleteSession, mockUpdateAthleteSession + session fixtures
+├── weeks.ts          # mockFetchWeekPlan, mockGetOrCreateWeekPlan, mockUpdateWeekPlan
+│                     # + week plan fixtures (keyed by athleteId)
+├── profile.ts        # mockFetchProfile, mockUpdateProfile + profile fixtures
+└── strava.ts         # mockFetchStravaConnection, mockUpdateStravaToken + strava fixtures
+```
+
+**Barrel re-export** in `index.ts` is justified here: it avoids updating every import site (currently all query files import from `~/lib/mock-data`). The barrel is purely a compatibility shim — no new abstraction.
+
+---
+
+## Version Lifecycle
+
+| Event | `package.json` version | `CHANGELOG.md` |
+|-------|----------------------|----------------|
+| Initial seed (this feature) | `0.1.0` | v0.1.0 entry created manually |
+| `fix:` or `refactor:` commit merged to main | patch bump (e.g. `0.1.1`) | Appended by release-it |
+| `feat:` commit merged to main | minor bump (e.g. `0.2.0`) | Appended by release-it |
+| `BREAKING CHANGE` in commit footer | major bump (e.g. `1.0.0`) | Appended by release-it |
+
+**Git tags** mark each release: `v0.1.0`, `v0.1.1`, etc. Tags are the anchor points for changelog diff ranges.
+
+---
+
+## Row Mapper Exports (for unit tests)
+
+To enable unit testing of row mappers without calling full query functions, the mapper functions must be exported:
+
+| File | Current | Change |
+|------|---------|--------|
+| `app/lib/queries/sessions.ts` | `function toSession(row)` (unexported) | `export function toSession(row)` |
+| `app/lib/queries/weeks.ts` | `function toWeekPlan(row)` (unexported) | `export function toWeekPlan(row)` |
+
+This is the minimal change needed. Exporting the mapper does not change runtime behaviour; it only enables test isolation.

--- a/specs/005-tests-refactor/plan.md
+++ b/specs/005-tests-refactor/plan.md
@@ -1,0 +1,307 @@
+# Implementation Plan: Test Suite, Codebase Refactor, URL-Based Locale & Versioning
+
+**Branch**: `005-tests-refactor` | **Date**: 2026-03-09 | **Spec**: `specs/005-tests-refactor/spec.md`
+
+## Summary
+
+Establish a Vitest-based test suite covering pure utilities, data-layer query functions (mock-mode), and React Query hook integration. Follow with a focused structural refactor to bring all files under 200 lines and route files to orchestration-only. Add URL-based locale (`/pl/`, `/en/`) with Polish as default. Automate changelog and versioning using `release-it` via GitHub Actions on merge to main.
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (strict), React 19
+**Primary Dependencies**: React Router 7 (SPA, `ssr: false`), TanStack Query 5, Supabase JS 2, i18next + react-i18next, Zod 4, date-fns 4
+**Storage**: Supabase (PostgreSQL) — mock mode used in all tests
+**Testing**: Vitest 3 + `@testing-library/react` 16 + `@testing-library/user-event` 14 + `jsdom` environment + `@vitest/coverage-v8`
+**Target Platform**: Browser SPA (Vite dev server, no SSR)
+**Project Type**: Web application (SPA)
+**Performance Goals**: Full test suite completes in < 60 s; zero regressions post-refactor
+**Constraints**: No real Supabase credentials in tests; no new runtime beyond pnpm; bundle additions must stay within constitution Principle IV limits
+**Scale/Scope**: ~75 source files; ~3500 LOC currently; 4 user stories across 3 technical layers
+
+---
+
+## Constitution Check
+
+*GATE: Must pass before implementation. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality & Maintainability | ✅ PASS | Refactor enforces named exports, strict TS, `cn()`, path aliases — no new violations introduced |
+| II. Testing Standards | ✅ PASS | Test suite specifically required by spec; mock implementations already exist in query files; optimistic-update cycle already implemented in hooks |
+| III. UX Consistency | ✅ PASS | Locale change adds PL default; all strings already translated; language toggle updated, not replaced |
+| IV. Performance Requirements | ✅ PASS | `vitest` + `@vitest/coverage-v8` are devDependencies only (zero bundle impact); `release-it` runs in CI only; React Router locale prefix adds no runtime overhead |
+| V. Simplicity & Anti-Complexity | ✅ PASS | No new abstractions; tests use existing mock layer; `release-it` replaces a hand-rolled solution, not adding to one |
+
+**Gate violations**: None. Implementation may proceed.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-tests-refactor/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code Changes
+
+```text
+# New test infrastructure
+app/
+└── test/
+    ├── setup.ts                     # Vitest global setup (jest-dom matchers)
+    ├── utils/
+    │   ├── render.tsx               # Custom render with QueryClient + AuthProvider wrapper
+    │   └── query-client.ts          # createTestQueryClient() factory
+    ├── unit/
+    │   ├── date.test.ts             # date.ts utility functions
+    │   ├── week-view.test.ts        # week-view.ts utility functions
+    │   ├── query-keys.test.ts       # keys.ts factories
+    │   ├── sessions-mapper.test.ts  # toSession row mapper
+    │   └── weeks-mapper.test.ts     # toWeekPlan row mapper
+    ├── integration/
+    │   ├── useSessions.test.tsx     # Hook: fetch, create, update, delete
+    │   ├── useWeekPlan.test.tsx     # Hook: fetch, getOrCreate, update
+    │   ├── login.test.tsx           # Auth flow: valid/invalid credentials
+    │   ├── coach-week-view.test.tsx # Coach: athlete select → sessions CRUD
+    │   └── athlete-week-view.test.tsx # Athlete: read-only, completion toggle
+    └── mocks/
+        └── modules.ts               # vi.mock declarations for query modules
+
+# Config files added at root
+vitest.config.ts                     # Separate from vite.config.ts
+.github/
+└── workflows/
+    └── release.yml                  # release-it on push to main
+
+# Refactored source files (split, not deleted)
+app/
+├── lib/
+│   ├── mock-data.ts                 # Split: mock-data/sessions.ts, mock-data/weeks.ts, mock-data/profile.ts
+│   └── context/
+│       └── AuthContext.tsx          # Extract useAuthInit.ts helper (init logic)
+├── components/
+│   └── training/
+│       ├── SessionForm.tsx          # Split into SessionForm + SessionFormFields.tsx
+│       └── type-fields/             # No change needed (already focused)
+├── routes/
+│   ├── coach/
+│   │   └── week.$weekId.tsx         # Already 160 lines, may need minor extraction
+│   └── athlete/
+│       └── week.$weekId.tsx         # 91 lines, fine
+
+# Locale routing
+app/
+├── routes.ts                        # All routes wrapped with /:locale prefix
+├── i18n/
+│   └── config.ts                   # Default lng → 'pl'; URL-driven locale detection
+└── components/
+    └── layout/
+        └── LanguageToggle.tsx       # Updated to navigate to locale URL
+```
+
+---
+
+## Complexity Tracking
+
+No constitution violations requiring justification.
+
+---
+
+## Phase 0: Research
+
+See `research.md` for full findings. Decisions summarised:
+
+### Test Runner: Vitest 3
+
+**Decision**: Vitest 3 + `@testing-library/react` 16 + `jsdom`
+**Rationale**: Native Vite integration; no separate build pipeline; `vi.mock` syntax mirrors jest; `@vitest/coverage-v8` uses V8's built-in instrumentation (fast, no Babel). Happy-dom is faster but jsdom is more complete for React Testing Library's DOM interactions.
+**Alternatives considered**: Jest — rejected because it requires a separate babel transform for ESM and Vite's plugin system (Tailwind CSS 4 plugin, path aliases) does not integrate.
+
+### Vitest Config Strategy
+
+**Decision**: Separate `vitest.config.ts` using `@vitejs/plugin-react` (NOT `reactRouter()` or `tailwindcss()`).
+**Rationale**: The `reactRouter()` Vite plugin must be excluded — it intercepts module resolution in ways incompatible with Vitest's test runner. `tailwindcss()` must also be excluded — it is a no-op in jsdom and can cause transform errors. `@vitejs/plugin-react` handles JSX and is the correct plugin for tests. It is currently bundled inside `reactRouter()` in the production config, so it must be added as an explicit devDependency: `pnpm add -D @vitejs/plugin-react`.
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./app/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['app/lib/**', 'app/components/**'],
+      exclude: ['app/components/ui/**', 'app/test/**'],
+      thresholds: { lines: 60, functions: 60 },
+    },
+  },
+})
+```
+
+### TanStack Query v5 Hook Testing
+
+**Decision**: `createTestQueryClient()` factory that creates a new `QueryClient` per test with `retry: false` and `gcTime: 0`. Wrap each render in a `QueryClientProvider`.
+**Rationale**: Each test gets an isolated cache; no state bleed between tests. The `renderWithProviders()` wrapper in `app/test/utils/render.tsx` accepts optional pre-seeded auth state so integration tests can fake an authenticated coach or athlete.
+
+```typescript
+// app/test/utils/query-client.ts
+import { QueryClient } from '@tanstack/react-query'
+export function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+```
+
+### Mocking Supabase-Dependent Query Functions
+
+**Decision**: `vi.mock('~/lib/queries/sessions')` at the top of each integration test, returning the already-exported mock functions from `mock-data.ts`.
+**Rationale**: The query files already branch on `isMockMode`. Rather than relying on environment detection, tests vi.mock the entire query module and substitute mock implementations directly. This makes test intent explicit and removes dependency on `VITE_SUPABASE_URL` being unset.
+
+```typescript
+vi.mock('~/lib/queries/sessions', async () => {
+  const { mockFetchSessionsByWeekPlan, mockCreateSession } = await import('~/lib/mock-data')
+  return { fetchSessionsByWeekPlan: mockFetchSessionsByWeekPlan, createSession: mockCreateSession, /* … */ }
+})
+```
+
+### React Router v7 Component Testing
+
+**Decision**: Use `createMemoryRouter` + `RouterProvider` from `react-router` for route-level integration tests. For hook-only tests (no routing), skip the router wrapper.
+**Rationale**: `MemoryRouter` is the legacy API; `createMemoryRouter` is the v7-native way and supports loaders/actions if needed later. Route components that call `useParams` or `useNavigate` need this wrapper.
+
+### Changelog / Versioning: release-it
+
+**Decision**: `release-it` with `@release-it/conventional-changelog` plugin
+**Rationale**: release-it is a well-established (10M+ weekly npm downloads), zero-Ruby, zero-Python tool that works natively with pnpm. The `@release-it/conventional-changelog` plugin handles conventional-commit parsing, CHANGELOG.md generation (append-only, no overwrite), and semantic version bumping. It integrates cleanly with GitHub Actions via `GITHUB_TOKEN`. `semantic-release` was considered but is heavier (monorepo of plugins, requires more CI boilerplate) and the opinionated release pipeline is overkill for a single-package SPA.
+
+**Bundle impact**: `release-it` is a `devDependency` only; zero production bundle impact.
+
+**GitHub Actions workflow** (`release.yml`):
+```yaml
+on:
+  push:
+    branches: [main]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm release-it --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### URL-Based Locale Strategy
+
+**Decision**: Add `/:locale` as a top-level layout route wrapping all authenticated routes. Redirect bare paths to `/pl/`. Language toggle navigates via `useNavigate`.
+**Rationale**: React Router v7 supports parameterised layout routes. A single `LocaleLayout` component reads `:locale` from params, validates it (`pl` | `en`), calls `i18n.changeLanguage()`, and persists the choice. Unknown locale → redirect to `/pl/`.
+
+---
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+See `data-model.md`. No new database entities. This feature adds:
+- Test fixtures (in-memory, derived from existing mock-data)
+- A `locale` route param (derived from URL, validated against `['pl', 'en']`)
+- A `version` field in `package.json` (already present, set to `0.0.0` → seeded to `0.1.0`)
+
+### Interface Contracts
+
+No external APIs added. Internal contracts documented in `contracts/`:
+- `contracts/test-utilities.md` — shape of `renderWithProviders()` and `createTestQueryClient()`
+- `contracts/locale-routing.md` — URL scheme and redirect rules
+
+### Quickstart
+
+See `quickstart.md` for developer onboarding to the new test setup.
+
+---
+
+## Implementation Order
+
+Stories are sequenced strictly: P1 (tests) → P2 (refactor) → P3 (locale) → P4 (changelog). Each story has a gate: the full test suite must pass before the next story begins.
+
+### P1 — Test Suite
+
+1. Install devDependencies: `vitest`, `@vitest/coverage-v8`, `@vitejs/plugin-react`, `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom`, `jsdom`
+2. Create `vitest.config.ts` (separate from `vite.config.ts`, excludes `reactRouter()` plugin)
+3. Add `"test": "vitest"` and `"test:coverage": "vitest --coverage"` scripts to `package.json`
+4. Create `app/test/setup.ts` (extends jest-dom matchers)
+5. Create `app/test/utils/query-client.ts` and `app/test/utils/render.tsx`
+6. Write unit tests for `date.ts` (all 6 exported functions)
+7. Write unit tests for `sessions.ts` `toSession` mapper (via extracted export)
+8. Write unit tests for `weeks.ts` `toWeekPlan` mapper (via extracted export)
+9. Write unit tests for `query keys.ts` factories
+10. Write integration test: `useSessions` hook (fetch, create, update, delete states)
+11. Write integration test: `useWeekPlan` hook (fetch, getOrCreate, update)
+12. Write integration test: login flow (valid → redirect, invalid → error)
+13. Write integration test: coach week view (athlete selection, session CRUD)
+14. Write integration test: athlete week view (read-only display, completion toggle)
+15. Run `pnpm test:coverage` → verify ≥ 60% coverage on target files
+
+### P2 — Refactor
+
+1. **Split `mock-data.ts`** (1012 lines): extract into `app/lib/mock-data/sessions.ts`, `weeks.ts`, `profile.ts`, `strava.ts`; keep `app/lib/mock-data/index.ts` as re-export barrel (barrel is justified: avoids touching every import site)
+2. **Split `SessionForm.tsx`** (398 lines): extract form-field rendering into `SessionFormFields.tsx`; `SessionForm.tsx` keeps only state + submit logic
+3. **Audit `AuthContext.tsx`** (270 lines): extract session-init logic into `useAuthInit.ts` if it brings the main file under 200 lines
+4. **Audit route files**: `week.$weekId.tsx` (coach, 160 lines) — inline helpers may need extraction; athlete route (91 lines) is fine
+5. Run `pnpm typecheck` → zero errors
+6. Run `pnpm test` → all tests pass (no regressions)
+
+### P3 — URL-Based Locale
+
+1. Update `app/routes.ts`: wrap coach + athlete + settings routes under `/:locale` layout
+2. Create `app/routes/locale-layout.tsx`: reads `:locale` param, validates, calls `i18n.changeLanguage()`, redirects unknown → `/pl/`
+3. Update `app/i18n/config.ts`: set `lng: 'pl'` as default (remove localStorage fallback)
+4. Update `LanguageToggle.tsx`: use `useNavigate` to switch locale segment in URL; persist to `localStorage` for returning users
+5. Update `app/routes/home.tsx`: redirect `/` → `/pl/` or stored locale
+6. Add i18n translation keys for any new UI text (added to both `en/` and `pl/`)
+7. Run integration tests → verify locale preservation across navigation
+8. Run `pnpm typecheck` → zero errors
+
+### P4 — Changelog & Versioning
+
+1. Install `release-it` + `@release-it/conventional-changelog` as devDependencies
+2. Create `.release-it.json` config: conventional changelog plugin, GitHub releases, `package.json` version bump
+3. Set `package.json` version to `0.1.0`
+4. Create `CHANGELOG.md` with `v0.1.0` historical baseline entry (features 001–005)
+5. Create `.github/workflows/release.yml` (as per research section above)
+6. Add `"release": "release-it"` script to `package.json`
+7. Verify with a dry run: `pnpm release-it --dry-run`
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `reactRouter()` Vite plugin conflicts with Vitest module resolution | Medium | Use separate `vitest.config.ts` that excludes the plugin; confirmed pattern in React Router v7 community |
+| `toSession` / `toWeekPlan` mappers are not exported (private) | High | Export them from their query files so unit tests can import directly; no API contract change |
+| URL locale prefix breaks existing Strava OAuth redirect URIs | Low | Strava redirect uses `VITE_APP_URL` env var (absolute URL); not affected by route structure changes |
+| `release-it` CI token permissions | Low | Workflow requires `permissions: contents: write`; documented in quickstart |
+| mock-data.ts split causes import path churn | Medium | Re-export barrel at `mock-data/index.ts` keeps all existing import sites working |

--- a/specs/005-tests-refactor/quickstart.md
+++ b/specs/005-tests-refactor/quickstart.md
@@ -1,0 +1,162 @@
+# Quickstart: Test Suite & New Conventions
+
+**Branch**: `005-tests-refactor`
+
+---
+
+## Running Tests
+
+```bash
+# Run all tests (watch mode)
+pnpm test
+
+# Run once with coverage report
+pnpm test:coverage
+
+# Run a specific test file
+pnpm test app/test/unit/date.test.ts
+
+# Run only integration tests
+pnpm test app/test/integration
+```
+
+Coverage report outputs to `coverage/` (HTML) and terminal (text). Target: ≥ 60% lines/functions on `app/lib/**` and `app/components/**` (excluding `app/components/ui/**`).
+
+---
+
+## Writing a New Test
+
+### Unit test (pure function)
+
+```typescript
+// app/test/unit/my-utility.test.ts
+import { describe, it, expect } from 'vitest'
+import { myFunction } from '~/lib/utils/my-utility'
+
+describe('myFunction', () => {
+  it('returns expected value for standard input', () => {
+    expect(myFunction('2026-W10')).toBe('2026-03-02')
+  })
+
+  it('throws on invalid input', () => {
+    expect(() => myFunction('bad-input')).toThrow('Invalid')
+  })
+})
+```
+
+### Integration test (React Query hook)
+
+```typescript
+// app/test/integration/useMyHook.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '~/test/utils/render'
+import { useMyHook } from '~/lib/hooks/useMyHook'
+import { mockMyQuery } from '~/lib/mock-data'
+
+vi.mock('~/lib/queries/my-query', () => ({
+  fetchMyData: mockMyQuery,
+}))
+
+describe('useMyHook', () => {
+  it('loads data successfully', async () => {
+    const { result } = renderHook(() => useMyHook('some-id'), {
+      wrapper: ({ children }) => renderWithProviders(children).container.parentElement!,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ id: 'some-id' })
+  })
+})
+```
+
+### Integration test (component + routing)
+
+```typescript
+// app/test/integration/my-page.test.tsx
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '~/test/utils/render'
+import MyPage from '~/routes/my-page'
+
+describe('MyPage', () => {
+  it('renders correctly for authenticated user', async () => {
+    renderWithProviders(<MyPage />, {
+      mockUser: { id: 'user-1', role: 'athlete', name: 'Alice', email: 'alice@test.com' },
+      initialRoute: '/pl/athlete/week/2026-W10',
+    })
+    await waitFor(() => expect(screen.getByText(/Week 10/i)).toBeInTheDocument())
+  })
+})
+```
+
+---
+
+## What NOT to Test
+
+Follow the spec's philosophy: **test valuable journeys, not coverage numbers**.
+
+| ✅ Test | ❌ Skip |
+|--------|--------|
+| `toSession` row mapper transforms DB rows correctly | React component renders a button |
+| `getCurrentWeekId()` returns correct ISO format | `trainingTypeConfig` object has expected keys |
+| Login with valid credentials → session established | Every mutation's `onSuccess` toast message |
+| Session delete removes item from cache | A shadcn `<Button>` renders with the right class |
+
+---
+
+## URL Locale Convention
+
+All in-app navigation must include the locale segment. Use the `useLocaleNavigate()` helper (added in P3):
+
+```typescript
+// Instead of:
+navigate('/coach/week/2026-W10')
+
+// Use:
+const { locale } = useParams()
+navigate(`/${locale}/coach/week/2026-W10`)
+```
+
+Or use the `useLocaleNavigate()` hook which auto-prepends the current locale.
+
+---
+
+## Release Process
+
+Releases are **fully automated** on push to `main`. There is nothing to run locally.
+
+Commit messages must follow Conventional Commits for correct version bumps:
+
+| Prefix | Version bump | Example |
+|--------|-------------|---------|
+| `feat:` | minor (0.x.0) | `feat: add athlete notes field` |
+| `fix:` | patch (0.0.x) | `fix: session date off by one` |
+| `refactor:` | patch | `refactor: split mock-data module` |
+| `chore:` | none | `chore: update dependencies` |
+| `docs:` | none | `docs: update README` |
+| `BREAKING CHANGE` in footer | major (x.0.0) | any commit with `BREAKING CHANGE: ...` footer |
+
+To preview what would be released without actually releasing:
+```bash
+pnpm release-it --dry-run
+```
+
+---
+
+## Mock Data Structure (after refactor)
+
+```typescript
+// All existing imports still work unchanged:
+import { mockFetchSessionsByWeekPlan } from '~/lib/mock-data'
+
+// The barrel re-exports from sub-modules:
+// ~/lib/mock-data → ~/lib/mock-data/sessions.ts
+//                → ~/lib/mock-data/weeks.ts
+//                → ~/lib/mock-data/profile.ts
+//                → ~/lib/mock-data/strava.ts
+```
+
+Test fixtures available:
+- `athlete-1` (Alice): weeks W09, W10, W11 with detailed sessions
+- `athlete-2` (Bob): week W10 only, beginner plan
+- `coach-1`: has access to both athletes

--- a/specs/005-tests-refactor/research.md
+++ b/specs/005-tests-refactor/research.md
@@ -1,0 +1,346 @@
+# Research: Test Suite, Refactor, Locale, Versioning
+
+**Branch**: `005-tests-refactor` | **Date**: 2026-03-09
+
+---
+
+## 1. Vitest with React Router v7 + React 19
+
+**Decision**: Vitest 3 + jsdom environment + separate `vitest.config.ts`
+
+**Rationale**: The `reactRouter()` Vite plugin hooks into module resolution in ways that conflict with Vitest's test runner (specifically module pre-bundling and virtual module handling for routes). The solution is a dedicated `vitest.config.ts` that loads only the plugins safe for test execution: `tailwindcss()` and `tsconfigPaths()`.
+
+**Packages needed**:
+```
+pnpm add -D vitest @vitest/coverage-v8 @testing-library/react @testing-library/user-event @testing-library/jest-dom jsdom
+```
+
+Expected versions (compatible with React 19):
+- `vitest` ^3.x
+- `@testing-library/react` ^16.x (React 19 support added in 16.0)
+- `@testing-library/user-event` ^14.x
+- `@testing-library/jest-dom` ^6.x
+- `jsdom` ^25.x
+
+**Environment choice (jsdom vs happy-dom)**:
+- `jsdom` is the safe default: fuller spec compliance, required for some `@testing-library/react` queries
+- `happy-dom` is ~2–3× faster but misses some DOM APIs; not worth the risk for integration tests involving form events and navigation
+
+**Alternatives considered**: Jest — rejected. Jest requires babel transforms to handle ESM imports and does not integrate with Vite plugins (Tailwind CSS 4 uses a Vite plugin, not PostCSS; path aliases via `vite-tsconfig-paths` would need manual jest `moduleNameMapper` setup). Vitest has zero additional configuration cost for this stack.
+
+---
+
+## 2. Vitest Config (separate from vite.config.ts)
+
+**Critical**: Use `@vitejs/plugin-react` (not `tailwindcss()` or `reactRouter()`).
+- `reactRouter()` must be excluded — it breaks Vitest module resolution.
+- `tailwindcss()` must be excluded — it's a no-op in jsdom and can cause transform errors.
+- `@vitejs/plugin-react` handles JSX transform for tests (currently bundled inside `reactRouter()` in the app config, so it needs to be added as an explicit devDependency).
+
+```bash
+pnpm add -D @vitejs/plugin-react
+```
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [
+    react(),          // JSX transform — NOT reactRouter()
+    tsconfigPaths(),  // keeps ~/ path alias working
+    // Do NOT include tailwindcss() — no-op in jsdom, can cause transform errors
+  ],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./app/test/setup.ts'],
+    include: ['app/test/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      include: ['app/lib/**', 'app/components/**'],
+      exclude: ['app/components/ui/**', 'app/test/**'],
+      reporter: ['text', 'html'],
+      thresholds: { lines: 60, functions: 60 },
+    },
+  },
+})
+```
+
+`globals: true` enables `describe`, `it`, `expect`, `vi` without imports in test files.
+
+`setupFiles` runs before each test file to register `@testing-library/jest-dom` matchers.
+
+**`app/test/setup.ts`:**
+```typescript
+import '@testing-library/jest-dom'
+
+// Initialize i18n with empty resources for tests — avoids missing-key warnings
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { common: {}, coach: {}, athlete: {}, training: {} } },
+  interpolation: { escapeValue: false },
+})
+```
+
+---
+
+## 3. TanStack Query v5 Hook Testing Pattern
+
+**Decision**: `createTestQueryClient()` + `renderWithProviders()` wrapper
+
+Every test gets a fresh `QueryClient` instance (no shared state) with retries disabled.
+
+```typescript
+// app/test/utils/query-client.ts
+import { QueryClient } from '@tanstack/react-query'
+
+export function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+```
+
+```tsx
+// app/test/utils/render.tsx
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { RenderOptions } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createTestQueryClient } from './query-client'
+
+interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  mockUser?: { id: string; role: 'coach' | 'athlete'; name: string; email: string }
+}
+
+export function renderWithProviders(
+  ui: ReactNode,
+  options: RenderWithProvidersOptions = {}
+) {
+  const queryClient = createTestQueryClient()
+  const { mockUser, ...renderOptions } = options
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {/* AuthProvider mock or real depending on test */}
+        {children}
+      </QueryClientProvider>
+    )
+  }
+
+  return { ...render(ui, { wrapper: Wrapper, ...renderOptions }), queryClient }
+}
+```
+
+---
+
+## 4. Mocking Query Modules (Supabase-free tests)
+
+**Decision**: `vi.mock('~/lib/queries/sessions')` substituting mock implementations directly.
+
+Query files already export `mockFetchSessionsByWeekPlan`, etc. Tests import these and wire them via vi.mock:
+
+```typescript
+vi.mock('~/lib/queries/sessions', async () => {
+  const mockData = await import('~/lib/mock-data')
+  return {
+    fetchSessionsByWeekPlan: mockData.mockFetchSessionsByWeekPlan,
+    createSession: mockData.mockCreateSession,
+    updateSession: mockData.mockUpdateSession,
+    deleteSession: mockData.mockDeleteSession,
+    updateAthleteSession: mockData.mockUpdateAthleteSession,
+  }
+})
+```
+
+This is explicit and test-intent is clear. It does not rely on `VITE_SUPABASE_URL` being absent.
+
+**Important**: `vi.mock` calls are hoisted to the top of the file by Vitest (same as Jest). The async import inside the factory is needed to avoid circular reference issues with the mock-data module.
+
+---
+
+## 5. React Router v7 Component Testing
+
+**Decision**: `createMemoryRouter` + `RouterProvider` for route-level integration tests.
+
+```tsx
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { render } from '@testing-library/react'
+
+const router = createMemoryRouter([
+  {
+    path: '/coach/week/:weekId',
+    element: <CoachWeekPage />,
+  },
+], {
+  initialEntries: ['/coach/week/2026-W10'],
+})
+
+render(
+  <QueryClientProvider client={createTestQueryClient()}>
+    <RouterProvider router={router} />
+  </QueryClientProvider>
+)
+```
+
+For hooks that only use `useNavigate` or `useParams`, wrap the component in `RouterProvider`. For hooks with no routing dependency, skip the router wrapper entirely.
+
+**Alternatives considered**: `MemoryRouter` — the v6/legacy API, still works in v7 but not idiomatic. The `createMemoryRouter` API is the v7-native approach and better aligns with future test evolution.
+
+---
+
+## 6. Changelog/Versioning: release-it vs semantic-release
+
+### release-it (chosen)
+
+- **npm downloads**: ~10M/week
+- **pnpm compatible**: yes — runs as a CLI tool in devDependencies
+- **Conventional commits**: via `@release-it/conventional-changelog` plugin (wraps `conventional-changelog-core`)
+- **CHANGELOG behaviour**: append-only prepend — never overwrites existing content (satisfies FR-029)
+- **GitHub integration**: creates GitHub releases via `GITHUB_TOKEN`; optional PR/issue links in changelog
+- **Config**: single `.release-it.json` file
+
+```json
+{
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": "angular",
+      "infile": "CHANGELOG.md"
+    }
+  },
+  "git": {
+    "commitMessage": "chore: release v${version}",
+    "tagName": "v${version}"
+  },
+  "github": {
+    "release": true,
+    "releaseName": "v${version}"
+  },
+  "npm": {
+    "publish": false
+  }
+}
+```
+
+### semantic-release (rejected)
+
+- More opinionated, designed for library publishing workflows
+- Requires multiple plugins (`@semantic-release/commit-analyzer`, `@semantic-release/changelog`, `@semantic-release/git`, `@semantic-release/github`) to achieve the same result
+- The `prepare` phase runs locally in CI and can conflict with lock-file-frozen installs
+- Overkill for a single SPA with no npm publishing requirement
+
+---
+
+## 7. GitHub Actions Release Workflow
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history needed for changelog generation
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Release
+        run: pnpm release-it --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`--ci` flag skips interactive prompts and uses the version bump inferred from commits since the last tag.
+
+---
+
+## 8. URL-Based Locale (React Router v7)
+
+**Decision**: Top-level `/:locale` parameterised layout route
+
+React Router v7 supports `layout()` with a path prefix. All authenticated routes nest under `/:locale`. A `LocaleLayout` component:
+1. Reads `params.locale`
+2. If unsupported → `<Navigate to="/pl/..." replace />`
+3. Calls `i18n.changeLanguage(locale)` (synchronous in-memory operation)
+4. Persists locale to `localStorage`
+5. Renders `<Outlet />`
+
+The home route (`/`) redirects to `/pl/` (or stored locale).
+
+`routes.ts` structure:
+```typescript
+route(':locale', 'routes/locale-layout.tsx', [
+  index('routes/home.tsx'),
+  ...prefix('coach', [
+    layout('routes/coach/layout.tsx', [
+      index('routes/coach/week.tsx'),
+      route('week/:weekId', 'routes/coach/week.$weekId.tsx'),
+    ]),
+  ]),
+  ...prefix('athlete', [...]),
+  route('settings', 'routes/settings.tsx'),
+])
+```
+
+The `LanguageToggle` currently reads from localStorage. It will be updated to use `useNavigate` and construct the new URL by replacing the locale segment:
+
+```typescript
+const navigate = useNavigate()
+const { locale } = useParams()
+
+function handleSwitch(newLocale: string) {
+  const newPath = location.pathname.replace(`/${locale}/`, `/${newLocale}/`)
+  navigate(newPath)
+  localStorage.setItem('locale', newLocale)
+}
+```
+
+---
+
+## 9. Refactor Scope — File Size Audit
+
+Files currently exceeding 200 lines:
+
+| File | Lines | Action |
+|------|-------|--------|
+| `app/lib/mock-data.ts` | 1012 | Split into `mock-data/sessions.ts`, `mock-data/weeks.ts`, `mock-data/profile.ts`, `mock-data/strava.ts` with barrel re-export |
+| `app/components/training/SessionForm.tsx` | 398 | Extract field rendering to `SessionFormFields.tsx`; form keeps state + submit |
+| `app/lib/context/AuthContext.tsx` | 270 | Extract `useAuthInit()` hook (session restoration + athlete loading logic) |
+
+Files close to 200 lines (monitor, may not need splitting):
+
+| File | Lines |
+|------|-------|
+| `app/routes/coach/week.$weekId.tsx` | 160 |
+| `app/lib/queries/sessions.ts` | 180 |
+
+All other files are well within limits.

--- a/specs/005-tests-refactor/spec.md
+++ b/specs/005-tests-refactor/spec.md
@@ -1,0 +1,181 @@
+# Feature Specification: Test Suite, Codebase Refactor, URL-Based Locale & Versioning
+
+**Feature Branch**: `005-tests-refactor`
+**Created**: 2026-03-09
+**Status**: Draft
+**Input**: User description: "Add the Unit and Integration tests that will help to build further features and ensure no regression is caused. Following the test suite creation, plan a major refactor of the application so that the code is clean, written with the best industry standards in mind and well structured architecture. No visual regression at this stage as the app is about to be redesigned as well. Currently the code is messy, the styles are everywhere, it's hard to navigate, sizable files. I want to clean up and make it prepared for further development. As part of these changes, add a requirement to keep the locale (language) in the url and load PL as a default."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Developer Runs Tests to Verify Nothing is Broken (Priority: P1)
+
+A developer makes a code change and runs the test suite to confirm no existing functionality has regressed. All utility functions, data transformation logic, and query helpers have unit tests. Core user flows — login, viewing a week plan, creating a session — are covered by integration tests that exercise the full component-to-data-layer path.
+
+**Why this priority**: Tests are the foundation that makes everything else safe. Without them, the refactor (P2) cannot proceed with confidence, and future features carry regression risk. This story must be completed before any significant code changes.
+
+**Independent Test**: Can be fully tested by running the test command and verifying all tests pass in a clean environment, without needing any UI changes or infrastructure.
+
+**Acceptance Scenarios**:
+
+1. **Given** the test suite is installed, **When** a developer runs the test command, **Then** all unit and integration tests complete and report a pass/fail result with coverage summary.
+2. **Given** a utility function (e.g., date formatting, week-id calculation), **When** its unit test runs in isolation, **Then** the function's output matches expected values for standard and edge-case inputs.
+3. **Given** a data query function (e.g., fetch week plan, create session), **When** its unit test runs with a mock data layer, **Then** it correctly maps DB-shaped data to typed application models and handles error states.
+4. **Given** a React Query hook, **When** its integration test renders it inside a test provider, **Then** it loads data from the mock layer, exposes the correct state (loading → data → error), and updates the cache after a mutation.
+5. **Given** the login integration test, **When** a user submits valid credentials, **Then** the session is established and the user is redirected to the correct role-based home route.
+6. **Given** the coach week plan integration test, **When** a coach selects an athlete and navigates to a week, **Then** the correct sessions are rendered and athlete-switching triggers a fresh data load.
+7. **Given** any test run, **When** a developer introduces a regression in a utility or query function, **Then** the relevant test fails with a clear, descriptive error message pointing to the affected assertion.
+
+---
+
+### User Story 2 - Developer Navigates and Modifies a Clean Codebase (Priority: P2)
+
+A developer opening the project for the first time can understand the architecture in under 10 minutes. Files are small and focused (single responsibility), naming is consistent, logic is co-located with its feature area, and there are no god-files or scattered inline styles. Adding a new feature requires touching predictable, well-bounded locations.
+
+**Why this priority**: The refactor cannot begin until P1 (tests) is in place, because tests provide the safety net. Once tests pass, the refactor ensures the codebase is ready for the planned redesign and future development without accumulating further technical debt.
+
+**Independent Test**: Can be fully tested by reviewing the directory structure, checking that no file exceeds 200 lines (excluding generated/shadcn files), verifying all styles use the design system exclusively, and running the full test suite to confirm the refactor introduced no regressions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the refactored codebase, **When** a developer looks for the logic handling athlete session creation, **Then** they find it in a single, clearly-named file under the appropriate feature directory with no duplicated logic elsewhere.
+2. **Given** any non-UI, non-shadcn source file, **When** a developer opens it, **Then** it is under 200 lines, has a single clear purpose, and contains no inline style definitions outside of the design system's utility classes.
+3. **Given** the component library, **When** a developer needs to reuse a UI element, **Then** shared components are co-located in a discoverable folder, not duplicated across route files.
+4. **Given** a route file, **When** a developer opens it, **Then** it contains only orchestration logic (layout, data fetching hooks, event handler wiring) and delegates rendering to imported components.
+5. **Given** the style system, **When** a developer applies styling, **Then** there is a single source of truth for design tokens (colors, spacing), with no raw hex values or magic numbers in component files.
+6. **Given** the full test suite, **When** the refactor is complete, **Then** all tests that passed before the refactor continue to pass after it — no regressions introduced.
+
+---
+
+### User Story 3 - User Gets Polish as Default Language and Bookmarkable Locale URLs (Priority: P3)
+
+When a user opens the application for the first time they see the interface in Polish. If they switch to English, the URL reflects the chosen locale (e.g., `/en/coach/week/2026-W10`). Sharing or bookmarking a URL preserves the locale for whoever opens the link. Users who previously chose English are remembered across sessions.
+
+**Why this priority**: This is a self-contained UX change that does not depend on the refactor completing, but it is best implemented during the refactor because it touches routing and layout — areas already being restructured.
+
+**Independent Test**: Can be fully tested by opening the application without any stored preference, verifying the default language is Polish, switching to English and verifying the URL changes to include `/en/`, then copying that URL to a new private browser tab and verifying English is still active.
+
+**Acceptance Scenarios**:
+
+1. **Given** a first-time visitor with no stored language preference, **When** they load the application, **Then** the interface is displayed in Polish and the URL reflects the `pl` locale segment.
+2. **Given** a user on the Polish locale, **When** they switch the language to English via the language toggle, **Then** the URL updates to include the `en` locale segment and all interface text changes to English without a full page reload.
+3. **Given** a URL containing a locale segment (e.g., `/en/coach/week/2026-W10`), **When** a user opens that URL directly, **Then** the interface is displayed in the locale specified in the URL, regardless of any stored preference.
+4. **Given** a URL with no locale segment (e.g., `/coach/week`), **When** a user opens it, **Then** they are redirected to the equivalent Polish URL (`/pl/coach/week`) transparently.
+5. **Given** a user who has previously selected English, **When** they return to the application, **Then** their stored preference is applied and they land on the English locale URL.
+6. **Given** the locale in the URL, **When** the user navigates between pages within the app, **Then** the locale segment is preserved across all internal navigation.
+
+---
+
+### User Story 4 - Changelog Stays Current Without Any Developer Action (Priority: P4)
+
+Every meaningful change to the codebase is automatically recorded in `CHANGELOG.md` as part of the normal merge flow — no developer needs to remember to run a command or edit a file. When a PR is merged to the main branch, the changelog and version number are updated automatically. The file can still be edited by hand if a correction or clarification is needed, but maintenance requires zero deliberate effort under normal circumstances.
+
+**Why this priority**: Versioning and changelog automation layers on top of the working codebase. It has no dependencies on the other stories but is easiest to introduce after the refactor establishes a clean commit baseline.
+
+**Independent Test**: Can be fully tested by merging a conventional commit to the main branch and verifying that `CHANGELOG.md` and `package.json` are updated automatically — with no developer intervention between the merge and the updated file appearing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer merges a PR to main, **When** the merge completes, **Then** `CHANGELOG.md` and the version in `package.json` are updated automatically without any follow-up command.
+2. **Given** a set of conventional commits since the last version, **When** the automatic update runs, **Then** a `CHANGELOG.md` entry is produced grouping changes under headings (e.g., Features, Bug Fixes, Refactor) with links to the relevant commits or PRs.
+3. **Given** a breaking change commit, **When** the automatic update runs, **Then** the major version number is incremented and the changelog entry clearly flags the breaking change.
+4. **Given** a patch-level fix commit, **When** the automatic update runs, **Then** only the patch version is incremented and the changelog reflects the fix.
+5. **Given** the changelog, **When** a stakeholder reads it, **Then** each entry is written in plain language describing the user-visible impact, not raw technical implementation detail.
+6. **Given** no meaningful commits since the last version tag, **When** the automatic update runs, **Then** it exits without creating a duplicate or empty changelog entry.
+7. **Given** a developer needs to correct a changelog entry, **When** they manually edit `CHANGELOG.md`, **Then** the edit is preserved and the next automatic update appends below it without overwriting the correction.
+
+---
+
+### Edge Cases
+
+- What happens when an unsupported locale segment appears in the URL (e.g., `/de/coach/week`)? → The application redirects to the Polish default and does not throw an unhandled error.
+- What happens when a test runs in an environment without a real data backend? → All tests use the existing mock data layer; no real Supabase credentials are required.
+- What happens when a refactored file is accidentally left with a circular import? → TypeScript compilation must fail loudly and the CI build must not pass.
+- What happens when a user opens a locale URL while already authenticated in a different role? → The locale is preserved but route-level auth guards still apply.
+- What happens when the stored locale preference is corrupted or unrecognised? → Fall back to Polish without a runtime error.
+- What happens when commits do not follow the conventional commit format? → Non-conventional commits are included in the changelog under an "Other" category and do not block the release.
+- What happens when changelog generation runs on a branch with no new commits since the last tag? → The tool exits gracefully without producing an empty entry.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Test Infrastructure**
+
+- **FR-001**: The project MUST have a test runner configured that can execute unit and integration tests via a single command with human-readable output.
+- **FR-002**: Unit tests MUST cover all pure utility functions: date helpers (`getCurrentWeekId`, `weekIdToMonday`, `getWeekDateRange`), training-type configuration, and query key factories.
+- **FR-003**: Unit tests MUST cover all data query functions (fetch, create, update, delete for sessions and week plans) using a mock data layer — not real network calls.
+- **FR-004**: Unit tests MUST cover typed row-mapper functions to verify correct snake_case → camelCase transformation and type narrowing.
+- **FR-005**: Integration tests MUST cover React Query hooks by rendering them in a minimal test environment with mocked data dependencies and asserting loading, success, and error states.
+- **FR-006**: Integration tests MUST cover the login flow: valid credentials → session established → redirect; invalid credentials → error shown → no redirect.
+- **FR-007**: Integration tests MUST cover the coach week view: athlete selection → correct data loaded → session CRUD operations reflected in the cache.
+- **FR-008**: Integration tests MUST cover the athlete week view: read-only session display, session completion toggle reflected in the cache.
+- **FR-009**: The test suite MUST produce a code coverage report; initial coverage MUST reach at least 60% of non-UI, non-generated source files.
+- **FR-010**: Tests MUST run without any real Supabase credentials or network access, relying entirely on the existing mock data layer.
+
+**Codebase Refactor**
+
+- **FR-011**: No non-shadcn, non-generated source file (`.ts`, `.tsx`) MAY exceed 200 lines — large files MUST be split into focused modules.
+- **FR-012**: Route files MUST contain only page-level orchestration (hook calls, layout, event wiring) and delegate all rendering logic to named imported components.
+- **FR-013**: All shared component logic that is currently duplicated across routes MUST be extracted to a shared component or hook, eliminating duplication.
+- **FR-014**: Styling MUST use only the project's design system utility classes; no raw colour values, magic spacing numbers, or per-file style blocks may remain.
+- **FR-015**: The directory structure MUST match the canonical layout defined in CLAUDE.md; no files may live outside their designated folder.
+- **FR-016**: All TypeScript strict-mode errors MUST be resolved; `pnpm typecheck` MUST pass with zero errors after the refactor.
+- **FR-017**: The full test suite MUST pass after the refactor is complete, confirming zero regressions were introduced.
+
+**URL-Based Locale**
+
+- **FR-018**: All application routes MUST include a locale prefix segment (`/pl/` or `/en/`) as the first path component.
+- **FR-019**: The default locale MUST be Polish (`pl`); any request to a path without a locale segment MUST redirect to the equivalent `/pl/` path.
+- **FR-020**: The locale in the URL MUST be the single source of truth for the active language; switching language via the UI toggle MUST update the URL and persist the preference in session/local storage.
+- **FR-021**: When a user navigates within the application, the locale segment MUST be preserved in every generated internal link and programmatic navigation call.
+- **FR-022**: Unsupported locale values in the URL MUST result in a redirect to the Polish default rather than an unhandled error.
+- **FR-023**: The existing language toggle component MUST remain functional and now drive URL-based locale changes rather than in-memory state only.
+
+**Versioning & Changelog**
+
+- **FR-024**: The project MUST adopt semantic versioning (`major.minor.patch`); version MUST be tracked in `package.json` as the single source of truth.
+- **FR-025**: All commit messages MUST follow the Conventional Commits specification (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `break:`, etc.) to enable automated changelog generation.
+- **FR-026**: `CHANGELOG.md` and the version in `package.json` MUST be updated automatically on every merge to the main branch — no developer action is required beyond writing conventional commits.
+- **FR-027**: The generated changelog MUST group entries under standard headings: **Features**, **Bug Fixes**, **Refactor**, **Breaking Changes**, and **Other** — with each entry linking to its commit or PR.
+- **FR-028**: A `feat:` commit MUST trigger a minor version bump; a `fix:` or `refactor:` commit MUST trigger a patch bump; a commit with `BREAKING CHANGE` in the footer MUST trigger a major bump.
+- **FR-029**: Manual edits to `CHANGELOG.md` MUST be preserved; the automation MUST only prepend new entries and MUST NOT overwrite or reformat existing content.
+- **FR-030**: The initial `CHANGELOG.md` MUST be seeded with a `v0.1.0` entry summarising the existing feature branches (001–005) as a historical baseline.
+
+### Key Entities
+
+- **Test Suite**: The collection of unit and integration tests, configuration, and coverage reporting. Scoped to business logic and data layers; excludes visual/snapshot tests.
+- **Mock Data Layer**: Existing in-memory mock used in development (`isMockMode`). Tests MUST reuse this layer rather than introducing separate test fixtures.
+- **Locale Segment**: The two-character language code prefix in the URL path (`pl`, `en`). Acts as the canonical locale identifier for the active session.
+- **Semantic Version**: A `major.minor.patch` identifier stored in `package.json` and marked in the git history with a tag (e.g., `v1.2.0`).
+- **Changelog Entry**: A structured record in `CHANGELOG.md` documenting all changes in a release, grouped by change type and linked to source commits or PRs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer can run the full test suite in under 60 seconds on a standard development machine and get a clear pass/fail result.
+- **SC-002**: Test suite achieves ≥ 60% code coverage on all non-UI, non-generated source files (utilities, query functions, hooks, row mappers).
+- **SC-003**: All unit and integration tests continue to pass after the refactor is merged — zero regressions reported.
+- **SC-004**: No source file outside `app/components/ui/` (shadcn-managed) exceeds 200 lines after the refactor.
+- **SC-005**: `pnpm typecheck` completes with zero TypeScript errors after the refactor.
+- **SC-006**: A new developer can identify the correct file to modify for any given application behaviour in under 5 minutes by reading the directory structure alone.
+- **SC-007**: The application loads in Polish by default for a first-time visitor with no stored preferences, with zero additional configuration required.
+- **SC-008**: Locale is preserved when any internal link or back/forward browser navigation is used — 100% of navigation paths retain the locale segment.
+- **SC-009**: The CI build (typecheck + tests) completes successfully on the `005-tests-refactor` branch before any PR merge.
+- **SC-010**: After any merge to main, `CHANGELOG.md` and `package.json` are updated automatically within the merge pipeline — zero developer actions required beyond writing the commit.
+- **SC-011**: The `CHANGELOG.md` file is present in the repository root and contains at least the `v0.1.0` historical baseline entry before the first automated release.
+- **SC-012**: Every release version is traceable from `CHANGELOG.md` → git tag → individual commits, forming a complete audit trail.
+
+## Assumptions
+
+- The existing mock data layer (`app/lib/mock-data.ts` + `isMockMode` flag) is sufficient for test isolation; no new fixture system is introduced.
+- Visual regression tests are explicitly out of scope for this feature — the application is undergoing a visual redesign separately.
+- The refactor does not change any user-visible behaviour except the URL locale prefix and the Polish default language.
+- Locale preference persistence uses the existing browser storage mechanism (sessionStorage or localStorage) already in use in the project.
+- The test framework choice (e.g., Vitest + Testing Library) is left to the planning phase, but must integrate with the existing Vite build without additional build tooling.
+- `app/components/ui/` (shadcn-managed) files are excluded from the 200-line rule and coverage requirements.
+- Strava-related files are in scope for the test suite but only for mock-mode paths — no live Strava API calls in tests.
+- Conventional Commits will be adopted from this feature forward; retroactive rewriting of existing commit history is out of scope.
+- The changelog automation runs in the CI/CD pipeline on merge to main; it does not require any local tooling to be installed by individual developers.
+- The automation tool must integrate with the existing `pnpm` workspace without introducing a separate runtime (e.g., no Ruby gems or Python scripts).
+- Git tags are the mechanism for marking releases; no separate release management database is introduced.

--- a/specs/005-tests-refactor/tasks.md
+++ b/specs/005-tests-refactor/tasks.md
@@ -1,0 +1,227 @@
+# Tasks: Test Suite, Codebase Refactor, URL-Based Locale & Versioning
+
+**Branch**: `005-tests-refactor`
+**Input**: Design documents from `/specs/005-tests-refactor/`
+**Spec**: `spec.md` | **Plan**: `plan.md` | **Research**: `research.md` | **Data model**: `data-model.md`
+
+**Test philosophy**: Only tests that protect valuable journeys are included. Trivial config objects (training-types, query key tuples) are not tested — they add maintenance cost without catching real bugs. Row mappers, date math, data aggregation, and full data-layer flows are tested.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Parallelizable — different file, no in-flight dependency
+- **[US#]**: User story this task belongs to
+- Stories must execute in order (P1→P2→P3→P4) — each builds on the previous
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Install test infrastructure, create config files, add npm scripts.
+
+- [x] T001 Install test devDependencies in `package.json`: `vitest @vitest/coverage-v8 @vitejs/plugin-react @testing-library/react @testing-library/user-event @testing-library/jest-dom jsdom`
+- [x] T002 [P] Install changelog devDependencies in `package.json`: `release-it @release-it/conventional-changelog`
+- [x] T003 Create `vitest.config.ts` at repo root — uses `@vitejs/plugin-react` + `tsconfigPaths()`, environment `jsdom`, globals `true`, setupFiles `./app/test/setup.ts`, coverage include `app/lib/**` + `app/components/**` (exclude `app/components/ui/**`), thresholds `lines: 60, functions: 60`
+- [x] T004 Create `app/test/setup.ts` — imports `@testing-library/jest-dom`; initialises a minimal i18n instance (`lng: 'en'`, empty resource bundles) so components using `useTranslation` don't throw in tests
+- [x] T005 Add scripts to `package.json`: `"test": "vitest"`, `"test:run": "vitest run"`, `"test:coverage": "vitest run --coverage"`, `"release": "release-it"`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Export the private row mappers so unit tests can import them; build the shared test render utilities.
+
+**⚠️ CRITICAL**: Phases 3–7 cannot begin until this phase is complete.
+
+- [x] T006 Export `toSession` row mapper from `app/lib/queries/sessions.ts` — change `function toSession` to `export function toSession`
+- [x] T007 [P] Export `toWeekPlan` row mapper from `app/lib/queries/weeks.ts` — change `function toWeekPlan` to `export function toWeekPlan`
+- [x] T008 Create `app/test/utils/query-client.ts` — exports `createTestQueryClient()` returning a `QueryClient` with `retry: false`, `staleTime: Infinity`, `gcTime: Infinity` on queries and `retry: false` on mutations
+- [x] T009 Create `app/test/utils/render.tsx` — exports `renderWithProviders(ui, options?)` wrapping `ui` in `QueryClientProvider` (fresh `createTestQueryClient()`) + a mock `AuthContext` pre-seeded with optional `mockUser` (id, role, name, email, selectedAthleteId); returns all RTL render result properties plus `queryClient` for cache assertions; accepts optional `initialRoute` and wraps in `createMemoryRouter` when provided
+
+**Checkpoint**: `pnpm test:run` should find 0 test files and exit cleanly (no errors).
+
+---
+
+## Phase 3: User Story 1 — Test Suite (Priority: P1) 🎯 MVP
+
+**Goal**: A developer can run `pnpm test:run` and get a pass/fail signal across all valuable unit and integration tests. No real Supabase credentials required.
+
+**Independent Test**: Run `pnpm test:coverage` in a clean checkout with no `.env` file. All tests pass and coverage on `app/lib/**` reaches ≥ 60%.
+
+### Unit Tests
+
+- [x] T010 [P] [US1] Create `app/test/unit/date.test.ts` — tests for all 6 functions in `app/lib/utils/date.ts`: `getCurrentWeekId` (format `YYYY-WNN`), `weekIdToMonday` (returns correct Monday date string for known week IDs, throws on invalid input), `mondayToWeekId` (round-trip with `weekIdToMonday`), `getNextWeekId` + `getPrevWeekId` (boundary: week 1 / week 52–53), `getWeekDateRange` (correct start/end dates and formatted string)
+- [x] T011 [P] [US1] Create `app/test/unit/week-view.test.ts` — tests for both functions in `app/lib/utils/week-view.ts`: `groupSessionsByDay` (sessions grouped into correct day buckets, sorted by `sortOrder`, empty days initialised as `[]`), `computeWeekStats` (completion percentage 0 when no sessions, 100 when all complete, rest_day sessions excluded from totals, `totalActualRunKm` only sums `run` type)
+- [x] T012 [P] [US1] Create `app/test/unit/sessions-mapper.test.ts` — tests for the exported `toSession` from `app/lib/queries/sessions.ts`: snake_case fields map to correct camelCase properties (`week_plan_id → weekPlanId`, `day_of_week → dayOfWeek`, `is_completed → isCompleted`, `trainee_notes → athleteNotes`, etc.); null fields stay `null`; `type_specific_data` defaults to `{ type: training_type }` when absent
+- [x] T013 [P] [US1] Create `app/test/unit/weeks-mapper.test.ts` — tests for the exported `toWeekPlan` from `app/lib/queries/weeks.ts`: all snake_case fields map correctly (`week_start → weekStart`, `week_number → weekNumber`, `total_planned_km → totalPlannedKm`, `actual_total_km → actualTotalKm`, etc.); nullable fields preserved
+
+### Integration Tests
+
+- [x] T014 [US1] Create `app/test/integration/useSessions.test.tsx` — `vi.mock('~/lib/queries/sessions')` substituting mock functions from `~/lib/mock-data`; test: `useSessions` transitions from loading → data with correct session list for a known `weekPlanId`; `useCreateSession` adds a new session and invalidates the cache; `useUpdateSession` applies optimistic update immediately and rolls back on simulated error; `useDeleteSession` removes the session optimistically
+- [x] T015 [US1] Create `app/test/integration/useWeekPlan.test.tsx` — `vi.mock('~/lib/queries/weeks')` substituting mock functions; test: `useWeekPlan` returns `null` for unknown week, returns plan for known week with correct athlete scoping; `useGetOrCreateWeekPlan` seeding the cache on success; `useUpdateWeekPlan` applying optimistic update and rolling back on error
+- [x] T016 [US1] Create `app/test/integration/login.test.tsx` — renders the login form via `renderWithProviders` (unauthenticated); submits valid credentials (`coach@synek.app` / `coach123`) and asserts session is established (user in auth context / redirect occurs); submits invalid credentials and asserts error message is shown and no redirect happens
+- [x] T017 [US1] Create `app/test/integration/coach-week-view.test.tsx` — `vi.mock` sessions + weeks query modules; renders coach week view with a pre-seeded coach user + `selectedAthleteId: 'athlete-1'`; asserts sessions for Alice's W10 are rendered; triggers a session delete and asserts the session is removed from the rendered list (cache reflects the mutation); switching `selectedAthleteId` to `'athlete-2'` triggers a fresh data load showing Bob's sessions
+- [x] T018 [US1] Create `app/test/integration/athlete-week-view.test.tsx` — `vi.mock` sessions + weeks query modules; renders athlete week view with `mockUser: { id: 'athlete-1', role: 'athlete' }`; asserts sessions are displayed in read-only mode (no add/delete controls); toggles a completion checkbox and asserts the session's `isCompleted` state updates in the cache
+
+### Coverage Gate
+
+- [x] T019 [US1] Run `pnpm test:coverage` and verify the threshold check passes (≥ 60% lines and functions on `app/lib/**`); fix any failing test or adjust a single threshold value in `vitest.config.ts` if a specific non-critical file skews the number
+
+**Checkpoint**: `pnpm test:run` is green. All 9 test files pass. Coverage meets threshold.
+
+---
+
+## Phase 4: User Story 2 — Codebase Refactor (Priority: P2)
+
+**Goal**: No non-shadcn source file exceeds 200 lines. Route files contain only orchestration logic. `pnpm typecheck` passes.
+
+**Independent Test**: Run `find app -name "*.ts" -o -name "*.tsx" | grep -v "components/ui" | xargs wc -l | awk '$1 > 200 {print}'` and get zero output. Run `pnpm typecheck` → zero errors. Run `pnpm test:run` → all tests still pass.
+
+- [x] T020 [US2] Create `app/lib/mock-data/` directory and split `app/lib/mock-data.ts` (1012 lines) into four focused modules: `sessions.ts` (session fixtures + mock CRUD functions), `weeks.ts` (week plan fixtures + mock CRUD), `profile.ts` (profile fixtures + mock profile functions), `strava.ts` (Strava fixtures + mock Strava functions); create `app/lib/mock-data/index.ts` as a barrel re-exporting everything from all four modules
+- [x] T021 [US2] Delete `app/lib/mock-data.ts` and verify all existing import sites (`~/lib/mock-data`) continue to resolve through the barrel; fix any broken imports
+- [x] T022 [US2] Extract `app/components/training/SessionFormFields.tsx` from `app/components/training/SessionForm.tsx` (398 lines) — move all field rendering (sport-specific fields, duration/distance inputs, coach comments textarea, type selector) into `SessionFormFields`; `SessionForm.tsx` keeps only form state management, validation, and submit handling; both files must be under 200 lines
+- [x] T023 [US2] Audit `app/lib/context/AuthContext.tsx` (270 lines) — if file exceeds 200 lines after removing blank lines and comments, extract the session-restoration and athlete-loading side-effect logic into `app/lib/hooks/useAuthInit.ts`; `AuthContext.tsx` imports and calls the hook; ensure the public interface of `AuthContext` is unchanged
+- [x] T024 [US2] Audit `app/routes/coach/week.$weekId.tsx` (160 lines) and `app/routes/settings.tsx` — extract any inline helper functions or large JSX blocks that push the file toward 200 lines into co-located component files; route files should contain only hook calls, event handler wiring, and top-level layout
+- [x] T025 [US2] Run `pnpm typecheck` → fix any TypeScript errors introduced by the refactor (typically import path updates, type narrowing after file splits)
+- [x] T026 [US2] Run `pnpm test:run` → confirm all tests from Phase 3 still pass; fix any test import paths broken by the mock-data split
+
+**Checkpoint**: All files under 200 lines. `pnpm typecheck` clean. `pnpm test:run` green.
+
+---
+
+## Phase 5: User Story 3 — URL-Based Locale (Priority: P3)
+
+**Goal**: Every application URL begins with `/pl/` or `/en/`. First-time visitors see Polish. Language toggle updates the URL. Unsupported locale segments redirect to `/pl/`.
+
+**Independent Test**: Open app with no localStorage. URL shows `/pl/`. Toggle to English — URL changes to `/en/...`. Open `/de/coach/week` directly — redirected to `/pl/coach/week`. Copy an `/en/` URL into a fresh private tab — English is active.
+
+- [x] T027 [US3] Update `app/routes.ts` — wrap all authenticated routes (`coach`, `athlete`, `settings`, `home`) under a `route(':locale', 'routes/locale-layout.tsx', [...])` parent; `login` route stays outside the locale wrapper (public, no prefix); run `pnpm typecheck` after this change as React Router will regenerate route types
+- [x] T028 [US3] Create `app/routes/locale-layout.tsx` — reads `params.locale`; if not in `['pl', 'en']`, returns `<Navigate>` replacing the locale segment with `pl`; otherwise calls `i18n.changeLanguage(locale)` and `localStorage.setItem('locale', locale)`; renders `<Outlet />`; named export only
+- [x] T029 [US3] Update `app/i18n/config.ts` — change default `lng` to `'pl'`; remove the `localStorage.getItem('language')` fallback (locale is now URL-driven, not storage-driven at init time); keep `fallbackLng: 'en'`
+- [x] T030 [US3] Update `app/routes/home.tsx` — redirect bare `/` navigations to `/${storedLocale}/` where `storedLocale = localStorage.getItem('locale') ?? 'pl'`; if the user is authenticated, include the role-based sub-path (`/coach` or `/athlete`)
+- [x] T031 [US3] Update `app/components/layout/LanguageToggle.tsx` — replace the current localStorage-only toggle with a `useNavigate` + `useParams` approach: read current `locale` from params, construct new path by replacing the locale segment, call `navigate(newPath)` and `localStorage.setItem('locale', newLocale)`
+- [x] T032 [US3] Update all `useNavigate` calls and `<Link>` hrefs in coach and athlete route files to prepend the current locale segment (use `useParams().locale` inline or a small `useLocaleNavigate` hook if the pattern appears 3+ times)
+- [x] T033 [US3] Add any new i18n keys introduced in this phase to both `app/i18n/resources/en/common.json` and `app/i18n/resources/pl/common.json` simultaneously
+- [x] T034 [US3] Run `pnpm typecheck` + `pnpm test:run` — fix any regressions; update integration tests in `app/test/integration/` that use hardcoded paths (`/coach/week/...`) to include the `/pl/` prefix
+
+**Checkpoint**: App loads in Polish by default. Language toggle works. All tests green. Typecheck clean.
+
+---
+
+## Phase 6: User Story 4 — Automated Changelog & Versioning (Priority: P4)
+
+**Goal**: Every merge to `main` automatically updates `CHANGELOG.md` and bumps the version in `package.json`. Zero developer action required.
+
+**Independent Test**: Run `pnpm release-it --dry-run` locally and verify it reports the computed version bump without writing any files. Merge a `feat:` commit to `main` and observe the GitHub Actions workflow produce a new git tag and prepend a changelog entry.
+
+- [x] T035 [US4] Set `version` in `package.json` to `"0.1.0"` (from `"0.0.0"` or whatever placeholder exists)
+- [x] T036 [US4] Create `CHANGELOG.md` at repo root with a `## [0.1.0]` entry summarising the five completed feature branches (001-sheets-data-migration, 002, 003, 004-settings-strava, 005-tests-refactor) as a human-readable historical baseline
+- [x] T037 [US4] Create `.release-it.json` at repo root — configure: `git.commitMessage: "chore: release v${version}"`, `git.tagName: "v${version}"`, `git.requireBranch: "main"`, `github.release: true`, plugin `@release-it/conventional-changelog` with `preset: "conventionalcommits"` and `infile: "CHANGELOG.md"`; set `npm.publish: false`
+- [x] T038 [US4] Create `.github/workflows/release.yml` — trigger on `push: branches: [main]`; jobs: `test` (runs `pnpm typecheck` + `pnpm test:run`) and `release` (needs `test`, runs `pnpm exec release-it --ci` with `GITHUB_TOKEN`, `permissions: contents: write`, `fetch-depth: 0` checkout)
+- [x] T039 [US4] Run `pnpm release-it --dry-run` locally to verify the config is valid and the CHANGELOG format is correct; fix any config errors
+
+**Checkpoint**: `.release-it.json` valid. Dry run exits cleanly. CI workflow file lints correctly (`gh workflow list` if GitHub CLI available).
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality gates and CI housekeeping.
+
+- [x] T040 [P] Run `pnpm typecheck` one final time across the full branch — resolve any remaining TypeScript strict-mode errors (unused variables, type assertions, etc.)
+- [x] T041 [P] Run `pnpm test:coverage` and confirm the coverage report shows ≥ 60% on the defined include paths; if any file dramatically undershoots consider whether a missing test case is genuinely valuable (not just coverage padding)
+- [x] T042 Verify no non-shadcn source file exceeds 200 lines: `find app -name "*.ts" -o -name "*.tsx" | grep -v "components/ui" | xargs wc -l | sort -rn | head -20` — inspect top results and split any remaining oversized files
+- [x] T043 Update `CLAUDE.md` `## Active Technologies` section with the test stack entry for feature 005: Vitest 3, @testing-library/react 16, release-it
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Setup)         — no dependencies, start immediately
+Phase 2 (Foundational)  — depends on Phase 1; BLOCKS all user stories
+Phase 3 (US1 Tests)     — depends on Phase 2; MVP increment
+Phase 4 (US2 Refactor)  — depends on Phase 3 (tests are the safety net)
+Phase 5 (US3 Locale)    — depends on Phase 4 (refactor restructures routing first)
+Phase 6 (US4 Changelog) — depends on Phase 5 (needs clean baseline before first release)
+Phase 7 (Polish)        — depends on Phases 3–6
+```
+
+### User Story Dependencies
+
+- **US1** (P1 Tests): Can start after Foundational. Delivers standalone value — CI can run after this phase.
+- **US2** (P2 Refactor): Requires US1 complete. Tests are the refactor's safety net.
+- **US3** (P3 Locale): Requires US2 complete. Touches routing layer restructured in refactor.
+- **US4** (P4 Changelog): Requires US3 complete. Cleanest to establish after the branch settles.
+
+### Parallel Opportunities
+
+Within Phase 1:
+- T001 (test deps) and T002 (release-it deps) can run in parallel — different concerns
+
+Within Phase 2:
+- T006 (export `toSession`) and T007 (export `toWeekPlan`) are in different files — parallel
+- T008 (`query-client.ts`) and T009 (`render.tsx`) are in different files — parallel (after T006/T007)
+
+Within Phase 3:
+- T010, T011, T012, T013 are independent unit test files — all can run in parallel
+
+---
+
+## Parallel Execution Examples
+
+### Phase 2 — Parallel start:
+```
+Agent A: T006 — Export toSession from sessions.ts
+Agent B: T007 — Export toWeekPlan from weeks.ts
+→ Both done → Agent A: T008 (query-client.ts), Agent B: T009 (render.tsx)
+```
+
+### Phase 3 — Unit tests (all parallel):
+```
+Agent A: T010 — date.test.ts
+Agent B: T011 — week-view.test.ts
+Agent C: T012 — sessions-mapper.test.ts
+Agent D: T013 — weeks-mapper.test.ts
+→ All done → T014 useSessions.test.tsx → T015 useWeekPlan.test.tsx → ... (sequential, each builds on prior)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 only — after Phases 1–3)
+
+1. Phase 1: Install deps, create vitest.config.ts, setup.ts, scripts
+2. Phase 2: Export mappers, create test utilities
+3. Phase 3: Write unit + integration tests, verify coverage
+4. **STOP**: `pnpm test:run` is green — CI is now possible, refactor can begin safely
+
+### Full Delivery (sequential)
+
+```
+Phases 1–2 → Foundation ready
+Phase 3    → Tests passing → merge or gate
+Phase 4    → Refactor complete, no regressions
+Phase 5    → Locale routing working
+Phase 6    → Changelog automation live
+Phase 7    → Polish + final QA
+```
+
+---
+
+## Task Summary
+
+| Phase | Story | Tasks | Parallelizable |
+|-------|-------|-------|---------------|
+| Phase 1: Setup | — | 5 | T001, T002 |
+| Phase 2: Foundational | — | 4 | T006+T007, T008+T009 |
+| Phase 3: Tests | US1 | 10 | T010–T013 |
+| Phase 4: Refactor | US2 | 7 | — |
+| Phase 5: Locale | US3 | 8 | — |
+| Phase 6: Changelog | US4 | 5 | — |
+| Phase 7: Polish | — | 4 | T040+T041 |
+| **Total** | | **43** | |
+
+**MVP scope**: Phases 1–3 (19 tasks) — test suite running in CI.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
   ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["node", "vite/client"],
+    "types": ["node", "vite/client", "vitest/globals"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tsconfigPaths(),
+    // Do NOT include tailwindcss() — no-op in jsdom, can cause transform errors
+    // Do NOT include reactRouter() — breaks Vitest module resolution
+  ],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./app/test/setup.ts'],
+    onConsoleLog(log) {
+      if (log.includes('i18next is maintained')) return false;
+    },
+    include: ['app/test/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      // Spec SC-002: coverage applies to non-UI, non-generated source files only
+      include: ['app/lib/**'],
+      exclude: [
+        'app/test/**',
+        // Context providers — tested via vi.mock, not direct instantiation
+        'app/lib/context/**',
+        // Auth helpers — mock-mode only infrastructure
+        'app/lib/auth.ts',
+        // Real Supabase query functions — require live credentials (FR-010 explicitly prohibits this)
+        // The mapper functions (toSession, toWeekPlan) are unit-tested separately
+        'app/lib/queries/sessions.ts',
+        'app/lib/queries/weeks.ts',
+        // Out of scope for P1 test story (profile + strava)
+        'app/lib/queries/profile.ts',
+        'app/lib/queries/strava-connection.ts',
+        'app/lib/hooks/useProfile.ts',
+        'app/lib/hooks/useStravaConnection.ts',
+        // Pure config declaration — no executable statements to cover
+        'app/lib/utils/training-types.ts',
+      ],
+      thresholds: {
+        lines: 60,
+        functions: 60,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- **Vitest test suite** — 61 tests (9 files): unit tests for date utils, week-view computation, and row mappers; integration tests for hooks (useWeekPlan, useSessions), login flow, and coach/athlete week views; coverage gated at 60% lines/functions
- **Mock-data refactor** — split monolithic `mock-data.ts` into `mock-data/` directory with shared seed state (`_shared.ts`) and domain-specific CRUD modules (`sessions.ts`, `weeks.ts`)
- **SessionForm extraction** — pulled all form field JSX into `SessionFormFields.tsx`, reducing `SessionForm.tsx` from ~300 to ~165 lines
- **URL-based locale routing** — `/:locale/*` wraps all authenticated routes; `LocaleLayout` syncs i18n on param change; Polish as default language; `useLocalePath()` hook for locale-aware navigation; login stays at `/login`
- **Changelog automation** — `release-it` + `@release-it/conventional-changelog`; `CHANGELOG.md` with 0.1.0 baseline; GitHub Actions `release.yml` workflow (test → release)
- **Noise suppression** — i18next promotional log filtered via Vitest `onConsoleLog` config hook

## Test plan

- [x] `pnpm test:run` — 61/61 tests pass, no i18next promo log in output
- [x] `pnpm typecheck` — no type errors
- [x] Manual: navigate to `/` → redirects to `/pl/coach` or `/pl/athlete`
- [x] Manual: language toggle switches between `/pl/...` and `/en/...` URLs
- [x] Manual: unsupported locale in URL (e.g. `/de/coach`) redirects to `/pl/coach`

🤖 Generated with [Claude Code](https://claude.com/claude-code)