### PR TITLE
feat: landing page with registration flow and unified nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,6 +426,8 @@ When writing new migrations, place in `supabase/migrations/` with prefix `00N_`.
 - Supabase PostgreSQL — new `invites` table; no schema changes to existing tables (006-coach-athlete-invite)
 - TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui, i18nex (007-athlete-planning)
 - PostgreSQL via Supabase — one new column `profiles.can_self_plan boolean DEFAULT false` (007-athlete-planning)
+- TypeScript 5 (strict) + React 19 + React Router 7, TanStack Query 5, Supabase JS 2, shadcn/ui, i18next, Zod 4 (008-landing-page)
+- Supabase PostgreSQL — new `feedback_submissions` table (migration 014); no changes to existing tables (008-landing-page)
 
 ## Recent Changes
 - 001-sheets-data-migration: Added TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, Zod 4, date-fns 4, papaparse (devDependency — migration script only)

--- a/app/components/landing/ContactSection.tsx
+++ b/app/components/landing/ContactSection.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { CheckCircle2 } from 'lucide-react'
+import { useAuth } from '~/lib/context/AuthContext'
+import { useSubmitFeedback } from '~/lib/hooks/useFeedback'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { cn } from '~/lib/utils'
+
+interface ContactSectionProps {
+  className?: string
+}
+
+export function ContactSection({ className }: ContactSectionProps) {
+  const { t } = useTranslation('landing')
+  const { user } = useAuth()
+  const { mutate, status } = useSubmitFeedback()
+
+  const [name, setName] = useState(user?.name ?? '')
+  const [email, setEmail] = useState(user?.email ?? '')
+  const [message, setMessage] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+
+  const isSuccess = status === 'success'
+  const isError = status === 'error'
+  const isPending = status === 'pending'
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (honeypot) return
+
+    mutate(
+      { name: name.trim(), email: email.trim(), message: message.trim(), userId: user?.id ?? null },
+      {
+        onSuccess: () => {
+          setName(user?.name ?? '')
+          setEmail(user?.email ?? '')
+          setMessage('')
+        },
+      }
+    )
+  }
+
+  return (
+    <section id="contact" className={cn('bg-muted/40 px-4 py-24', className)}>
+      <div className="mx-auto max-w-md">
+        <div className="mb-8 text-center">
+          <h2 className="text-3xl font-bold tracking-tight">{t('contact.title')}</h2>
+          <p className="mt-2 text-muted-foreground">{t('contact.subtitle')}</p>
+          <p className="mt-1 text-sm font-medium text-primary">{t('contact.betaNote')}</p>
+        </div>
+
+        {isSuccess ? (
+          <div className="flex flex-col items-center gap-3 rounded-xl border bg-background p-8 text-center shadow-sm">
+            <CheckCircle2 className="h-10 w-10 text-primary" />
+            <p className="font-medium">{t('contact.submitSuccess')}</p>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-4 rounded-xl border bg-background p-8 shadow-sm"
+          >
+            <div className="space-y-1">
+              <label htmlFor="contact-name" className="text-sm font-medium">
+                {t('contact.name')}
+              </label>
+              <Input
+                id="contact-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="name"
+                required
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="contact-email" className="text-sm font-medium">
+                {t('contact.email')}
+              </label>
+              <Input
+                id="contact-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="contact-message" className="text-sm font-medium">
+                {t('contact.message')}
+              </label>
+              <textarea
+                id="contact-message"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder={t('contact.messagePlaceholder')}
+                required
+                rows={5}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </div>
+
+            {/* Honeypot */}
+            <input
+              name="website"
+              tabIndex={-1}
+              aria-hidden="true"
+              className="sr-only"
+              value={honeypot}
+              onChange={(e) => setHoneypot(e.target.value)}
+            />
+
+            {isError && (
+              <p className="text-sm text-destructive">{t('contact.submitError')}</p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? '…' : t('contact.submit')}
+            </Button>
+          </form>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/components/landing/FeaturesSection.tsx
+++ b/app/components/landing/FeaturesSection.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+import { CheckCircle2 } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+interface FeaturesSectionProps {
+  className?: string
+}
+
+export function FeaturesSection({ className }: FeaturesSectionProps) {
+  const { t } = useTranslation('landing')
+
+  const items = ([1, 2, 3, 4, 5] as const).map((n) => ({
+    n,
+    title: t(`features.item${n}.title` as never),
+    desc: t(`features.item${n}.desc` as never),
+  }))
+
+  return (
+    <section id="features" className={cn('px-4 py-24', className)}>
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-12 text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            {t('features.title')}
+          </h2>
+          <p className="mt-3 text-lg text-muted-foreground">
+            {t('features.subtitle')}
+          </p>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map(({ n, title, desc }) => (
+            <div key={n} className="flex gap-4">
+              <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+              <div>
+                <h3 className="font-semibold">{title}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/components/landing/HeroSection.tsx
+++ b/app/components/landing/HeroSection.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import { cn } from '~/lib/utils'
+import { Button } from '~/components/ui/button'
+
+interface HeroSectionProps {
+  className?: string
+}
+
+export function HeroSection({ className }: HeroSectionProps) {
+  const { t } = useTranslation('landing')
+
+  function scrollTo(id: string) {
+    document.querySelector(id)?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  return (
+    <section
+      id="get-started"
+      className={cn(
+        'flex min-h-screen flex-col items-center justify-center px-4 pt-14 text-center',
+        className
+      )}
+    >
+      <div className="mx-auto max-w-3xl space-y-6">
+        {/* Beta badge */}
+        <span className="inline-block rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+          {t('hero.badge')}
+        </span>
+
+        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+          {t('hero.headline')}
+        </h1>
+
+        <p className="mx-auto max-w-2xl text-lg text-muted-foreground sm:text-xl">
+          {t('hero.subheadline')}
+        </p>
+
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+          <Button size="lg" onClick={() => scrollTo('#join-beta')}>
+            {t('hero.ctaJoinBeta')}
+          </Button>
+          <button
+            onClick={() => scrollTo('#log-in')}
+            className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+          >
+            {t('hero.ctaLogIn')}
+          </button>
+        </div>
+
+        <p className="text-sm text-muted-foreground">{t('hero.betaNote')}</p>
+      </div>
+    </section>
+  )
+}

--- a/app/components/landing/JoinBetaSection.tsx
+++ b/app/components/landing/JoinBetaSection.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router'
+import { Button } from '~/components/ui/button'
+import { cn } from '~/lib/utils'
+
+interface JoinBetaSectionProps {
+  className?: string
+}
+
+export function JoinBetaSection({ className }: JoinBetaSectionProps) {
+  const { t } = useTranslation('landing')
+
+  return (
+    <section id="join-beta" className={cn('bg-muted/40 px-4 py-24', className)}>
+      <div className="mx-auto max-w-md text-center">
+        <span className="mb-3 inline-block rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+          {t('beta.badge')}
+        </span>
+        <h2 className="text-3xl font-bold tracking-tight">{t('beta.title')}</h2>
+        <p className="mt-2 text-muted-foreground">{t('beta.subtitle')}</p>
+        <div className="mt-8">
+          <Button asChild size="lg">
+            <Link to="/register">{t('beta.cta')}</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/components/landing/LandingNav.tsx
+++ b/app/components/landing/LandingNav.tsx
@@ -1,0 +1,134 @@
+import { useTranslation } from 'react-i18next'
+import { Activity } from 'lucide-react'
+import { Link, useLocation } from 'react-router'
+import { cn } from '~/lib/utils'
+import { ThemeToggle } from '~/components/layout/ThemeToggle'
+import { LanguageToggle } from '~/components/layout/LanguageToggle'
+
+type AnchorLink = { key: string; href: string; route?: never }
+type RouteLink = { key: string; route: string; href?: never }
+type NavLink = AnchorLink | RouteLink
+
+const NAV_LINKS: NavLink[] = [
+  { key: 'getStarted', href: '#get-started' },
+  { key: 'whySynek', href: '#why-synek' },
+  { key: 'features', href: '#features' },
+  { key: 'logIn', route: '/login' },
+  { key: 'joinBeta', route: '/register' },
+  { key: 'contact', href: '#contact' },
+]
+
+interface LandingNavProps {
+  className?: string
+}
+
+export function LandingNav({ className }: LandingNavProps) {
+  const { t } = useTranslation('landing')
+  const { pathname } = useLocation()
+  const isLanding = pathname === '/'
+
+  function handleNavClick(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
+    e.preventDefault()
+    const el = document.querySelector(href)
+    el?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  function resolveHref(href: string): string {
+    return isLanding ? href : `/${href}`
+  }
+
+  return (
+    <header
+      className={cn(
+        'fixed top-0 inset-x-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60',
+        className
+      )}
+    >
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        {/* Logo */}
+        <div className="flex items-center gap-2 font-bold">
+          <Activity className="h-5 w-5 text-primary" />
+          <span>Synek</span>
+        </div>
+
+        {/* Desktop nav + controls */}
+        <div className="hidden items-center gap-6 md:flex">
+          <nav className="flex items-center gap-6">
+            {NAV_LINKS.map((link) =>
+              link.route ? (
+                <Link
+                  key={link.key}
+                  to={link.route}
+                  className={cn(
+                    'text-sm font-medium text-muted-foreground transition-colors hover:text-foreground',
+                    link.key === 'joinBeta' &&
+                      'rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
+                  )}
+                >
+                  {t(`nav.${link.key}` as never)}
+                </Link>
+              ) : isLanding ? (
+                <a
+                  key={link.key}
+                  href={link.href}
+                  onClick={(e) => handleNavClick(e, link.href!)}
+                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {t(`nav.${link.key}` as never)}
+                </a>
+              ) : (
+                <Link
+                  key={link.key}
+                  to={resolveHref(link.href!)}
+                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {t(`nav.${link.key}` as never)}
+                </Link>
+              )
+            )}
+          </nav>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <LanguageToggle />
+          </div>
+        </div>
+
+        {/* Mobile: toggles right, nav scrolls left */}
+        <div className="flex items-center gap-2 md:hidden">
+          <nav className="flex items-center gap-4 overflow-x-auto">
+            {NAV_LINKS.map((link) =>
+              link.route ? (
+                <Link
+                  key={link.key}
+                  to={link.route}
+                  className="whitespace-nowrap text-sm font-medium text-muted-foreground hover:text-foreground"
+                >
+                  {t(`nav.${link.key}` as never)}
+                </Link>
+              ) : isLanding ? (
+                <a
+                  key={link.key}
+                  href={link.href}
+                  onClick={(e) => handleNavClick(e, link.href!)}
+                  className="whitespace-nowrap text-sm font-medium text-muted-foreground hover:text-foreground"
+                >
+                  {t(`nav.${link.key}` as never)}
+                </a>
+              ) : (
+                <Link
+                  key={link.key}
+                  to={resolveHref(link.href!)}
+                  className="whitespace-nowrap text-sm font-medium text-muted-foreground hover:text-foreground"
+                >
+                  {t(`nav.${link.key}` as never)}
+                </Link>
+              )
+            )}
+          </nav>
+          <ThemeToggle />
+          <LanguageToggle />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/app/components/landing/WhySynekSection.tsx
+++ b/app/components/landing/WhySynekSection.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+import { Calendar, Eye, User, MessageSquare } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+const CARD_ICONS = [Calendar, Eye, User, MessageSquare]
+
+interface WhySynekSectionProps {
+  className?: string
+}
+
+export function WhySynekSection({ className }: WhySynekSectionProps) {
+  const { t } = useTranslation('landing')
+
+  const cards = ([1, 2, 3, 4] as const).map((n) => ({
+    n,
+    Icon: CARD_ICONS[n - 1],
+    title: t(`whySynek.card${n}.title` as never),
+    desc: t(`whySynek.card${n}.desc` as never),
+  }))
+
+  return (
+    <section
+      id="why-synek"
+      className={cn('bg-muted/40 px-4 py-24', className)}
+    >
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-12 text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            {t('whySynek.title')}
+          </h2>
+          <p className="mt-3 text-lg text-muted-foreground">
+            {t('whySynek.subtitle')}
+          </p>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {cards.map(({ n, Icon, title, desc }) => (
+            <div
+              key={n}
+              className="rounded-xl border bg-background p-6 shadow-sm"
+            >
+              <Icon className="mb-4 h-8 w-8 text-primary" />
+              <h3 className="mb-2 font-semibold">{title}</h3>
+              <p className="text-sm text-muted-foreground">{desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Activity } from 'lucide-react';
+import { Link, useParams } from 'react-router';
 import { LanguageToggle } from './LanguageToggle';
 import { ThemeToggle } from './ThemeToggle';
 import { UserMenu } from './UserMenu';
@@ -8,14 +9,17 @@ import { useAuth } from '~/lib/context/AuthContext';
 export function Header() {
   const { t } = useTranslation();
   const { user } = useAuth();
+  const { locale } = useParams<{ locale?: string }>();
+  const resolvedLocale = locale ?? localStorage.getItem('locale') ?? 'pl';
+  const logoHref = user ? `/${resolvedLocale}/${user.role}` : '/';
 
   return (
     <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
-        <div className="flex items-center gap-2">
+        <Link to={logoHref} className="flex items-center gap-2">
           <Activity className="h-5 w-5 text-primary" />
           <span className="font-semibold">{t('appName')}</span>
-        </div>
+        </Link>
         <div className="flex items-center gap-2">
           {user && <UserMenu />}
           <ThemeToggle />

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -5,10 +5,12 @@ import enCommon from './resources/en/common.json';
 import enCoach from './resources/en/coach.json';
 import enAthlete from './resources/en/athlete.json';
 import enTraining from './resources/en/training.json';
+import enLanding from './resources/en/landing.json';
 import plCommon from './resources/pl/common.json';
 import plCoach from './resources/pl/coach.json';
 import plAthlete from './resources/pl/athlete.json';
 import plTraining from './resources/pl/training.json';
+import plLanding from './resources/pl/landing.json';
 
 const resources = {
   en: {
@@ -16,12 +18,14 @@ const resources = {
     coach: enCoach,
     athlete: enAthlete,
     training: enTraining,
+    landing: enLanding,
   },
   pl: {
     common: plCommon,
     coach: plCoach,
     athlete: plAthlete,
     training: plTraining,
+    landing: plLanding,
   },
 };
 
@@ -30,7 +34,7 @@ i18n.use(initReactI18next).init({
   lng: 'pl',
   fallbackLng: 'en',
   defaultNS: 'common',
-  ns: ['common', 'coach', 'athlete', 'training'],
+  ns: ['common', 'coach', 'athlete', 'training', 'landing'],
   interpolation: {
     escapeValue: false,
   },

--- a/app/i18n/i18next.d.ts
+++ b/app/i18n/i18next.d.ts
@@ -3,6 +3,7 @@ import type common from './resources/en/common.json';
 import type coach from './resources/en/coach.json';
 import type athlete from './resources/en/athlete.json';
 import type training from './resources/en/training.json';
+import type landing from './resources/en/landing.json';
 
 declare module 'i18next' {
   interface CustomTypeOptions {
@@ -12,6 +13,7 @@ declare module 'i18next' {
       coach: typeof coach;
       athlete: typeof athlete;
       training: typeof training;
+      landing: typeof landing;
     };
   }
 }

--- a/app/i18n/resources/en/landing.json
+++ b/app/i18n/resources/en/landing.json
@@ -1,0 +1,103 @@
+{
+  "nav": {
+    "getStarted": "Get Started",
+    "whySynek": "Why Synek",
+    "features": "Features",
+    "logIn": "Log In",
+    "joinBeta": "Join Beta",
+    "contact": "Contact"
+  },
+  "hero": {
+    "badge": "Public Beta — Free Account",
+    "headline": "Effortless training management for coaches and athletes",
+    "subheadline": "The Synek app gives coaches a structured way to plan weekly training, and athletes can easily track and update their progress.",
+    "ctaJoinBeta": "Join the Beta — It's Free",
+    "ctaLogIn": "Already have an account?",
+    "betaNote": "We're in beta and your feedback shapes what we build next."
+  },
+  "whySynek": {
+    "title": "Why synek.app?",
+    "subtitle": "Simple and intuitive. Built from real collaboration between coaches and athletes.",
+    "card1": {
+      "title": "Structured weekly planning",
+      "desc": "Plan each week as a whole — load, type, and daily sessions — not just a list of workouts."
+    },
+    "card2": {
+      "title": "Full coach visibility",
+      "desc": "Coaches see what athletes complete, how they feel, and where the plan needs adjusting."
+    },
+    "card3": {
+      "title": "Athlete autonomy",
+      "desc": "Athletes can self-plan and log notes on every session."
+    },
+    "card4": {
+      "title": "Beta built by users",
+      "desc": "We're actively building with early users. Your feedback directly drives what we add next."
+    }
+  },
+  "features": {
+    "title": "What's inside",
+    "subtitle": "Everything you need to run a structured training programme — nothing you don't.",
+    "item1": {
+      "title": "Weekly training planning",
+      "desc": "Plans are organised by training week. Add sessions by day, set load, and leave coaching notes."
+    },
+    "item2": {
+      "title": "Sport-specific sessions",
+      "desc": "Run, cycling, strength, yoga, swimming, mobility, and rest — each with relevant fields."
+    },
+    "item3": {
+      "title": "Coach & athlete roles",
+      "desc": "Coaches manage multiple athletes. Each athlete sees only their own plan."
+    },
+    "item4": {
+      "title": "Self-planning mode",
+      "desc": "Coaches can enable athletes to plan their own weeks — useful for experienced athletes."
+    },
+    "item5": {
+      "title": "Strava sync",
+      "desc": "Connect Strava to pull completed activities directly into your training log."
+    }
+  },
+  "login": {
+    "title": "Log in to Synek",
+    "subtitle": "Pick up where you left off.",
+    "email": "Email",
+    "password": "Password",
+    "submit": "Log In",
+    "forgotPassword": "Forgot password?",
+    "noAccount": "New here?",
+    "noAccountCta": "Join the beta →"
+  },
+  "beta": {
+    "title": "Join the Beta",
+    "subtitle": "Free access during beta. No credit card. No expiry.",
+    "badge": "Beta — Free",
+    "betaNote": "You're joining during our public beta. That means free access and a direct line to the team — we read every piece of feedback.",
+    "roleLabel": "I am a...",
+    "roleCoach": "Coach",
+    "roleAthlete": "Athlete",
+    "name": "Full name",
+    "email": "Email",
+    "password": "Password",
+    "passwordHint": "At least 8 characters, one uppercase, one number",
+    "submit": "Create free account",
+    "selectRole": "Please select Coach or Athlete before continuing",
+    "emailAlreadyRegistered": "This email is already registered. Try logging in instead.",
+    "alreadyHaveAccount": "Already have an account?",
+    "alreadyHaveAccountCta": "Log in →",
+    "cta": "Join the beta"
+  },
+  "contact": {
+    "title": "Get in touch",
+    "subtitle": "Got feedback, a question, or an idea? We're a small team and we read everything.",
+    "betaNote": "This is the fastest way to shape what we build next.",
+    "name": "Your name",
+    "email": "Your email",
+    "message": "Your message",
+    "messagePlaceholder": "Tell us what you think, what's missing, or what could be better...",
+    "submit": "Send message",
+    "submitSuccess": "Message sent — thank you! We'll get back to you soon.",
+    "submitError": "Something went wrong. Please try again in a moment."
+  }
+}

--- a/app/i18n/resources/pl/landing.json
+++ b/app/i18n/resources/pl/landing.json
@@ -1,0 +1,103 @@
+{
+  "nav": {
+    "getStarted": "Zacznij",
+    "whySynek": "Dlaczego Synek",
+    "features": "Funkcje",
+    "logIn": "Zaloguj się",
+    "joinBeta": "Dołącz do Bety",
+    "contact": "Kontakt"
+  },
+  "hero": {
+    "badge": "Publiczna Beta - Bezpłatne Konto",
+    "headline": "Wygodne prowadzenie treningów dla trenerów i zawodników",
+    "subheadline": "Aplikacja Synek daje trenerom ustrukturyzowany sposób planowania tygodniowych treningów, a zawodnicy mogą z łatwością aktualizować swoje postępy.",
+    "ctaJoinBeta": "Dołącz do Bety — To Bezpłatne",
+    "ctaLogIn": "Masz już konto?",
+    "betaNote": "Jesteśmy w fazie beta i Twoje opinie kształtują to, co budujemy."
+  },
+  "whySynek": {
+    "title": "Dlaczego synek.app?",
+    "subtitle": "Prosty i intuicyjny. Zbudowany na podstawie współpracy trenerów i zawodników.",
+    "card1": {
+      "title": "Ustrukturyzowane planowanie tygodniowe",
+      "desc": "Planuj każdy tydzień jako całość — obciążenie, typ i dzienne sesje — nie tylko listę treningów."
+    },
+    "card2": {
+      "title": "Pełna widoczność trenera",
+      "desc": "Trenerzy widzą co zawodnicy wykonują, jak się czują i gdzie plan wymaga korekty."
+    },
+    "card3": {
+      "title": "Autonomia zawodnika",
+      "desc": "Zawodnicy mogą samodzielnie planować i dodawać notatki do każdej sesji."
+    },
+    "card4": {
+      "title": "Beta budowana przez użytkowników",
+      "desc": "Aktywnie budujemy z wczesnymi użytkownikami. Twoje opinie bezpośrednio wpływają na to, co dodajemy."
+    }
+  },
+  "features": {
+    "title": "Co znajdziesz w środku",
+    "subtitle": "Wszystko czego potrzebujesz do prowadzenia ustrukturyzowanego programu treningowego — nic więcej.",
+    "item1": {
+      "title": "Planowanie treningów tygodniowo",
+      "desc": "Plany są zorganizowane wg tygodnia treningowego. Dodawaj sesje według dnia, ustaw obciążenie i zostaw notatki."
+    },
+    "item2": {
+      "title": "Sesje specyficzne dla sportu",
+      "desc": "Bieg, kolarstwo, siłownia, joga, pływanie, mobilność i odpoczynek — każde z odpowiednimi polami."
+    },
+    "item3": {
+      "title": "Role trenera i zawodnika",
+      "desc": "Trenerzy zarządzają wieloma zawodnikami. Każdy zawodnik widzi tylko swój plan."
+    },
+    "item4": {
+      "title": "Tryb samodzielnego planowania",
+      "desc": "Trenerzy mogą umożliwić zawodnikom planowanie własnych tygodni — przydatne dla doświadczonych."
+    },
+    "item5": {
+      "title": "Synchronizacja ze Stravą",
+      "desc": "Połącz Stravę, aby pobierać ukończone aktywności bezpośrednio do dziennika treningowego."
+    }
+  },
+  "login": {
+    "title": "Zaloguj się do Synek",
+    "subtitle": "Wróć tam, gdzie skończyłeś.",
+    "email": "E-mail",
+    "password": "Hasło",
+    "submit": "Zaloguj się",
+    "forgotPassword": "Nie pamiętasz hasła?",
+    "noAccount": "Nowy tutaj?",
+    "noAccountCta": "Dołącz do bety →"
+  },
+  "beta": {
+    "title": "Dołącz do Bety",
+    "subtitle": "Bezpłatny dostęp przez cały czas trwania bety. Bez karty. Bez wygaśnięcia.",
+    "badge": "Beta — Bezpłatna",
+    "betaNote": "Dołączasz w trakcie publicznej bety. Oznacza to bezpłatny dostęp i bezpośredni kontakt z zespołem — czytamy każdą opinię.",
+    "roleLabel": "Jestem...",
+    "roleCoach": "Trenerem",
+    "roleAthlete": "Zawodnikiem",
+    "name": "Imię i nazwisko",
+    "email": "E-mail",
+    "password": "Hasło",
+    "passwordHint": "Co najmniej 8 znaków, jedna wielka litera, jedna cyfra",
+    "submit": "Utwórz bezpłatne konto",
+    "selectRole": "Wybierz Trener lub Zawodnik przed kontynuowaniem",
+    "emailAlreadyRegistered": "Ten e-mail jest już zarejestrowany. Spróbuj się zalogować.",
+    "alreadyHaveAccount": "Masz już konto?",
+    "alreadyHaveAccountCta": "Zaloguj się →",
+    "cta": "Dołącz do bety"
+  },
+  "contact": {
+    "title": "Skontaktuj się",
+    "subtitle": "Masz opinię, pytanie lub pomysł? Jesteśmy małym zespołem i czytamy wszystko.",
+    "betaNote": "To najszybszy sposób na wpłynięcie na to, co budujemy.",
+    "name": "Twoje imię",
+    "email": "Twój e-mail",
+    "message": "Twoja wiadomość",
+    "messagePlaceholder": "Powiedz nam co myślisz, czego brakuje lub co można poprawić...",
+    "submit": "Wyślij wiadomość",
+    "submitSuccess": "Wiadomość wysłana — dziękujemy! Odpiszemy wkrótce.",
+    "submitError": "Coś poszło nie tak. Spróbuj ponownie za chwilę."
+  }
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -70,11 +70,20 @@ export function mockRegisterCoach(
   _password: string,
   name: string
 ): AuthUser {
+  return mockRegisterUser(email, _password, name, 'coach');
+}
+
+export function mockRegisterUser(
+  email: string,
+  _password: string,
+  name: string,
+  role: UserRole
+): AuthUser {
   const newUser: AuthUser & { password: string } = {
     id: crypto.randomUUID(),
     email,
     password: _password,
-    role: 'coach',
+    role,
     name,
     avatarUrl: null,
   };

--- a/app/lib/hooks/useFeedback.ts
+++ b/app/lib/hooks/useFeedback.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '~/lib/queries/keys'
+import { createFeedback } from '~/lib/queries/feedback'
+
+export function useSubmitFeedback() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: createFeedback,
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.feedback.all })
+    },
+  })
+}

--- a/app/lib/mock-data/feedback.ts
+++ b/app/lib/mock-data/feedback.ts
@@ -1,0 +1,15 @@
+import type { FeedbackSubmission } from '~/types/feedback'
+
+let MOCK_FEEDBACK: FeedbackSubmission[] = []
+
+export function getMockFeedback(): FeedbackSubmission[] {
+  return MOCK_FEEDBACK
+}
+
+export function addMockFeedback(submission: FeedbackSubmission): void {
+  MOCK_FEEDBACK.push(submission)
+}
+
+export function resetMockFeedback(): void {
+  MOCK_FEEDBACK = []
+}

--- a/app/lib/mock-data/index.ts
+++ b/app/lib/mock-data/index.ts
@@ -1,3 +1,4 @@
 export * from './weeks';
 export * from './sessions';
 export * from './invites';
+export * from './feedback';

--- a/app/lib/queries/feedback.ts
+++ b/app/lib/queries/feedback.ts
@@ -1,0 +1,45 @@
+import { supabase, isMockMode } from '~/lib/supabase'
+import { addMockFeedback } from '~/lib/mock-data/feedback'
+import type { FeedbackSubmission, CreateFeedbackInput } from '~/types/feedback'
+
+function toFeedbackSubmission(row: Record<string, unknown>): FeedbackSubmission {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    email: row.email as string,
+    message: row.message as string,
+    userId: (row.user_id as string) ?? null,
+    createdAt: row.created_at as string,
+  }
+}
+
+export async function createFeedback(
+  input: CreateFeedbackInput
+): Promise<FeedbackSubmission> {
+  if (isMockMode) {
+    const submission: FeedbackSubmission = {
+      id: crypto.randomUUID(),
+      name: input.name,
+      email: input.email,
+      message: input.message,
+      userId: input.userId ?? null,
+      createdAt: new Date().toISOString(),
+    }
+    addMockFeedback(submission)
+    return submission
+  }
+
+  const { data, error } = await supabase
+    .from('feedback_submissions')
+    .insert({
+      name: input.name,
+      email: input.email,
+      message: input.message,
+      user_id: input.userId ?? null,
+    })
+    .select('id, name, email, message, user_id, created_at')
+    .single()
+
+  if (error) throw error
+  return toFeedbackSubmission(data as Record<string, unknown>)
+}

--- a/app/lib/queries/keys.ts
+++ b/app/lib/queries/keys.ts
@@ -25,4 +25,7 @@ export const queryKeys = {
   selfPlan: {
     byAthlete: (athleteId: string) => ['selfPlan', athleteId] as const,
   },
+  feedback: {
+    all: ['feedback'] as const,
+  },
 };

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,7 +9,6 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '~/components/ui/tooltip';
 import { Toaster } from '~/components/ui/sonner';
-import { Header } from '~/components/layout/Header';
 import { AuthProvider } from '~/lib/context/AuthContext';
 import { ThemeProvider } from '~/lib/context/ThemeContext';
 
@@ -72,12 +71,7 @@ export default function App() {
       <ThemeProvider>
       <AuthProvider>
         <TooltipProvider>
-          <div className="min-h-screen bg-background">
-            <Header />
-            <main className="container mx-auto px-4 py-6">
-              <Outlet />
-            </main>
-          </div>
+          <Outlet />
           <Toaster position="bottom-right" richColors />
         </TooltipProvider>
       </AuthProvider>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -7,11 +7,14 @@ import {
 } from '@react-router/dev/routes';
 
 export default [
-  // Bare / redirects to /${locale} using stored preference
-  index('routes/root-redirect.tsx'),
+  // Public landing page — no auth required
+  index('routes/landing.tsx'),
 
   // Login is public and outside the locale wrapper
   route('login', 'routes/login.tsx'),
+
+  // Register is public and outside the locale wrapper
+  route('register', 'routes/register.tsx'),
 
   // Invite landing page — public, no locale prefix
   route('invite/:token', 'routes/invite.$token.tsx'),

--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router'
+import { useAuth } from '~/lib/context/AuthContext'
+import { LandingNav } from '~/components/landing/LandingNav'
+import { HeroSection } from '~/components/landing/HeroSection'
+import { WhySynekSection } from '~/components/landing/WhySynekSection'
+import { FeaturesSection } from '~/components/landing/FeaturesSection'
+import { JoinBetaSection } from '~/components/landing/JoinBetaSection'
+import { ContactSection } from '~/components/landing/ContactSection'
+
+export function meta() {
+  return [
+    { title: 'Synek — Training planning for coaches and athletes' },
+    { name: 'description', content: 'Synek gives coaches a structured way to plan weekly training and gives athletes full visibility into what\'s ahead. Free during public beta.' },
+  ]
+}
+
+export default function LandingPage() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (user) {
+      const locale = localStorage.getItem('locale') ?? 'pl'
+      navigate(`/${locale}/${user.role}`, { replace: true })
+    }
+  }, [user, navigate])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <LandingNav />
+      <main>
+        <HeroSection />
+        <WhySynekSection />
+        <FeaturesSection />
+        <JoinBetaSection />
+        <ContactSection />
+      </main>
+    </div>
+  )
+}

--- a/app/routes/locale-layout.tsx
+++ b/app/routes/locale-layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Navigate, Outlet, useLocation, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { Header } from '~/components/layout/Header';
 
 const SUPPORTED_LOCALES = ['pl', 'en'] as const;
 type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
@@ -27,5 +28,12 @@ export default function LocaleLayout() {
     return <Navigate to={`/pl${pathAfterLocale}`} replace />;
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto px-4 py-6">
+        <Outlet />
+      </main>
+    </>
+  );
 }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router';
+import { LandingNav } from '~/components/landing/LandingNav';
 import { Activity, Eye, EyeOff } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
 import { z } from 'zod';
@@ -118,7 +119,9 @@ export default function LoginPage() {
   const privacyNoticeUrl = import.meta.env.VITE_PRIVACY_NOTICE_URL ?? '/privacy';
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+    <div className="min-h-screen bg-background">
+      <LandingNav />
+      <main className="flex min-h-screen items-center justify-center px-4 pt-14">
       <div className="w-full max-w-sm space-y-8">
         {/* Logo */}
         <div className="flex flex-col items-center gap-2">
@@ -329,6 +332,7 @@ export default function LoginPage() {
           </div>
         )}
       </div>
+      </main>
     </div>
   );
 }

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,0 +1,254 @@
+import { useState } from 'react'
+import { useNavigate, Link } from 'react-router'
+import { Eye, EyeOff } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+import { useAuth } from '~/lib/context/AuthContext'
+import { supabase, isMockMode } from '~/lib/supabase'
+import { mockRegisterUser, mockLogin } from '~/lib/auth'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { cn } from '~/lib/utils'
+import { LandingNav } from '~/components/landing/LandingNav'
+import type { UserRole } from '~/lib/auth'
+
+export function meta() {
+  return [{ title: 'Register — Synek' }]
+}
+
+const registerSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email'),
+  password: z
+    .string()
+    .min(8, 'Min 8 characters')
+    .regex(/[A-Z]/, 'Must contain uppercase')
+    .regex(/[0-9]/, 'Must contain a number'),
+})
+
+export default function RegisterPage() {
+  const { t } = useTranslation('landing')
+  const { login } = useAuth()
+  const navigate = useNavigate()
+
+  const [role, setRole] = useState<UserRole | null>(null)
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const [isPending, setIsPending] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (honeypot) return
+
+    if (!role) {
+      setError(t('beta.selectRole'))
+      return
+    }
+
+    const result = registerSchema.safeParse({ name: name.trim(), email: email.trim(), password })
+    if (!result.success) {
+      const errs: Record<string, string> = {}
+      for (const issue of result.error.issues) {
+        const field = String(issue.path[0])
+        errs[field] = issue.message
+      }
+      setFieldErrors(errs)
+      return
+    }
+
+    setFieldErrors({})
+    setError(null)
+    setIsPending(true)
+
+    try {
+      if (isMockMode) {
+        const registered = mockRegisterUser(
+          result.data.email,
+          result.data.password,
+          result.data.name,
+          role
+        )
+        await mockLogin(registered.email, result.data.password)
+        await login(registered.email, result.data.password)
+      } else {
+        const res = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/register-user`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+            },
+            body: JSON.stringify({
+              name: result.data.name,
+              email: result.data.email,
+              password: result.data.password,
+              role,
+            }),
+          }
+        )
+        const payload = await res.json() as { success?: boolean; error?: string }
+
+        if (!res.ok) {
+          if (payload.error === 'email_taken') {
+            setFieldErrors({ email: t('beta.emailAlreadyRegistered') })
+            setIsPending(false)
+            return
+          }
+          throw new Error(payload.error ?? 'internal_error')
+        }
+
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email: result.data.email,
+          password: result.data.password,
+        })
+        if (signInError) throw signInError
+      }
+
+      const locale = localStorage.getItem('locale') ?? 'pl'
+      navigate(`/${locale}/${role}`, { replace: true })
+    } catch {
+      setError(t('beta.selectRole'))
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <LandingNav />
+      <main className="flex min-h-screen items-center justify-center px-4 pt-14">
+        <div className="w-full max-w-md space-y-8">
+          <div className="text-center">
+            <span className="mb-3 inline-block rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+              {t('beta.badge')}
+            </span>
+            <h1 className="text-2xl font-bold tracking-tight">{t('beta.title')}</h1>
+            <p className="mt-1 text-sm text-muted-foreground">{t('beta.subtitle')}</p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-5 rounded-xl border bg-background p-8 shadow-sm">
+            {/* Beta note */}
+            <p className="rounded-lg bg-primary/5 p-3 text-sm text-muted-foreground">
+              {t('beta.betaNote')}
+            </p>
+
+            {/* Role picker */}
+            <div className="space-y-2">
+              <p className="text-sm font-medium">{t('beta.roleLabel')}</p>
+              <div className="grid grid-cols-2 gap-2">
+                {(['coach', 'athlete'] as const).map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => setRole(r)}
+                    className={cn(
+                      'rounded-lg border px-4 py-3 text-sm font-medium transition-colors',
+                      role === r
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-border bg-background hover:bg-muted'
+                    )}
+                  >
+                    {t(r === 'coach' ? 'beta.roleCoach' : 'beta.roleAthlete')}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Name */}
+            <div className="space-y-1">
+              <label htmlFor="reg-name" className="text-sm font-medium">
+                {t('beta.name')}
+              </label>
+              <Input
+                id="reg-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="name"
+                required
+              />
+              {fieldErrors.name && (
+                <p className="text-xs text-destructive">{fieldErrors.name}</p>
+              )}
+            </div>
+
+            {/* Email */}
+            <div className="space-y-1">
+              <label htmlFor="reg-email" className="text-sm font-medium">
+                {t('beta.email')}
+              </label>
+              <Input
+                id="reg-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+              />
+              {fieldErrors.email && (
+                <p className="text-xs text-destructive">{fieldErrors.email}</p>
+              )}
+            </div>
+
+            {/* Password */}
+            <div className="space-y-1">
+              <label htmlFor="reg-password" className="text-sm font-medium">
+                {t('beta.password')}
+              </label>
+              <div className="relative">
+                <Input
+                  id="reg-password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+                  tabIndex={-1}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              <p className="text-xs text-muted-foreground">{t('beta.passwordHint')}</p>
+              {fieldErrors.password && (
+                <p className="text-xs text-destructive">{fieldErrors.password}</p>
+              )}
+            </div>
+
+            {/* Honeypot */}
+            <input
+              name="website"
+              tabIndex={-1}
+              aria-hidden="true"
+              className="sr-only"
+              value={honeypot}
+              onChange={(e) => setHoneypot(e.target.value)}
+            />
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <Button type="submit" className="w-full" disabled={isPending || !role}>
+              {isPending ? '…' : t('beta.submit')}
+            </Button>
+
+            <p className="text-center text-sm text-muted-foreground">
+              {t('beta.alreadyHaveAccount')}{' '}
+              <Link to="/login" className="font-medium text-primary hover:underline">
+                {t('beta.alreadyHaveAccountCta')}
+              </Link>
+            </p>
+          </form>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/routes/root-redirect.tsx
+++ b/app/routes/root-redirect.tsx
@@ -1,6 +1,0 @@
-import { Navigate } from 'react-router';
-
-export default function RootRedirect() {
-  const locale = localStorage.getItem('locale') ?? 'pl';
-  return <Navigate to={`/${locale}`} replace />;
-}

--- a/app/types/feedback.ts
+++ b/app/types/feedback.ts
@@ -1,0 +1,15 @@
+export interface FeedbackSubmission {
+  id: string
+  name: string
+  email: string
+  message: string
+  userId: string | null
+  createdAt: string
+}
+
+export interface CreateFeedbackInput {
+  name: string
+  email: string
+  message: string
+  userId?: string | null
+}

--- a/specs/008-landing-page/checklists/requirements.md
+++ b/specs/008-landing-page/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Public Landing Page
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec updated 2026-03-10: "Free Trial" renamed to "Join Beta" to reflect beta status and free accounts; registration now supports both Coach and Athlete roles; beta messaging and feedback encouragement added as explicit requirements.
+
+Spec is ready for `/speckit.plan`.

--- a/specs/008-landing-page/contracts/ui-contracts.md
+++ b/specs/008-landing-page/contracts/ui-contracts.md
@@ -1,0 +1,127 @@
+# UI Contracts: 008-landing-page
+
+The landing page exposes three interactive forms. This document specifies each form's input contract, validation rules, submission behaviour, and success/error states.
+
+---
+
+## Form 1: Login (Log In section)
+
+### Inputs
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| email | text (email) | yes | valid email format |
+| password | password | yes | non-empty |
+
+### Submission
+
+- Calls `useAuth().login(email, password)`
+- On success: redirect to `/${locale}/${user.role}` (locale from localStorage, default `pl`)
+- On error: display error message inline below the form (do NOT clear inputs)
+
+### States
+
+| State | UI |
+|-------|----|
+| Idle | Submit button enabled |
+| Pending | Submit button disabled + loading indicator |
+| Error | Error message below form |
+| Success | Redirect (form unmounts) |
+
+---
+
+## Form 2: Join Beta Registration (Join Beta section)
+
+### Inputs
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| role | radio/toggle ('coach' \| 'athlete') | yes | must be selected |
+| name | text | yes | min 1 character |
+| email | text (email) | yes | valid email format |
+| password | password | yes | min 8 chars, 1 uppercase, 1 number |
+| website (honeypot) | text (hidden, `aria-hidden`, `tabIndex={-1}`) | — | must be empty |
+
+### Submission
+
+- Mock mode: `mockRegisterUser(email, password, name, role)` → `mockLogin()` → `login()`
+- Real mode: POST to `${VITE_SUPABASE_URL}/functions/v1/register-user` with `{ name, email, password, role }`
+  - On HTTP 200: `supabase.auth.signInWithPassword({ email, password })` (session fixation prevention)
+  - On HTTP 4xx with `error: 'email_already_registered'`: show email-field error
+  - On other errors: show generic error (never reveal if email is taken)
+- On success: redirect to `/${locale}/${role}` (locale from localStorage, default `pl`)
+
+### States
+
+| State | UI |
+|-------|----|
+| Idle, no role selected | Submit button disabled |
+| Idle, role selected | Submit button enabled |
+| Pending | Submit button disabled + loading indicator |
+| Email error | Inline error below email field |
+| Generic error | Inline error below submit button |
+| Success | Redirect (form unmounts) |
+
+### Error Messages (i18n keys)
+
+| Condition | Key |
+|-----------|-----|
+| Email already registered | `landing:beta.emailAlreadyRegistered` |
+| Generic/network error | `common:auth.invalidCredentials` |
+| Validation: role missing | `landing:beta.selectRole` |
+
+---
+
+## Form 3: Contact / Feedback (Contact section)
+
+### Inputs
+
+| Field | Type | Required | Prefilled when authed? | Validation |
+|-------|------|----------|------------------------|------------|
+| name | text | yes | yes — from `user.name` | min 1 character |
+| email | text (email) | yes | yes — from `user.email` | valid email format |
+| message | textarea | yes | no | min 1 character |
+| website (honeypot) | text (hidden, `aria-hidden`, `tabIndex={-1}`) | — | no | must be empty |
+
+Prefilled fields remain editable. The `userId` captured from the session is **not shown** to the user — it is sent as part of the mutation payload silently.
+
+### Submission
+
+- Calls `useSubmitFeedback()` mutation from `~/lib/hooks/useFeedback`
+- Payload includes `userId: user?.id ?? null` from auth context
+- Mutation inserts into `feedback_submissions` (or mock store)
+- On success: show inline confirmation message + clear all fields
+- On error: show generic error message below the submit button
+
+### States
+
+| State | UI |
+|-------|----|
+| Idle | Submit button enabled |
+| Pending | Submit button disabled + loading indicator |
+| Success | Confirmation message shown; form cleared |
+| Error | Error message below submit button |
+
+### Error Messages (i18n keys)
+
+| Condition | Key |
+|-----------|-----|
+| Submit failed | `landing:contact.submitError` |
+| Success confirmation | `landing:contact.submitSuccess` |
+
+---
+
+## Navigation Contract
+
+The sticky nav renders anchor links. Each link's `href` is a hash anchor matching the `id` attribute on each section wrapper.
+
+| Nav Label (i18n key) | Target `id` |
+|---------------------|-------------|
+| `landing:nav.getStarted` | `#get-started` |
+| `landing:nav.whySynek` | `#why-synek` |
+| `landing:nav.features` | `#features` |
+| `landing:nav.logIn` | `#log-in` |
+| `landing:nav.joinBeta` | `#join-beta` |
+| `landing:nav.contact` | `#contact` |
+
+Smooth scrolling is achieved via CSS `scroll-behavior: smooth` on `<html>` (already standard in Tailwind reset) or `element.scrollIntoView({ behavior: 'smooth' })` per link click.

--- a/specs/008-landing-page/data-model.md
+++ b/specs/008-landing-page/data-model.md
@@ -1,0 +1,157 @@
+# Data Model: 008-landing-page
+
+**Phase 1 output** | **Date**: 2026-03-10
+
+---
+
+## New Entity: FeedbackSubmission
+
+Represents a message submitted via the Contact section. Submissions are accepted from both anonymous visitors and authenticated users. An optional `userId` FK links the record to a `profiles` row when the submitter is logged in — enabling the team to distinguish high-value internal feedback from pre-signup feedback.
+
+**Admin processing**: feedback is read directly via the Supabase dashboard. No admin UI is built as part of this feature.
+
+### TypeScript Type
+
+```typescript
+// app/types/feedback.ts
+export interface FeedbackSubmission {
+  id: string
+  name: string
+  email: string
+  message: string
+  userId: string | null   // null = anonymous visitor; non-null = authenticated user
+  createdAt: string       // ISO 8601
+}
+
+export interface CreateFeedbackInput {
+  name: string
+  email: string
+  message: string
+  userId?: string | null  // passed from auth context when available
+}
+```
+
+### Database Table
+
+```sql
+-- supabase/migrations/014_feedback_submissions.sql
+create table feedback_submissions (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  email       text not null,
+  message     text not null,
+  user_id     uuid references profiles(id) on delete set null,  -- null = anonymous
+  created_at  timestamptz not null default now()
+);
+
+-- Public insert (both anon and authenticated users can submit)
+-- No read/update/delete for anon — team reads via Supabase dashboard
+alter table feedback_submissions enable row level security;
+
+create policy "Anyone can insert feedback"
+  on feedback_submissions for insert
+  with check (true);
+```
+
+### Validation Rules
+
+- `name`: required, min 1 character (prefilled from auth context for logged-in users)
+- `email`: required, valid email format (prefilled from auth context for logged-in users)
+- `message`: required, min 1 character
+- `userId`: optional; populated automatically from session — never entered manually by the user
+
+### Row Mapper
+
+```typescript
+// app/lib/queries/feedback.ts
+function toFeedbackSubmission(row: Record<string, unknown>): FeedbackSubmission {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    email: row.email as string,
+    message: row.message as string,
+    userId: (row.user_id as string) ?? null,
+    createdAt: row.created_at as string,
+  }
+}
+```
+
+### ContactSection UX — Auth-aware behaviour
+
+| Visitor state | Name field | Email field | userId on submit |
+|---------------|------------|-------------|-----------------|
+| Anonymous | Editable, empty | Editable, empty | `null` |
+| Authenticated | Prefilled, editable | Prefilled, editable | `user.id` |
+
+Authenticated users can still edit their name/email before submitting (e.g. if they want to submit anonymously or use a different address). The `userId` is always captured from the session regardless of what name/email they type — it is not displayed to the user.
+
+---
+
+## Modified Entity: AuthUser (registration extension)
+
+No schema change to the `profiles` table. The existing `profiles` table already has `role` ('coach' | 'athlete'). The change is in the **registration flow**: a new `register-user` edge function accepts both roles.
+
+### New Edge Function Input
+
+```typescript
+// supabase/functions/register-user/index.ts — input shape
+interface RegisterUserInput {
+  name: string
+  email: string
+  password: string
+  role: 'coach' | 'athlete'
+}
+```
+
+### Mock Registration Extension
+
+```typescript
+// app/lib/auth.ts — new helper (generalises mockRegisterCoach)
+export function mockRegisterUser(
+  email: string,
+  password: string,
+  name: string,
+  role: 'coach' | 'athlete'
+): AuthUser
+```
+
+---
+
+## No Other Schema Changes
+
+The landing page hero, Why Synek, and Features sections are purely presentational. The Login section reuses the existing `supabase.auth.signInWithPassword` flow. No tables are modified beyond the new `feedback_submissions`.
+
+---
+
+## Query Key Addition
+
+```typescript
+// app/lib/queries/keys.ts — addition
+export const feedbackKeys = {
+  all: ['feedback'] as const,
+}
+```
+
+---
+
+## Mock Data Module
+
+```typescript
+// app/lib/mock-data/feedback.ts
+
+import type { FeedbackSubmission } from '~/types/feedback'
+
+let MOCK_FEEDBACK: FeedbackSubmission[] = []
+
+export function getMockFeedback(): FeedbackSubmission[] {
+  return MOCK_FEEDBACK
+}
+
+export function addMockFeedback(submission: FeedbackSubmission): void {
+  MOCK_FEEDBACK.push(submission)
+}
+
+export function resetMockFeedback(): void {
+  MOCK_FEEDBACK = []
+}
+```

--- a/specs/008-landing-page/plan.md
+++ b/specs/008-landing-page/plan.md
@@ -1,0 +1,203 @@
+# Implementation Plan: Public Landing Page
+
+**Branch**: `008-landing-page` | **Date**: 2026-03-10 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Build a public marketing landing page at `/` that presents Synek's value proposition, communicates beta status with free accounts, and provides three self-contained interactive sections: Log In, Join Beta (role-selectable registration), and Contact (feedback form). The landing page is a top-level SPA route with its own sticky nav, outside the authenticated app shell. The feature also introduces athlete self-registration (currently invite-only) and a new `feedback_submissions` table.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (strict) + React 19
+**Primary Dependencies**: React Router 7, TanStack Query 5, Supabase JS 2, shadcn/ui, i18next, Zod 4
+**Storage**: Supabase PostgreSQL — new `feedback_submissions` table (migration 014); no changes to existing tables
+**Testing**: Vitest 4, @testing-library/react 16, jsdom
+**Target Platform**: Browser SPA (ssr: false)
+**Performance Goals**: Page interactive in under 3 seconds; no new heavy dependencies
+**Constraints**: No new npm packages; bundle unchanged
+**Scale/Scope**: Public-facing page; no auth required
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality & Maintainability | ✅ PASS | Named exports, strict TS, `cn()`, `~/` imports, row mappers in query files |
+| II. Testing Standards | ✅ PASS | `feedback.ts` query has real + mock implementations; `mockRegisterUser` generalises existing mock helper; `pnpm typecheck` gate enforced |
+| III. UX Consistency | ✅ PASS | `landing` namespace added to both `en/` and `pl/` simultaneously; shadcn components via CLI only; no sport colors needed |
+| IV. Performance Requirements | ✅ PASS | No new dependencies; bundle unchanged; feedback submission uses standard TanStack mutation |
+| V. Simplicity & Anti-Complexity | ✅ PASS | Single route file + section components; no new abstractions; existing auth flow reused; inline forms with no shared form state |
+
+**Post-design re-check**: No violations introduced by Phase 1 design. One complexity note: `register-user` is a new edge function rather than extending `register-coach` — this is the simpler choice because it avoids modifying a deployed function and its existing callers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-landing-page/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── ui-contracts.md  # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── routes/
+│   └── landing.tsx                    # NEW — replaces root-redirect as index route
+├── components/
+│   └── landing/
+│       ├── LandingNav.tsx             # NEW — sticky anchor nav
+│       ├── HeroSection.tsx            # NEW — hero / get-started
+│       ├── WhySynekSection.tsx        # NEW — value differentiators
+│       ├── FeaturesSection.tsx        # NEW — feature list
+│       ├── LoginSection.tsx           # NEW — inline login form
+│       ├── JoinBetaSection.tsx        # NEW — role picker + registration form
+│       └── ContactSection.tsx         # NEW — feedback form
+├── lib/
+│   ├── queries/
+│   │   └── feedback.ts               # NEW — createFeedback (real + mock)
+│   ├── hooks/
+│   │   └── useFeedback.ts            # NEW — useSubmitFeedback mutation
+│   ├── mock-data/
+│   │   └── feedback.ts               # NEW — in-memory store + resetMockFeedback()
+│   └── auth.ts                       # MODIFIED — add mockRegisterUser(role)
+├── types/
+│   └── feedback.ts                   # NEW — FeedbackSubmission, CreateFeedbackInput
+├── i18n/resources/
+│   ├── en/landing.json               # NEW
+│   └── pl/landing.json               # NEW
+└── i18n/config.ts                    # MODIFIED — add 'landing' to namespaces array
+
+supabase/
+├── migrations/
+│   └── 014_feedback_submissions.sql  # NEW — feedback_submissions table + RLS
+└── functions/
+    └── register-user/
+        └── index.ts                  # NEW — unified registration (coach | athlete)
+```
+
+**Files removed**: `app/routes/root-redirect.tsx` (landing page takes over the index route)
+**Files modified**: `app/routes.ts` (index → landing.tsx), `app/lib/auth.ts` (add mockRegisterUser), `app/lib/mock-data/index.ts` (re-export feedback), `app/lib/queries/keys.ts` (add feedbackKeys), `app/i18n/config.ts` (add landing namespace)
+
+**Structure Decision**: Single project (Option 1). All changes are within the existing SPA structure. The edge function follows the pattern of `supabase/functions/register-coach/` and `supabase/functions/claim-invite/`.
+
+---
+
+## Phase 0: Research Summary
+
+All unknowns resolved. See [research.md](./research.md) for full rationale.
+
+| Unknown | Resolution |
+|---------|-----------|
+| Landing page route location | Top-level index route (`/`), replaces root-redirect.tsx |
+| Authenticated user redirect | Handled inside landing.tsx via `useAuth().user` + `useNavigate`, same pattern as login.tsx |
+| Athlete self-registration | New `register-user` edge function accepting `role: 'coach' \| 'athlete'` |
+| Mock support for athlete registration | New `mockRegisterUser(email, password, name, role)` in auth.ts |
+| Contact form storage | New `feedback_submissions` table (migration 014); no third-party service |
+| i18n namespace | New `landing` namespace; both EN and PL files required |
+| Header suppression | Landing is layout-less (top-level route); app Header never renders on this page |
+| New npm dependencies | None required |
+
+---
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+See [data-model.md](./data-model.md).
+
+**New entity**: `FeedbackSubmission` — stored in `feedback_submissions` table. Fields: `id`, `name`, `email`, `message`, `created_at`. No auth FK (unauthenticated inserts allowed via RLS policy).
+
+**Registration extension**: No schema change. New `register-user` edge function accepts `role: 'coach' | 'athlete'`; `profiles` table already has `role` column.
+
+### UI Contracts
+
+See [contracts/ui-contracts.md](./contracts/ui-contracts.md).
+
+Three forms defined:
+1. **Login form** — email + password → `useAuth().login()` → role-based redirect
+2. **Join Beta form** — role picker + name + email + password → `register-user` edge function → fresh sign-in → redirect
+3. **Contact form** — name + email + message → `useSubmitFeedback()` mutation → confirmation message
+
+All three include honeypot fields. All use Zod for validation. All display inline errors without page reload.
+
+### Navigation Contract
+
+Six anchor links in sticky nav: `#get-started`, `#why-synek`, `#features`, `#log-in`, `#join-beta`, `#contact`. Smooth scroll via `scrollIntoView({ behavior: 'smooth' })`.
+
+### Key Implementation Decisions
+
+#### 1. Route Change: `/` → `landing.tsx`
+
+`routes.ts` changes from:
+```typescript
+index('routes/root-redirect.tsx'),
+```
+to:
+```typescript
+index('routes/landing.tsx'),
+```
+
+The redirect logic for authenticated users moves into `landing.tsx`:
+```typescript
+// Early in component — same pattern as login.tsx
+useEffect(() => {
+  if (user) {
+    const locale = localStorage.getItem('locale') ?? 'pl'
+    navigate(`/${locale}/${user.role}`, { replace: true })
+  }
+}, [user, navigate])
+```
+
+`root-redirect.tsx` is deleted.
+
+#### 2. Athlete Self-Registration via `register-user` Edge Function
+
+The new function (`supabase/functions/register-user/index.ts`) follows the `register-coach` pattern exactly, adding `role` to the request body and the `profiles` insert:
+
+```typescript
+// Input shape
+{ name: string, email: string, password: string, role: 'coach' | 'athlete' }
+```
+
+In mock mode, `JoinBetaSection` calls the new `mockRegisterUser` helper:
+```typescript
+// app/lib/auth.ts — new export
+export function mockRegisterUser(
+  email: string,
+  password: string,
+  name: string,
+  role: 'coach' | 'athlete'
+): AuthUser
+```
+
+#### 3. Feedback Mutation (no optimistic update needed)
+
+`useSubmitFeedback` is a simple mutation — no optimistic update required because the contact form has no pre-existing data to patch. The UI state (loading/success/error) is managed locally in `ContactSection.tsx` using the mutation's `status` field.
+
+#### 4. i18n Config Update
+
+```typescript
+// app/i18n/config.ts — add to ns array
+ns: ['common', 'coach', 'athlete', 'training', 'landing'],
+```
+
+`useTranslation('landing')` used in all `app/components/landing/` files.
+
+#### 5. Landing Nav — No React Router `<Link>`
+
+Nav items are plain `<a href="#section-id">` tags (not React Router `<Link>`), since they are hash anchors on the same page, not route transitions.
+
+---
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification required.

--- a/specs/008-landing-page/quickstart.md
+++ b/specs/008-landing-page/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: 008-landing-page
+
+## Prerequisites
+
+```bash
+git checkout 008-landing-page
+pnpm install        # no new dependencies added in this feature
+pnpm dev            # http://localhost:5173
+```
+
+The app runs in mock mode when Supabase credentials are absent (`.env` not set up). All landing page flows (login, registration, contact form) work in mock mode.
+
+---
+
+## Key Entry Points
+
+| What | Where |
+|------|-------|
+| Landing page route | `app/routes/landing.tsx` |
+| Landing section components | `app/components/landing/` |
+| Feedback query | `app/lib/queries/feedback.ts` |
+| Feedback hook | `app/lib/hooks/useFeedback.ts` |
+| Feedback mock data | `app/lib/mock-data/feedback.ts` |
+| Registration edge function | `supabase/functions/register-user/index.ts` |
+| i18n copy | `app/i18n/resources/{en,pl}/landing.json` |
+| DB migration | `supabase/migrations/012_feedback_submissions.sql` |
+
+---
+
+## Mock Mode Behaviour
+
+| Action | Mock behaviour |
+|--------|---------------|
+| Login (existing user) | Uses `mockLogin()` — coach@synek.app / alice@synek.app / bob@synek.app |
+| Register as Coach | Creates in-memory user via `mockRegisterUser(..., 'coach')` |
+| Register as Athlete | Creates in-memory user via `mockRegisterUser(..., 'athlete')` |
+| Contact form submit | Inserts into in-memory `MOCK_FEEDBACK` store |
+
+---
+
+## Running Tests
+
+```bash
+pnpm test                    # run all tests
+pnpm test app/test/unit/     # unit tests only
+pnpm test app/test/integration/  # integration tests only
+pnpm typecheck               # type check (must pass before PR)
+```
+
+---
+
+## Adding / Editing Landing Copy
+
+All user-visible strings live in:
+- `app/i18n/resources/en/landing.json`
+- `app/i18n/resources/pl/landing.json`
+
+Use `useTranslation('landing')` in landing components. Always update both files simultaneously.
+
+---
+
+## Testing the Registration Flow Manually
+
+1. Navigate to `http://localhost:5173`
+2. Click **Join Beta** in the nav — page scrolls to the Join Beta section
+3. Select role (Coach or Athlete)
+4. Fill in name, email, password
+5. Submit — app redirects to the appropriate dashboard
+6. Verify in the browser that the user is now logged in (header shows name/avatar)
+
+To test athlete registration in mock mode, select "Athlete" in the role picker. The new account is created in memory and you can log out and back in using the same credentials within the same browser session.
+
+---
+
+## Deploying the Edge Function
+
+```bash
+supabase functions deploy register-user
+```
+
+The `register-user` function accepts both `coach` and `athlete` roles. The existing `register-coach` function remains deployed and unchanged (still used by `login.tsx`).

--- a/specs/008-landing-page/research.md
+++ b/specs/008-landing-page/research.md
@@ -1,0 +1,95 @@
+# Research: 008-landing-page
+
+**Phase 0 output** | **Date**: 2026-03-10
+
+---
+
+## 1. Route Integration
+
+**Decision**: Landing page becomes the new index route (`/`), replacing `root-redirect.tsx`.
+
+**Rationale**: The root URL is the natural home for the landing page. Authenticated users visiting `/` will be redirected to their dashboard from within the landing route — the same redirect logic currently in `root-redirect.tsx`. The landing page is registered as a top-level route (outside `/:locale` layout) so it gets its own sticky nav rather than the app's `Header`.
+
+**Alternatives considered**:
+- Register at `/landing` and keep root-redirect — rejected: forces users to know a separate URL; `/` should be the product's front door.
+- Include inside `/:locale` layout — rejected: app `Header` would render above the landing nav; users would see the auth UI before reaching the marketing content.
+
+**Impact**: `root-redirect.tsx` is deleted; `routes.ts` index entry points to `routes/landing.tsx`.
+
+---
+
+## 2. Athlete Self-Registration
+
+**Decision**: Add a new `register-user` Supabase Edge Function accepting `{ name, email, password, role: 'coach' | 'athlete' }`. The existing `register-coach` function remains unchanged (still used by `login.tsx`).
+
+**Rationale**: The spec requires athletes to self-register directly from the landing page, which is not currently supported. The cleanest approach is a new unified registration function rather than modifying the existing one, avoiding regressions in the current coach registration flow.
+
+**In mock mode**: A new `mockRegisterUser(email, password, name, role)` helper is added to `app/lib/auth.ts` (generalises the existing `mockRegisterCoach`). After mock registration, `mockLogin` + `login()` are called identically to the current coach flow.
+
+**Alternatives considered**:
+- Extend `register-coach` to accept a `role` parameter — rejected: would require updating the existing edge function and all callers; higher regression risk.
+- Use `supabase.auth.signUp` directly from the client — rejected: violates the convention established in `login.tsx` (edge function handles account creation to enforce business rules like duplicate detection and profile insert).
+
+---
+
+## 3. Contact / Feedback Form Storage
+
+**Decision**: Add a `feedback_submissions` Supabase table (migration `012_feedback_submissions.sql`). Submissions require no authentication. In mock mode, an in-memory store is used.
+
+**Rationale**: Keeping submissions in Supabase gives the team a central place to read beta feedback. No third-party service is introduced, avoiding new dependencies (Principle V).
+
+**Fields**: `id`, `name`, `email`, `message`, `created_at`. No FK to profiles — feedback is always anonymous/pre-auth.
+
+**Alternatives considered**:
+- Third-party form service (Formspree, Resend) — rejected: adds external dependency; constitution requires bundle and dependency justification.
+- Email-only via edge function — rejected: harder to query; Supabase table is queryable and auditable.
+
+---
+
+## 4. i18n Namespace
+
+**Decision**: Create a new `landing` namespace with files at `app/i18n/resources/en/landing.json` and `app/i18n/resources/pl/landing.json`.
+
+**Rationale**: Landing page copy (hero headlines, feature bullets, beta messaging, CTAs) is distinct from app UX strings. Separating into its own namespace keeps `common` lean and makes translations easy to hand off to copywriters.
+
+**Alternatives considered**:
+- Re-use `common` namespace — rejected: `common` is already broad; marketing copy does not belong alongside auth and UI strings.
+
+---
+
+## 5. Landing Page Component Structure
+
+**Decision**: A single route file `app/routes/landing.tsx` composes section sub-components from `app/components/landing/`. Each section is a named export from its own file.
+
+**Rationale**: Keeps the route file thin (constitution Principle V). Sections are independently readable and testable. Component files stay under the 200-line guideline.
+
+**Sections mapped to components**:
+| Section | Component |
+|---------|-----------|
+| Sticky nav | `LandingNav.tsx` |
+| Hero / Get Started | `HeroSection.tsx` |
+| Why Synek | `WhySynekSection.tsx` |
+| Features | `FeaturesSection.tsx` |
+| Log In | `LoginSection.tsx` |
+| Join Beta | `JoinBetaSection.tsx` |
+| Contact | `ContactSection.tsx` |
+
+---
+
+## 6. Redirect Behaviour for Authenticated Users
+
+**Decision**: Landing route reads `AuthContext.user` on mount; if the user is already authenticated, it immediately redirects to `/${locale}/${role}`. This replicates the behaviour previously in `root-redirect.tsx`.
+
+**Rationale**: Authenticated users should land in their app, not re-read marketing copy. The locale is read from `localStorage.getItem('locale') ?? 'pl'`, identical to the current pattern in `login.tsx`.
+
+---
+
+## 7. No New Major Dependencies
+
+No new npm packages are required. The landing page uses:
+- Existing shadcn/ui components (Button, Input, etc.)
+- `lucide-react` for icons (already installed)
+- Existing Tailwind tokens
+- Existing `cn()` utility
+
+This satisfies Principle IV (bundle discipline) and Principle V (simplicity).

--- a/specs/008-landing-page/spec.md
+++ b/specs/008-landing-page/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Public Landing Page
+
+**Feature Branch**: `008-landing-page`
+**Created**: 2026-03-10
+**Status**: Draft
+**Input**: User description: "Add a landing page that describes what the app does and that is the customer proposition. This should be a SPA with menu at the top that navigates by scrolling to anchors. The anchors should be: Get Started, Why Synek, Features, Log In, Join Beta (registration), Contact with feedback form. App is in BETA — accounts are free. Registration is open to both coaches and athletes. Encourage feedback throughout."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Prospect Discovers and Evaluates the App (Priority: P1)
+
+A potential customer (coach or athlete) lands on the Synek homepage for the first time. They want to quickly understand what the product does, who it is for, and why they should use it. They scroll through the page and read the key sections before deciding whether to sign up. The page communicates that Synek is in public beta and that joining is free — and frames giving feedback as a valued part of the beta experience.
+
+**Why this priority**: This is the primary conversion funnel entry point. Without a compelling value proposition and clear beta messaging, no visitor will proceed to registration or login.
+
+**Independent Test**: Accessible at the root URL with no authentication required; renders the full page with all sections visible and beta positioning clearly communicated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor arrives at the landing page, **When** the page loads, **Then** a sticky top navigation bar is visible with links: Get Started, Why Synek, Features, Log In, Join Beta, Contact.
+2. **Given** a visitor clicks a navigation link, **When** the link is activated, **Then** the page smoothly scrolls to the corresponding anchor section.
+3. **Given** a visitor reads the hero section, **When** they view the page, **Then** the headline clearly communicates what Synek does, that it is in beta, and that joining is free.
+4. **Given** a visitor reads the page, **When** they encounter calls to action, **Then** the messaging encourages them to try the app and share feedback.
+
+---
+
+### User Story 2 - Visitor Joins the Beta (Priority: P2)
+
+A prospect who has read the landing page decides to create a free beta account — as either a coach or an athlete. They click "Join Beta" in the nav or a CTA, select their role, and complete the registration form.
+
+**Why this priority**: Beta sign-up is the primary conversion goal of the landing page. The form must support both roles and clearly communicate free access.
+
+**Independent Test**: Clicking "Join Beta" scrolls to the registration section; selecting a role and submitting valid details creates an account of that role and redirects the user into the app.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor clicks "Join Beta" in the navigation, **When** the click is triggered, **Then** the page scrolls to the Join Beta section containing a registration form.
+2. **Given** the registration form, **When** a visitor views it, **Then** they can select their role: Coach or Athlete.
+3. **Given** the registration form with a role selected, **When** a visitor submits valid details (name, email, password), **Then** an account of the selected role is created and the user is redirected to their role-appropriate home.
+4. **Given** the registration form, **When** a visitor submits an already-registered email, **Then** an informative error message is shown below the email field.
+5. **Given** the registration form, **When** a visitor submits with missing required fields, **Then** inline validation errors appear for each missing field without page reload.
+6. **Given** the Join Beta section, **When** a visitor views it, **Then** the section clearly communicates that the app is in beta, accounts are free, and feedback is welcome.
+
+---
+
+### User Story 3 - Existing User Logs In from Landing Page (Priority: P3)
+
+An existing Synek user arrives at the landing page and wants to access their account. They click "Log In" in the navigation or the dedicated Log In section.
+
+**Why this priority**: Returning users must not be forced to navigate away from the landing page to find the login entry point.
+
+**Independent Test**: Clicking "Log In" scrolls to the Log In section; the login form authenticates and redirects existing users to their role-appropriate home.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user clicks "Log In" in the navigation, **When** the click is triggered, **Then** the page scrolls to the Log In section with email and password fields.
+2. **Given** a user submits correct credentials, **When** the form is submitted, **Then** the user is authenticated and redirected to their role-appropriate home.
+3. **Given** a user submits incorrect credentials, **When** the form is submitted, **Then** an error message is displayed without page reload.
+
+---
+
+### User Story 4 - Visitor Sends Feedback (Priority: P4)
+
+A visitor has a question or feedback about Synek. They scroll to the Contact section and submit the feedback form. The section explicitly welcomes beta feedback and positions it as helping shape the product.
+
+**Why this priority**: Beta-stage products depend on early user feedback. The Contact section doubles as a feedback channel and should be framed accordingly.
+
+**Independent Test**: Submitting the contact form with name, email, and message shows a confirmation message; the section copy references beta and thanks the visitor for contributing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor is in the Contact section, **When** they view it, **Then** the section communicates that feedback helps improve the beta.
+2. **Given** a visitor submits a complete form (name, email, message), **When** the form is submitted, **Then** a success confirmation is displayed and the form is cleared.
+3. **Given** a visitor submits with missing required fields, **Then** inline validation errors appear.
+4. **Given** a visitor submits with an invalid email format, **Then** an error is shown for the email field.
+
+---
+
+### Edge Cases
+
+- What happens when a user who is already authenticated visits the landing page — are they redirected to their dashboard or shown the landing page?
+- How does the navigation bar behave on mobile viewports — does it collapse into a hamburger menu?
+- What happens when the registration email is already in use?
+- What happens if the contact form submission fails (network error)?
+- What happens if a visitor submits the registration form without selecting a role?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The landing page MUST be accessible without authentication.
+- **FR-002**: The page MUST include a sticky top navigation bar with anchor links to: Get Started, Why Synek, Features, Log In, Join Beta, Contact.
+- **FR-003**: Clicking any navigation link MUST smoothly scroll the viewport to the corresponding page section.
+- **FR-004**: The page MUST include the following named sections in order: Hero / Get Started, Why Synek, Features, Log In, Join Beta, Contact.
+- **FR-005**: The Hero section MUST clearly state Synek's value proposition for coaches and athletes, communicate the beta status, and state that accounts are free.
+- **FR-006**: The "Why Synek" section MUST present the key differentiators and benefits of the platform.
+- **FR-007**: The "Features" section MUST list the main product features with brief descriptions.
+- **FR-008**: The "Log In" section MUST contain a working login form (email and password) that authenticates users and redirects them to their role-appropriate dashboard.
+- **FR-009**: The "Join Beta" section MUST contain a registration form that allows the visitor to choose their role (Coach or Athlete) before completing sign-up (name, email, password minimum).
+- **FR-010**: The "Join Beta" section MUST communicate that the app is in beta, that accounts are free, and that feedback is encouraged.
+- **FR-011**: The registration form MUST validate inputs and display inline errors without full-page reload.
+- **FR-012**: The "Contact" section MUST contain a feedback form (name, email, message) that submits successfully and shows a confirmation; section copy MUST reference beta and frame feedback as shaping the product.
+- **FR-013**: All public-facing forms MUST include honeypot spam protection.
+- **FR-014-A**: The Contact form MUST capture the authenticated user's ID when submitted by a logged-in user, storing `null` for anonymous visitors — enabling the team to distinguish internal user feedback from pre-signup feedback.
+- **FR-014-B**: When a logged-in user opens the Contact section, their name and email MUST be prefilled from their profile; the fields remain editable before submission.
+- **FR-014**: The page MUST be responsive and usable on mobile, tablet, and desktop viewports.
+- **FR-015**: The navigation bar MUST remain visible (sticky) while the user scrolls the page.
+- **FR-016**: After successful registration, the user MUST be signed in automatically and redirected to their role-appropriate dashboard (coach home for Coach, athlete home for Athlete).
+
+### Key Entities
+
+- **Landing Visitor**: Unauthenticated user browsing the page; no persistent state required.
+- **Beta Registration**: New account created via the Join Beta form; role (Coach or Athlete) is selected by the visitor during sign-up.
+- **Feedback Submission**: Name, email, and message submitted by a visitor. Carries an optional link to an authenticated user's profile — `null` for anonymous, user ID for logged-in users. Read by the team via the Supabase dashboard.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A first-time visitor can understand Synek's purpose, target audience, and beta status within 10 seconds of the page loading.
+- **SC-002**: A visitor can navigate to any section of the page within 2 interactions (one click from the navigation).
+- **SC-003**: A new user can complete beta registration (either role) and reach their dashboard in under 3 minutes.
+- **SC-004**: The page is fully functional and readable on screen widths from 375px (mobile) to 1440px (desktop).
+- **SC-005**: A visitor submitting the contact form receives a success confirmation within 5 seconds.
+- **SC-006**: All form validation errors are visible to the user without requiring a page reload.
+- **SC-007**: The page loads and becomes interactive within 3 seconds on a standard broadband connection.
+- **SC-008**: Beta messaging (free accounts, feedback welcome) is visible in at least two distinct sections of the page.
+
+## Assumptions
+
+- Both Coach and Athlete roles can self-register via the landing page; the athlete invite flow remains available but is no longer the only path for athletes.
+- The landing page is served as part of the existing SPA — no SSR or separate deployment required.
+- Contact form submissions are stored in a `feedback_submissions` Supabase table. The team reads feedback directly via the Supabase dashboard — no admin UI is built in this feature.
+- Page copy (headlines, feature descriptions, value propositions) will be provided in both English and Polish to align with the existing i18n setup.
+- The routing integration (how the landing page coexists with the current root redirect to `/:locale`) is deferred to planning.
+- An authenticated user visiting the landing page will be redirected to their dashboard (to be confirmed in planning).
+- The "Join Beta" label replaces "Free Trial" everywhere in the UI and copy; it better reflects the product stage and the free-access model.

--- a/specs/008-landing-page/tasks.md
+++ b/specs/008-landing-page/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: Public Landing Page
+
+**Input**: Design documents from `/specs/008-landing-page/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/ ✅
+
+**Tests**: No test tasks — not requested in spec. Run `pnpm typecheck` as the quality gate (T025).
+
+**Organization**: Tasks grouped by user story. US1 (pure presentation) is fully independent. US2–US4 each add one section and one backend concern.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Config, types, and translation key files that every landing component imports. Must be done before any component work begins.
+
+- [x] T001 Add `'landing'` to the `ns` array in `app/i18n/config.ts`
+- [x] T002 [P] Create `app/i18n/resources/en/landing.json` with all key names and placeholder English values (nav, hero, whySynek, features, beta, contact sections — see contracts/ui-contracts.md for key names)
+- [x] T003 [P] Create `app/i18n/resources/pl/landing.json` mirroring the same key structure as T002 with placeholder Polish values
+- [x] T004 [P] Create `app/types/feedback.ts` — `FeedbackSubmission` interface and `CreateFeedbackInput` interface per data-model.md
+- [x] T005 [P] Add `feedbackKeys` to `app/lib/queries/keys.ts` — `{ all: ['feedback'] as const }`
+
+**Checkpoint**: Config and types in place — component files can be created and will resolve imports correctly.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Route wiring, data layer, and mock auth extension that every user story depends on. Establishes the landing page as a reachable route and enables all forms to work in mock mode.
+
+**⚠️ CRITICAL**: No user story component work can begin until this phase is complete.
+
+- [x] T006 Update `app/routes.ts`: replace `index('routes/root-redirect.tsx')` with `index('routes/landing.tsx')`
+- [x] T007 Delete `app/routes/root-redirect.tsx`; create `app/routes/landing.tsx` as a minimal scaffold — auth redirect logic (`useEffect` on `user` → `navigate(/${locale}/${role})`) + empty `<main>` with six placeholder `<section id="…">` slots matching the nav anchors
+- [x] T008 [P] Create `supabase/migrations/014_feedback_submissions.sql` — `feedback_submissions` table with `user_id uuid references profiles(id) on delete set null` + RLS policy allowing public insert per data-model.md
+- [x] T009 [P] Add `mockRegisterUser(email, password, name, role: 'coach' | 'athlete'): AuthUser` to `app/lib/auth.ts` — follows the same pattern as existing `mockRegisterCoach`, adds the user to `MOCK_USERS` with the given role
+- [x] T010 [P] Create `app/lib/mock-data/feedback.ts` — mutable `MOCK_FEEDBACK` store, `addMockFeedback()`, `getMockFeedback()`, `resetMockFeedback()` (deep-clone reset) per data-model.md; add re-export to `app/lib/mock-data/index.ts`
+- [x] T011 Create `app/lib/queries/feedback.ts` — `createFeedback(input: CreateFeedbackInput)` with real Supabase path (`insert` into `feedback_submissions` selecting `id, name, email, message, user_id, created_at`) and mock path (`addMockFeedback`); `toFeedbackSubmission` row mapper; depends on T010
+- [x] T012 Create `app/lib/hooks/useFeedback.ts` — `useSubmitFeedback()` mutation using `createFeedback`; `onSettled` invalidates `feedbackKeys.all`; depends on T011
+
+**Checkpoint**: `pnpm dev` serves the app at `/` via the new landing scaffold (blank page). Auth redirect fires for logged-in users. Feedback data layer is fully wired in mock mode.
+
+---
+
+## Phase 3: User Story 1 — Prospect Discovers and Evaluates (Priority: P1) 🎯 MVP
+
+**Goal**: A visitor can land on `/`, read the full marketing page, and navigate to any section via the sticky nav.
+
+**Independent Test**: Navigate to `http://localhost:5173`. Verify the sticky nav is visible with six links. Click each link — page smooth-scrolls to the correct section. No login required. Authenticated users are redirected to their dashboard.
+
+- [x] T013 [US1] Create `app/components/landing/LandingNav.tsx` — sticky top bar, renders six `<a href="#…">` anchor links using i18n keys from `landing:nav.*`; uses `cn()` for active/scroll state; no React Router `<Link>` (hash anchors only)
+- [x] T014 [P] [US1] Create `app/components/landing/HeroSection.tsx` — `id="get-started"`, headline + subheadline communicating value prop + beta status, primary CTA button scrolling to `#join-beta`, secondary CTA linking to `#log-in`; uses `landing:hero.*` keys
+- [x] T015 [P] [US1] Create `app/components/landing/WhySynekSection.tsx` — `id="why-synek"`, three-to-four differentiator cards (structured training, coach visibility, athlete autonomy, beta access); uses `landing:whySynek.*` keys
+- [x] T016 [P] [US1] Create `app/components/landing/FeaturesSection.tsx` — `id="features"`, feature list/grid (week planning, session types, Strava sync, coach/athlete roles, self-planning); uses `landing:features.*` keys
+- [x] T017 [US1] Wire all four sections into `app/routes/landing.tsx`: import `LandingNav`, `HeroSection`, `WhySynekSection`, `FeaturesSection`; render them with correct section `id` attributes; add remaining placeholder sections (`#log-in`, `#join-beta`, `#contact`) as empty `<section>` stubs; depends on T013–T016
+
+**Checkpoint**: Full marketing page visible at `/`. Sticky nav scrolls to all sections. US1 independently deliverable.
+
+---
+
+## Phase 4: User Story 2 — Visitor Joins the Beta (Priority: P2)
+
+**Goal**: A visitor can select Coach or Athlete, fill in name/email/password, and create an account — landing on their role-appropriate dashboard.
+
+**Independent Test**: Click "Join Beta" in the nav. Select "Coach", fill form with valid data, submit. Verify redirect to `/pl/coach`. Repeat as Athlete → `/pl/athlete`. Submit with duplicate email → see email error. Submit empty form → see inline validation errors.
+
+- [x] T018 [US2] Create `supabase/functions/register-user/index.ts` — follows `supabase/functions/register-coach/index.ts` pattern exactly; accepts `{ name, email, password, role: 'coach' | 'athlete' }`; inserts into `auth.users` + `profiles` with the given role; returns `{ success: true }` or `{ error: string }`
+- [x] T019 [US2] Create `app/components/landing/JoinBetaSection.tsx` — `id="join-beta"`; role toggle (Coach / Athlete); name, email, password fields; honeypot `website` field (`aria-hidden`, `tabIndex={-1}`); Zod validation (same schema as `login.tsx`); mock path calls `mockRegisterUser(..., role)` then `login()`; real path POSTs to `register-user` edge function then `supabase.auth.signInWithPassword`; on success `navigate(/${locale}/${role})`; inline errors per contracts/ui-contracts.md; uses `landing:beta.*` keys; depends on T009
+
+**Checkpoint**: Full registration flow works in mock mode for both roles. US2 independently deliverable.
+
+---
+
+## Phase 5: User Story 3 — Existing User Logs In (Priority: P3)
+
+**Goal**: An existing user can log in directly from the landing page without navigating to `/login`.
+
+**Independent Test**: Click "Log In" in the nav. Enter `coach@synek.app / coach123`, submit. Verify redirect to `/pl/coach`. Enter wrong credentials → see error without page reload.
+
+- [x] T020 [US3] Create `app/components/landing/LoginSection.tsx` — `id="log-in"`; email + password fields; calls `useAuth().login(email, password)`; on success navigates to `/${locale}/${user.role}` via the same `useEffect` on `user` used in `login.tsx`; inline error display; loading state on submit button; uses `landing:login.*` keys; wire into `app/routes/landing.tsx`
+
+**Checkpoint**: Existing users can log in without leaving the landing page. US3 independently deliverable.
+
+---
+
+## Phase 6: User Story 4 — Visitor Sends Feedback (Priority: P4)
+
+**Goal**: Any visitor (logged-in or anonymous) can submit a feedback message; authenticated users have name/email prefilled and their `userId` is captured silently.
+
+**Independent Test**: As anonymous: scroll to Contact, fill name/email/message, submit → confirmation message, form clears. As authenticated user: verify name/email are prefilled. Submit → confirm `user_id` is non-null in the mock store (`getMockFeedback()`).
+
+- [x] T021 [US4] Create `app/components/landing/ContactSection.tsx` — `id="contact"`; reads `user` from `useAuth()`; prefills `name` and `email` from `user.name` / `user.email` when authenticated (fields remain editable); includes honeypot field; calls `useSubmitFeedback()` with `{ name, email, message, userId: user?.id ?? null }`; shows success confirmation + clears form on `isSuccess`; shows error message on `isError`; beta-framed copy via `landing:contact.*` keys; wire into `app/routes/landing.tsx`; depends on T012
+
+**Checkpoint**: Contact form works for both anonymous and authenticated users. `user_id` visible in Supabase dashboard for internal submissions. US4 independently deliverable.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Production-quality copy, responsive layout verification, and type safety gate.
+
+- [x] T022 [P] Fill production-quality English copy in `app/i18n/resources/en/landing.json` — replace all placeholders with final marketing text (hero headline, differentiators, feature descriptions, beta messaging, CTA labels, contact section copy, nav labels)
+- [x] T023 [P] Fill production-quality Polish copy in `app/i18n/resources/pl/landing.json` — translate all keys from T022
+- [ ] T024 [P] Verify responsive layout across all `app/components/landing/` components at 375px (mobile), 768px (tablet), 1440px (desktop) — fix any overflow, spacing, or readability issues
+- [x] T025 Run `pnpm typecheck`; fix all TypeScript errors in new files (`landing.tsx`, `app/components/landing/`, `app/lib/queries/feedback.ts`, `app/lib/hooks/useFeedback.ts`, `app/types/feedback.ts`, `app/lib/auth.ts`)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — BLOCKS all user story phases
+- **Phase 3 (US1)**: Depends on Phase 2 — can start as soon as Foundational is done
+- **Phase 4 (US2)**: Depends on Phase 2 (needs `mockRegisterUser` from T009)
+- **Phase 5 (US3)**: Depends on Phase 2 only (reuses existing auth — no new data layer)
+- **Phase 6 (US4)**: Depends on T012 (`useSubmitFeedback`) from Phase 2
+- **Phase 7 (Polish)**: Depends on all story phases complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent after Phase 2 — purely presentational
+- **US2 (P2)**: Independent after Phase 2 — needs T009 (mockRegisterUser)
+- **US3 (P3)**: Independent after Phase 2 — reuses existing `useAuth().login`
+- **US4 (P4)**: Independent after T012 (useFeedback hook) — needs ContactSection only
+
+### Within Each Phase
+
+- T002, T003, T004, T005 (Phase 1) — all parallel
+- T008, T009, T010 (Phase 2) — all parallel; T011 depends on T010; T012 depends on T011
+- T014, T015, T016 (Phase 3) — all parallel; T017 depends on T013–T016
+- T022, T023, T024 (Phase 7) — all parallel; T025 runs last
+
+---
+
+## Parallel Execution Examples
+
+### Phase 1 (all parallel)
+```
+T001 → i18n config
+T002 → en/landing.json
+T003 → pl/landing.json
+T004 → types/feedback.ts
+T005 → keys.ts
+```
+
+### Phase 3 (US1 sections in parallel, then wire)
+```
+T013 → LandingNav.tsx
+T014 → HeroSection.tsx        ← parallel
+T015 → WhySynekSection.tsx    ← parallel
+T016 → FeaturesSection.tsx    ← parallel
+            ↓ (all complete)
+T017 → landing.tsx (wire together)
+```
+
+### Phase 4–6 (can run in parallel after Phase 2)
+```
+T018 + T019 → US2 (JoinBeta edge fn + component)
+T020        → US3 (LoginSection)
+T021        → US4 (ContactSection, needs T012)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 — Read-only landing page)
+
+1. Complete Phase 1: Setup (T001–T005)
+2. Complete Phase 2: Foundational (T006–T012)
+3. Complete Phase 3: US1 (T013–T017)
+4. **Stop and validate**: marketing page visible at `/`, nav scrolls correctly, auth redirect works
+5. Ship / demo if ready
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Foundation
+2. Phase 3 (T013–T017) → Full page visible ✓
+3. Phase 4 (T018–T019) → Beta registration live ✓
+4. Phase 5 (T020) → Login section live ✓
+5. Phase 6 (T021) → Feedback form live ✓
+6. Phase 7 (T022–T025) → Production copy + polish ✓
+
+---
+
+## Notes
+
+- All `app/components/landing/` components: named exports, `className?: string` prop, `useTranslation('landing')`
+- Nav links are `<a href="#…">` (not React Router `<Link>`) — hash anchors, same page
+- Honeypot field in JoinBeta and Contact: `name="website"`, `tabIndex={-1}`, `aria-hidden="true"`
+- Mock mode is the development default — all flows work without Supabase credentials
+- `pnpm typecheck` MUST pass before PR (T025 is the final gate)

--- a/supabase/functions/register-user/index.ts
+++ b/supabase/functions/register-user/index.ts
@@ -1,0 +1,64 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-client-info, apikey',
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS });
+  }
+
+  try {
+    const body = await req.json() as {
+      name?: string;
+      email?: string;
+      password?: string;
+      role?: string;
+    };
+
+    const { name, email, password, role } = body;
+
+    if (!name || !email || !password) {
+      return json({ error: 'missing_params' }, 400);
+    }
+
+    if (role !== 'coach' && role !== 'athlete') {
+      return json({ error: 'invalid_role' }, 400);
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const { error: createError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, role },
+    });
+
+    if (createError) {
+      if (
+        createError.message?.includes('already been registered') ||
+        createError.message?.includes('already exists')
+      ) {
+        return json({ error: 'email_taken' }, 400);
+      }
+      return json({ error: 'internal_error' }, 500);
+    }
+
+    return json({ success: true });
+  } catch {
+    return json({ error: 'internal_error' }, 500);
+  }
+});

--- a/supabase/migrations/014_feedback_submissions.sql
+++ b/supabase/migrations/014_feedback_submissions.sql
@@ -1,0 +1,24 @@
+-- feedback_submissions: stores contact form messages from landing page visitors.
+-- user_id is nullable — null means anonymous/pre-signup visitor.
+-- Team reads submissions via Supabase dashboard; no admin UI is built.
+
+create table feedback_submissions (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  email       text not null,
+  message     text not null,
+  user_id     uuid references profiles(id) on delete set null,
+  created_at  timestamptz not null default now()
+);
+
+comment on column feedback_submissions.user_id is
+  'Null for anonymous visitors; non-null links submission to a known profile, indicating internal user feedback.';
+
+alter table feedback_submissions enable row level security;
+
+-- Anyone (including unauthenticated users) can insert feedback.
+-- No read/update/delete access for anon or authenticated users — only service role (Supabase dashboard).
+create policy "Anyone can insert feedback"
+  on feedback_submissions
+  for insert
+  with check (true);


### PR DESCRIPTION
## Summary
- Public landing page (`/`) with Hero, WhySynek, Features, JoinBeta, and Contact sections
- `/register` route with full registration form (role picker, name/email/password, honeypot)
- `/login` and `/register` both render `LandingNav` with `ThemeToggle` + `LanguageToggle`
- `LandingNav` anchor links navigate to `/#section` when not on the landing page
- `JoinBetaSection` stripped to a CTA button linking to `/register`
- Feedback submission infrastructure (query, hook, mock data, DB migration 014)
- `register-user` Supabase Edge Function
- EN/PL translations for `landing` namespace

## Test plan
- [ ] Visit `/` — landing page renders all sections, LandingNav shows toggles
- [ ] Click "Join Beta" in nav or JoinBeta section → navigates to `/register`
- [ ] Visit `/login` — LandingNav visible with ThemeToggle + LanguageToggle
- [ ] Visit `/register` — LandingNav visible; complete registration → redirects to `/${locale}/${role}`
- [ ] On `/login` or `/register`, click anchor nav links → navigate to `/#section` on landing page
- [ ] ThemeToggle and LanguageToggle work on landing, login, and register pages
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)