### PR TITLE
fix: improve mobile layout across landing page

### DIFF
--- a/app/components/landing/ContactSection.tsx
+++ b/app/components/landing/ContactSection.tsx
@@ -42,7 +42,7 @@ export function ContactSection({ className }: ContactSectionProps) {
   }
 
   return (
-    <section id="contact" className={cn('bg-muted/40 px-4 py-24', className)}>
+    <section id="contact" className={cn('bg-muted/40 px-4 py-16 sm:py-24', className)}>
       <div className="mx-auto max-w-md">
         <div className="mb-8 text-center">
           <h2 className="text-3xl font-bold tracking-tight">{t('contact.title')}</h2>
@@ -58,7 +58,7 @@ export function ContactSection({ className }: ContactSectionProps) {
         ) : (
           <form
             onSubmit={handleSubmit}
-            className="space-y-4 rounded-xl border bg-background p-8 shadow-sm"
+            className="space-y-4 rounded-xl border bg-background p-6 shadow-sm sm:p-8"
           >
             <div className="space-y-1">
               <label htmlFor="contact-name" className="text-sm font-medium">

--- a/app/components/landing/FeaturesSection.tsx
+++ b/app/components/landing/FeaturesSection.tsx
@@ -16,7 +16,7 @@ export function FeaturesSection({ className }: FeaturesSectionProps) {
   }))
 
   return (
-    <section id="features" className={cn('px-4 py-24', className)}>
+    <section id="features" className={cn('px-4 py-16 sm:py-24', className)}>
       <div className="mx-auto max-w-6xl">
         <div className="mb-12 text-center">
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">

--- a/app/components/landing/HeroSection.tsx
+++ b/app/components/landing/HeroSection.tsx
@@ -27,11 +27,11 @@ export function HeroSection({ className }: HeroSectionProps) {
           {t('hero.badge')}
         </span>
 
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
           {t('hero.headline')}
         </h1>
 
-        <p className="mx-auto max-w-2xl text-lg text-muted-foreground sm:text-xl">
+        <p className="mx-auto max-w-2xl text-base text-muted-foreground sm:text-xl">
           {t('hero.subheadline')}
         </p>
 

--- a/app/components/landing/JoinBetaSection.tsx
+++ b/app/components/landing/JoinBetaSection.tsx
@@ -11,7 +11,7 @@ export function JoinBetaSection({ className }: JoinBetaSectionProps) {
   const { t } = useTranslation('landing')
 
   return (
-    <section id="join-beta" className={cn('bg-muted/40 px-4 py-24', className)}>
+    <section id="join-beta" className={cn('bg-muted/40 px-4 py-16 sm:py-24', className)}>
       <div className="mx-auto max-w-md text-center">
         <span className="mb-3 inline-block rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
           {t('beta.badge')}

--- a/app/components/landing/LandingNav.tsx
+++ b/app/components/landing/LandingNav.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Activity } from 'lucide-react'
+import { Activity, Menu, X } from 'lucide-react'
 import { Link, useLocation } from 'react-router'
 import { cn } from '~/lib/utils'
 import { ThemeToggle } from '~/components/layout/ThemeToggle'
@@ -26,9 +27,11 @@ export function LandingNav({ className }: LandingNavProps) {
   const { t } = useTranslation('landing')
   const { pathname } = useLocation()
   const isLanding = pathname === '/'
+  const [menuOpen, setMenuOpen] = useState(false)
 
   function handleNavClick(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
     e.preventDefault()
+    setMenuOpen(false)
     const el = document.querySelector(href)
     el?.scrollIntoView({ behavior: 'smooth' })
   }
@@ -37,10 +40,59 @@ export function LandingNav({ className }: LandingNavProps) {
     return isLanding ? href : `/${href}`
   }
 
+  function renderLink(link: NavLink, mobile = false) {
+    const baseClass = mobile
+      ? 'block py-2 text-base font-medium text-muted-foreground hover:text-foreground'
+      : 'text-sm font-medium text-muted-foreground transition-colors hover:text-foreground'
+
+    if (link.route) {
+      return (
+        <Link
+          key={link.key}
+          to={link.route}
+          onClick={() => setMenuOpen(false)}
+          className={cn(
+            baseClass,
+            link.key === 'joinBeta' && !mobile &&
+              'rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground',
+            link.key === 'joinBeta' && mobile &&
+              'font-semibold text-primary hover:text-primary'
+          )}
+        >
+          {t(`nav.${link.key}` as never)}
+        </Link>
+      )
+    }
+
+    if (isLanding) {
+      return (
+        <a
+          key={link.key}
+          href={link.href}
+          onClick={(e) => handleNavClick(e, link.href!)}
+          className={baseClass}
+        >
+          {t(`nav.${link.key}` as never)}
+        </a>
+      )
+    }
+
+    return (
+      <Link
+        key={link.key}
+        to={resolveHref(link.href!)}
+        onClick={() => setMenuOpen(false)}
+        className={baseClass}
+      >
+        {t(`nav.${link.key}` as never)}
+      </Link>
+    )
+  }
+
   return (
     <header
       className={cn(
-        'fixed top-0 inset-x-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60',
+        'fixed inset-x-0 top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60',
         className
       )}
     >
@@ -54,38 +106,7 @@ export function LandingNav({ className }: LandingNavProps) {
         {/* Desktop nav + controls */}
         <div className="hidden items-center gap-6 md:flex">
           <nav className="flex items-center gap-6">
-            {NAV_LINKS.map((link) =>
-              link.route ? (
-                <Link
-                  key={link.key}
-                  to={link.route}
-                  className={cn(
-                    'text-sm font-medium text-muted-foreground transition-colors hover:text-foreground',
-                    link.key === 'joinBeta' &&
-                      'rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
-                  )}
-                >
-                  {t(`nav.${link.key}` as never)}
-                </Link>
-              ) : isLanding ? (
-                <a
-                  key={link.key}
-                  href={link.href}
-                  onClick={(e) => handleNavClick(e, link.href!)}
-                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  {t(`nav.${link.key}` as never)}
-                </a>
-              ) : (
-                <Link
-                  key={link.key}
-                  to={resolveHref(link.href!)}
-                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  {t(`nav.${link.key}` as never)}
-                </Link>
-              )
-            )}
+            {NAV_LINKS.map((link) => renderLink(link))}
           </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />
@@ -93,42 +114,29 @@ export function LandingNav({ className }: LandingNavProps) {
           </div>
         </div>
 
-        {/* Mobile: toggles right, nav scrolls left */}
-        <div className="flex items-center gap-2 md:hidden">
-          <nav className="flex items-center gap-4 overflow-x-auto">
-            {NAV_LINKS.map((link) =>
-              link.route ? (
-                <Link
-                  key={link.key}
-                  to={link.route}
-                  className="whitespace-nowrap text-sm font-medium text-muted-foreground hover:text-foreground"
-                >
-                  {t(`nav.${link.key}` as never)}
-                </Link>
-              ) : isLanding ? (
-                <a
-                  key={link.key}
-                  href={link.href}
-                  onClick={(e) => handleNavClick(e, link.href!)}
-                  className="whitespace-nowrap text-sm font-medium text-muted-foreground hover:text-foreground"
-                >
-                  {t(`nav.${link.key}` as never)}
-                </a>
-              ) : (
-                <Link
-                  key={link.key}
-                  to={resolveHref(link.href!)}
-                  className="whitespace-nowrap text-sm font-medium text-muted-foreground hover:text-foreground"
-                >
-                  {t(`nav.${link.key}` as never)}
-                </Link>
-              )
-            )}
-          </nav>
+        {/* Mobile: toggles + hamburger */}
+        <div className="flex items-center gap-1 md:hidden">
           <ThemeToggle />
           <LanguageToggle />
+          <button
+            type="button"
+            onClick={() => setMenuOpen((v) => !v)}
+            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          >
+            {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
         </div>
       </div>
+
+      {/* Mobile dropdown menu */}
+      {menuOpen && (
+        <div className="border-t bg-background px-4 pb-4 md:hidden">
+          <nav className="flex flex-col divide-y divide-border/50">
+            {NAV_LINKS.map((link) => renderLink(link, true))}
+          </nav>
+        </div>
+      )}
     </header>
   )
 }

--- a/app/components/landing/WhySynekSection.tsx
+++ b/app/components/landing/WhySynekSection.tsx
@@ -21,7 +21,7 @@ export function WhySynekSection({ className }: WhySynekSectionProps) {
   return (
     <section
       id="why-synek"
-      className={cn('bg-muted/40 px-4 py-24', className)}
+      className={cn('bg-muted/40 px-4 py-16 sm:py-24', className)}
     >
       <div className="mx-auto max-w-6xl">
         <div className="mb-12 text-center">

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -131,7 +131,7 @@ export default function RegisterPage() {
             <p className="mt-1 text-sm text-muted-foreground">{t('beta.subtitle')}</p>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-5 rounded-xl border bg-background p-8 shadow-sm">
+          <form onSubmit={handleSubmit} className="space-y-5 rounded-xl border bg-background p-6 shadow-sm sm:p-8">
             {/* Beta note */}
             <p className="rounded-lg bg-primary/5 p-3 text-sm text-muted-foreground">
               {t('beta.betaNote')}


### PR DESCRIPTION
- Replace horizontal-scroll nav with hamburger menu on mobile
- Reduce section vertical padding (py-24 → py-16 sm:py-24)
- Reduce form card padding (p-8 → p-6 sm:p-8) on contact and register
- Scale down hero headline and subheadline on mobile