### PR TITLE
feat: redesign UI with mobile nav, fix feedback form

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -5,8 +5,10 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
+  --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text',
+    system-ui, ui-sans-serif, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --radius: 0.75rem;
 }
 
 html.dark {
@@ -58,75 +60,90 @@ html.dark {
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --radius: 0.75rem;
+  --background: oklch(0.96 0 0);
+  --foreground: oklch(0.08 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.08 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.08 0 0);
+  --primary: oklch(0.08 0 0);
+  --primary-foreground: oklch(0.96 0 0);
+  --secondary: oklch(0.91 0 0);
+  --secondary-foreground: oklch(0.08 0 0);
+  --muted: oklch(0.93 0 0);
+  --muted-foreground: oklch(0.08 0 0 / 55%);
+  --accent: oklch(0.91 0 0);
+  --accent-foreground: oklch(0.08 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0 0 0 / 0.08);
+  --input: oklch(0.93 0 0);
+  --ring: oklch(0.08 0 0 / 0.4);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --surface-1: oklch(1 0 0);
+  --surface-2: oklch(0.93 0 0);
+  --surface-3: oklch(0.91 0 0);
+  --foreground-secondary: oklch(0.08 0 0 / 55%);
+  --foreground-tertiary: oklch(0.08 0 0 / 30%);
+  --separator: oklch(0 0 0 / 0.05);
+  --sidebar: oklch(0.98 0 0);
+  --sidebar-foreground: oklch(0.08 0 0);
+  --sidebar-primary: oklch(0.08 0 0);
+  --sidebar-primary-foreground: oklch(0.96 0 0);
+  --sidebar-accent: oklch(0.91 0 0);
+  --sidebar-accent-foreground: oklch(0.08 0 0);
+  --sidebar-border: oklch(0 0 0 / 0.08);
+  --sidebar-ring: oklch(0.08 0 0 / 0.4);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.08 0 0);
+  --foreground: oklch(0.98 0 0);
+  --card: oklch(0.13 0 0);
+  --card-foreground: oklch(0.98 0 0);
+  --popover: oklch(0.17 0 0);
+  --popover-foreground: oklch(0.98 0 0);
+  --primary: oklch(0.98 0 0);
+  --primary-foreground: oklch(0.08 0 0);
+  --secondary: oklch(0.22 0 0);
+  --secondary-foreground: oklch(0.98 0 0);
+  --muted: oklch(0.17 0 0);
+  --muted-foreground: oklch(0.98 0 0 / 60%);
+  --accent: oklch(0.22 0 0);
+  --accent-foreground: oklch(0.98 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --border: oklch(1 0 0 / 0.10);
+  --input: oklch(1 0 0 / 0.08);
+  --ring: oklch(0.98 0 0 / 0.4);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --surface-1: oklch(0.13 0 0);
+  --surface-2: oklch(0.17 0 0);
+  --surface-3: oklch(0.22 0 0);
+  --foreground-secondary: oklch(0.98 0 0 / 60%);
+  --foreground-tertiary: oklch(0.98 0 0 / 35%);
+  --separator: oklch(1 0 0 / 0.06);
+  --sidebar: oklch(0.13 0 0);
+  --sidebar-foreground: oklch(0.98 0 0);
+  --sidebar-primary: oklch(0.98 0 0);
+  --sidebar-primary-foreground: oklch(0.08 0 0);
+  --sidebar-accent: oklch(0.22 0 0);
+  --sidebar-accent-foreground: oklch(0.98 0 0);
+  --sidebar-border: oklch(1 0 0 / 0.10);
+  --sidebar-ring: oklch(0.98 0 0 / 0.4);
 }
 
 @layer base {
@@ -135,5 +152,16 @@ html.dark {
   }
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+@layer utilities {
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .pt-safe {
+    padding-top: env(safe-area-inset-top, 0px);
   }
 }

--- a/app/components/calendar/DayColumn.tsx
+++ b/app/components/calendar/DayColumn.tsx
@@ -56,32 +56,38 @@ export function DayColumn({
   return (
     <div
       className={cn(
-        'rounded-lg border bg-card p-2 min-h-[200px] flex flex-col',
-        isWeekend && 'bg-muted/30',
-        isCurrentDay && 'border-primary ring-1 ring-primary/20',
+        'rounded-xl bg-surface-1 p-3 min-h-[200px] flex flex-col ring-1 ring-[color:var(--border)]',
+        isWeekend && 'bg-surface-2/40',
       )}
     >
       <div className="flex items-center justify-between mb-2">
-        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          {t(`daysShort.${day}`)}
-        </h3>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1.5">
+          <h3 className="text-[10px] font-semibold text-[color:var(--foreground-secondary)] uppercase tracking-[0.08em]">
+            {t(`daysShort.${day}`)}
+          </h3>
           {dayDate && (
-            <span className={cn('text-xs normal-case', isCurrentDay ? 'text-primary font-semibold' : 'text-muted-foreground')}>
-              {format(dayDate, 'dd-MM-yy')}
+            <span
+              className={cn(
+                'flex h-7 w-7 items-center justify-center rounded-full text-[11px] font-semibold tabular-nums',
+                isCurrentDay
+                  ? 'bg-foreground text-background'
+                  : 'text-[color:var(--foreground-secondary)]'
+              )}
+            >
+              {format(dayDate, 'd')}
             </span>
           )}
-          {!readonly && !!onAddSession && !hasRestDay && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 sm:h-5 sm:w-5"
-              onClick={() => onAddSession(day)}
-            >
-              <Plus className="h-3 w-3" />
-            </Button>
-          )}
         </div>
+        {!readonly && !!onAddSession && !hasRestDay && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 sm:h-6 sm:w-6"
+            onClick={() => onAddSession(day)}
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        )}
       </div>
 
       <div className="flex flex-col gap-1.5 flex-1">
@@ -106,7 +112,7 @@ export function DayColumn({
         {sessions.length === 0 && !readonly && !!onAddSession && (
           <button
             onClick={() => onAddSession(day)}
-            className="flex-1 flex items-center justify-center border border-dashed rounded-md text-xs text-muted-foreground hover:border-primary hover:text-primary transition-colors min-h-[60px]"
+            className="flex-1 flex items-center justify-center border border-dashed border-[color:var(--border)] rounded-xl text-xs text-[color:var(--foreground-tertiary)] hover:border-foreground/20 hover:text-[color:var(--foreground-secondary)] transition-colors min-h-[56px] w-full"
           >
             <Plus className="h-3 w-3 mr-1" />
             {t('actions.add')}
@@ -114,8 +120,8 @@ export function DayColumn({
         )}
 
         {sessions.length === 0 && (readonly || !onAddSession) && (
-          <div className="flex-1 flex items-center justify-center text-[10px] text-muted-foreground min-h-[60px]">
-            -
+          <div className="flex-1 flex items-center justify-center text-[10px] text-[color:var(--foreground-tertiary)] min-h-[60px]">
+            —
           </div>
         )}
       </div>

--- a/app/components/calendar/SessionCard.tsx
+++ b/app/components/calendar/SessionCard.tsx
@@ -11,17 +11,23 @@ import {
   Activity,
   Pencil,
   Trash2,
-  Clock,
-  MapPin,
   Zap,
+  MoreVertical,
 } from 'lucide-react';
-import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Textarea } from '~/components/ui/textarea';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu';
 import { CompletionToggle } from '~/components/training/CompletionToggle';
 import { AthleteFeedback } from '~/components/training/AthleteFeedback';
 import { PerformanceEntry } from '~/components/training/PerformanceEntry';
 import { trainingTypeConfig } from '~/lib/utils/training-types';
+import { cn } from '~/lib/utils';
 import type { TrainingSession, AthleteSessionUpdate } from '~/types/training';
 
 const iconMap: Record<string, React.ElementType> = {
@@ -72,58 +78,66 @@ export function SessionCard({
   useEffect(() => {
     setCoachFeedback(session.coachPostFeedback ?? '');
   }, [session.id, session.coachPostFeedback]);
+
   const config = trainingTypeConfig[session.trainingType];
   const Icon = iconMap[config.icon] ?? Footprints;
-
   const isRestDay = session.trainingType === 'rest_day';
 
   return (
     <div
-      className={`group rounded-md border p-2 transition-colors hover:shadow-sm ${
-        session.isCompleted
-          ? 'bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-900'
-          : config.bgColor
-      }`}
+      className={cn(
+        'group rounded-xl p-3 transition-all ring-1 ring-[color:var(--border)]',
+        session.isCompleted ? 'bg-surface-2 opacity-70' : 'bg-surface-1'
+      )}
     >
       <div className="flex items-start justify-between gap-1">
-        <div className="flex items-center gap-1.5 min-w-0">
-          <Icon className={`h-3.5 w-3.5 shrink-0 ${config.color}`} />
-          <Badge
-            variant="secondary"
-            className={`text-[10px] px-1.5 py-0 ${config.color} ${config.bgColor} border-0`}
-          >
-            {t(`common:trainingTypes.${session.trainingType}`)}
-          </Badge>
-        </div>
+        {/* Sport badge pill — sport color only here */}
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full',
+            config.bgColor,
+            config.color
+          )}
+        >
+          <Icon className="h-2.5 w-2.5" />
+          {t(`common:trainingTypes.${session.trainingType}` as never)}
+        </span>
 
         {!readonly && (onEdit || onDelete) && (
-          <div className="flex gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
-            {onEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 sm:h-5 sm:w-5"
-                onClick={() => onEdit(session)}
+                className="h-7 w-7 shrink-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
               >
-                <Pencil className="h-3 w-3" />
+                <MoreVertical className="h-3.5 w-3.5" />
               </Button>
-            )}
-            {onDelete && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 sm:h-5 sm:w-5 text-destructive"
-                onClick={() => onDelete(session.id)}
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
-            )}
-          </div>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-36">
+              {onEdit && (
+                <DropdownMenuItem onClick={() => onEdit(session)}>
+                  <Pencil className="mr-2 h-3.5 w-3.5" />
+                  {t('common:actions.edit')}
+                </DropdownMenuItem>
+              )}
+              {onEdit && onDelete && <DropdownMenuSeparator />}
+              {onDelete && (
+                <DropdownMenuItem
+                  onClick={() => onDelete(session.id)}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="mr-2 h-3.5 w-3.5" />
+                  {t('common:actions.delete')}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
 
       {session.description && (
-        <p className="text-xs mt-1 line-clamp-2">{session.description}</p>
+        <p className="text-sm font-medium mt-2 line-clamp-2 leading-snug">{session.description}</p>
       )}
 
       {session.coachComments && (
@@ -134,20 +148,18 @@ export function SessionCard({
 
       <div className="flex flex-wrap gap-2 mt-1.5">
         {session.plannedDurationMinutes != null && (
-          <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
-            <Clock className="h-2.5 w-2.5" />
+          <span className="text-xs text-[color:var(--foreground-secondary)]">
             {session.plannedDurationMinutes} {t('training:units.min')}
           </span>
         )}
         {session.plannedDistanceKm != null && (
-          <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
-            <MapPin className="h-2.5 w-2.5" />
+          <span className="text-xs text-[color:var(--foreground-secondary)]">
             {session.plannedDistanceKm} {t('training:units.km')}
           </span>
         )}
       </div>
 
-      {/* Actual performance chips — shown when completed and at least one field is set */}
+      {/* Actual performance chips — shown when completed */}
       {session.isCompleted &&
         (session.actualDurationMinutes != null ||
           session.actualDistanceKm != null ||
@@ -155,46 +167,46 @@ export function SessionCard({
           session.avgHeartRate != null ||
           session.maxHeartRate != null ||
           session.rpe != null) && (
-          <div className="flex flex-wrap gap-1 mt-1.5 pt-1.5 border-t border-dashed">
+          <div className="flex flex-wrap gap-1 mt-1.5 pt-1.5 border-t border-[color:var(--separator)]">
             {session.actualDurationMinutes != null && (
-              <span className="text-[10px] bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded">
+              <span className="text-[10px] bg-surface-2 text-[color:var(--foreground-secondary)] px-1.5 py-0.5 rounded-md">
                 {t('training:actualPerformance.duration')}: {session.actualDurationMinutes}{' '}
                 {t('training:units.min')}
               </span>
             )}
             {session.actualDistanceKm != null && (
-              <span className="text-[10px] bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded">
+              <span className="text-[10px] bg-surface-2 text-[color:var(--foreground-secondary)] px-1.5 py-0.5 rounded-md">
                 {t('training:actualPerformance.distance')}: {session.actualDistanceKm}{' '}
                 {t('training:units.km')}
               </span>
             )}
             {session.actualPace != null && (
-              <span className="text-[10px] bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded">
+              <span className="text-[10px] bg-surface-2 text-[color:var(--foreground-secondary)] px-1.5 py-0.5 rounded-md">
                 {t('training:actualPerformance.pace')}: {session.actualPace}{' '}
                 {t('training:units.perKm')}
               </span>
             )}
             {session.avgHeartRate != null && (
-              <span className="text-[10px] bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded">
+              <span className="text-[10px] bg-surface-2 text-[color:var(--foreground-secondary)] px-1.5 py-0.5 rounded-md">
                 {t('training:actualPerformance.avgHr')}: {session.avgHeartRate}{' '}
                 {t('training:units.bpm')}
               </span>
             )}
             {session.maxHeartRate != null && (
-              <span className="text-[10px] bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded">
+              <span className="text-[10px] bg-surface-2 text-[color:var(--foreground-secondary)] px-1.5 py-0.5 rounded-md">
                 {t('training:actualPerformance.maxHr')}: {session.maxHeartRate}{' '}
                 {t('training:units.bpm')}
               </span>
             )}
             {session.rpe != null && (
-              <span className="text-[10px] bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded">
+              <span className="text-[10px] bg-surface-2 text-[color:var(--foreground-secondary)] px-1.5 py-0.5 rounded-md">
                 {t('training:actualPerformance.rpe')}: {session.rpe}/10
               </span>
             )}
             {session.stravaActivityId != null && (
               <span
                 title={t('strava.syncedBadge')}
-                className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-orange-100 text-orange-600 dark:bg-orange-950 dark:text-orange-400"
+                className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-md bg-orange-100 text-orange-600 dark:bg-orange-950 dark:text-orange-400"
               >
                 <Zap className="h-2.5 w-2.5" />
                 Strava
@@ -205,7 +217,7 @@ export function SessionCard({
 
       {/* Athlete notes — shown to coach when the athlete has left notes */}
       {!athleteMode && session.athleteNotes && (
-        <div className="mt-1.5 pt-1.5 border-t border-dashed">
+        <div className="mt-1.5 pt-1.5 border-t border-[color:var(--separator)]">
           <p className="text-[10px] font-medium text-muted-foreground mb-0.5">
             {t('training:athleteNotes.label')}
           </p>
@@ -215,7 +227,7 @@ export function SessionCard({
 
       {/* Coach post-training feedback — shown when completed */}
       {session.isCompleted && (
-        <div className="mt-1.5 pt-1.5 border-t border-dashed">
+        <div className="mt-1.5 pt-1.5 border-t border-[color:var(--separator)]">
           {!athleteMode ? (
             <div>
               <p className="text-[10px] font-medium text-muted-foreground mb-0.5">
@@ -251,7 +263,7 @@ export function SessionCard({
 
       {/* Athlete-specific features */}
       {(athleteMode || showAthleteControls) && !isRestDay && (
-        <div className="mt-2 pt-1.5 border-t border-dashed space-y-1">
+        <div className="mt-2 pt-1.5 border-t border-[color:var(--separator)] space-y-1">
           <CompletionToggle
             isCompleted={session.isCompleted}
             onChange={(completed) =>
@@ -280,7 +292,6 @@ export function SessionCard({
             notes={session.athleteNotes}
             onChange={(notes) => onUpdateNotes?.(session.id, notes)}
           />
-
         </div>
       )}
     </div>

--- a/app/components/calendar/WeekGrid.tsx
+++ b/app/components/calendar/WeekGrid.tsx
@@ -1,5 +1,15 @@
+import { useState } from 'react';
+import { addDays, format, isToday, parseISO } from 'date-fns';
+import { cn } from '~/lib/utils';
+import { trainingTypeConfig } from '~/lib/utils/training-types';
 import { DayColumn } from './DayColumn';
-import { DAYS_OF_WEEK, type DayOfWeek, type TrainingSession, type SessionsByDay, type AthleteSessionUpdate } from '~/types/training';
+import {
+  DAYS_OF_WEEK,
+  type DayOfWeek,
+  type TrainingSession,
+  type SessionsByDay,
+  type AthleteSessionUpdate,
+} from '~/types/training';
 
 interface WeekGridProps {
   sessionsByDay: SessionsByDay;
@@ -19,6 +29,67 @@ interface WeekGridProps {
   onSyncStrava?: () => void;
 }
 
+function getDefaultSelectedDay(weekStart: string | undefined): DayOfWeek {
+  if (!weekStart) return 'monday';
+  const monday = parseISO(weekStart);
+  for (let i = 0; i < 7; i++) {
+    if (isToday(addDays(monday, i))) return DAYS_OF_WEEK[i];
+  }
+  return 'monday';
+}
+
+interface MobileDayStripProps {
+  weekStart: string | undefined;
+  sessionsByDay: SessionsByDay;
+  selectedDay: DayOfWeek;
+  onSelectDay: (day: DayOfWeek) => void;
+}
+
+function MobileDayStrip({ weekStart, sessionsByDay, selectedDay, onSelectDay }: MobileDayStripProps) {
+  const monday = weekStart ? parseISO(weekStart) : null;
+
+  return (
+    <div className="flex justify-between px-1 mb-2">
+      {DAYS_OF_WEEK.map((day, i) => {
+        const dayDate = monday ? addDays(monday, i) : null;
+        const isCurrentDay = dayDate ? isToday(dayDate) : false;
+        const isSelected = selectedDay === day;
+        const sessions = sessionsByDay[day] ?? [];
+        const hasSessions = sessions.length > 0;
+        const firstSessionType = hasSessions ? sessions[0].trainingType : null;
+        const dotColor = firstSessionType ? trainingTypeConfig[firstSessionType].bgColor : 'bg-foreground/30';
+
+        return (
+          <button
+            key={day}
+            onClick={() => onSelectDay(day)}
+            className="flex flex-col items-center justify-center gap-0.5 min-h-[44px] min-w-[44px] py-1"
+          >
+            <span className="text-[10px] font-semibold uppercase text-[color:var(--foreground-tertiary)]">
+              {dayDate ? format(dayDate, 'EEEEE') : day[0].toUpperCase()}
+            </span>
+            <span
+              className={cn(
+                'flex h-7 w-7 items-center justify-center rounded-full text-sm font-medium',
+                isCurrentDay && 'bg-foreground text-background',
+                isSelected && !isCurrentDay && 'ring-1 ring-foreground/50',
+                !isCurrentDay && !isSelected && 'text-foreground'
+              )}
+            >
+              {dayDate ? format(dayDate, 'd') : ''}
+            </span>
+            {hasSessions ? (
+              <span className={cn('h-1 w-1 rounded-full mt-0.5', dotColor)} />
+            ) : (
+              <span className="h-1 w-1 mt-0.5" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function WeekGrid({
   sessionsByDay,
   weekStart,
@@ -35,28 +106,56 @@ export function WeekGrid({
   stravaConnected,
   onSyncStrava,
 }: WeekGridProps) {
+  const [selectedDay, setSelectedDay] = useState<DayOfWeek>(() =>
+    getDefaultSelectedDay(weekStart)
+  );
+
+  const dayColumnProps = {
+    readonly,
+    athleteMode,
+    showAthleteControls,
+    onAddSession,
+    onEditSession,
+    onDeleteSession,
+    onToggleComplete,
+    weekStart,
+    onUpdateNotes,
+    onUpdatePerformance,
+    onUpdateCoachPostFeedback,
+    stravaConnected,
+    onSyncStrava,
+  };
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-2">
-      {DAYS_OF_WEEK.map((day) => (
-        <DayColumn
-          key={day}
-          day={day}
-          sessions={sessionsByDay[day] ?? []}
-          readonly={readonly}
-          athleteMode={athleteMode}
-          showAthleteControls={showAthleteControls}
-          onAddSession={onAddSession}
-          onEditSession={onEditSession}
-          onDeleteSession={onDeleteSession}
-          onToggleComplete={onToggleComplete}
+    <>
+      {/* Mobile: day strip + single day view */}
+      <div className="md:hidden">
+        <MobileDayStrip
           weekStart={weekStart}
-          onUpdateNotes={onUpdateNotes}
-          onUpdatePerformance={onUpdatePerformance}
-          onUpdateCoachPostFeedback={onUpdateCoachPostFeedback}
-          stravaConnected={stravaConnected}
-          onSyncStrava={onSyncStrava}
+          sessionsByDay={sessionsByDay}
+          selectedDay={selectedDay}
+          onSelectDay={setSelectedDay}
         />
-      ))}
-    </div>
+        <div className="mt-3">
+          <DayColumn
+            day={selectedDay}
+            sessions={sessionsByDay[selectedDay] ?? []}
+            {...dayColumnProps}
+          />
+        </div>
+      </div>
+
+      {/* Desktop: 7-column grid */}
+      <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-7 gap-1.5">
+        {DAYS_OF_WEEK.map((day) => (
+          <DayColumn
+            key={day}
+            day={day}
+            sessions={sessionsByDay[day] ?? []}
+            {...dayColumnProps}
+          />
+        ))}
+      </div>
+    </>
   );
 }

--- a/app/components/calendar/WeekNavigation.tsx
+++ b/app/components/calendar/WeekNavigation.tsx
@@ -10,7 +10,6 @@ import {
   parseWeekId,
 } from '~/lib/utils/date';
 import { useLocalePath } from '~/lib/hooks/useLocalePath';
-import { cn } from '~/lib/utils';
 
 interface WeekNavigationProps {
   weekId: string;
@@ -26,27 +25,29 @@ export function WeekNavigation({ weekId, basePath }: WeekNavigationProps) {
   const isCurrentWeek = weekId === getCurrentWeekId();
 
   return (
-    <div className="flex items-center gap-1.5 sm:gap-3 w-full px-2 sm:px-4">
+    <div className="flex flex-1 items-center gap-1 sm:gap-2 ml-auto">
       <Button
-        variant="outline"
+        variant="ghost"
         size="icon"
-        className="h-8 w-8 sm:h-9 sm:w-9"
+        className="h-11 w-11 rounded-full shrink-0"
         onClick={() => navigate(localePath(`/${basePath}/week/${getPrevWeekId(weekId)}`))}
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
 
-      <div className="flex-1 text-center">
-        <h2 className="text-sm sm:text-lg font-semibold">
+      <div className="flex-1 text-center min-w-0 px-1">
+        <span className="text-sm font-semibold tracking-tight whitespace-nowrap">
           {t('week')} {weekNumber}
-        </h2>
-        <p className="text-[10px] sm:text-sm text-muted-foreground">{formatted}</p>
+        </span>
+        <span className="hidden sm:inline text-xs text-[color:var(--foreground-secondary)] ml-1.5">
+          · {formatted}
+        </span>
       </div>
 
       <Button
-        variant="outline"
+        variant="ghost"
         size="icon"
-        className="h-8 w-8 sm:h-9 sm:w-9"
+        className="h-11 w-11 rounded-full shrink-0"
         onClick={() => navigate(localePath(`/${basePath}/week/${getNextWeekId(weekId)}`))}
       >
         <ChevronRight className="h-4 w-4" />
@@ -57,7 +58,7 @@ export function WeekNavigation({ weekId, basePath }: WeekNavigationProps) {
         size="sm"
         disabled={isCurrentWeek}
         onClick={() => navigate(localePath(`/${basePath}/week/${getCurrentWeekId()}`))}
-        className="ml-1 sm:ml-2 text-xs"
+        className="text-xs px-3 py-1.5 rounded-full bg-surface-2 hover:bg-surface-3 min-h-[36px] transition-colors shrink-0"
       >
         {t('common:today', 'Today')}
       </Button>

--- a/app/components/calendar/WeekSummary.tsx
+++ b/app/components/calendar/WeekSummary.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Textarea } from '~/components/ui/textarea';
 import { Button } from '~/components/ui/button';
+import { cn } from '~/lib/utils';
 import { loadTypeConfig } from '~/lib/utils/training-types';
 import { LOAD_TYPES, type WeekPlan, type WeekStats } from '~/types/training';
 
@@ -60,7 +61,7 @@ export function WeekSummary({
             variant="ghost"
             size="icon"
             onClick={() => setIsExpanded((v) => !v)}
-            className="h-7 w-7"
+            className="h-7 w-7 text-[color:var(--foreground-tertiary)] hover:text-foreground transition-colors"
           >
             {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
           </Button>
@@ -73,7 +74,7 @@ export function WeekSummary({
 
             {/* ── LEFT: Plan ── */}
             <div className="px-6 pb-6 space-y-4">
-              <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground pt-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--foreground-tertiary)] pt-2">
                 {t('coach:weekSummary.plan')}
               </p>
 
@@ -84,7 +85,11 @@ export function WeekSummary({
                 </p>
                 {readonly ? (
                   weekPlan.loadType ? (
-                    <span className={`inline-flex items-center h-7 text-xs px-2.5 rounded-md font-medium ${loadTypeConfig[weekPlan.loadType].bgColor} ${loadTypeConfig[weekPlan.loadType].color}`}>
+                    <span className={cn(
+                      'inline-flex items-center rounded-full h-8 text-xs px-3 font-medium',
+                      loadTypeConfig[weekPlan.loadType].bgColor,
+                      loadTypeConfig[weekPlan.loadType].color
+                    )}>
                       {t(`common:loadType.${weekPlan.loadType}`)}
                     </span>
                   ) : (
@@ -100,7 +105,10 @@ export function WeekSummary({
                           key={lt}
                           variant={isSelected ? 'default' : 'outline'}
                           size="sm"
-                          className={`h-7 text-xs px-2.5 ${isSelected ? `${config.bgColor} ${config.color} border-0 hover:opacity-80` : ''}`}
+                          className={cn(
+                            'rounded-full h-8 text-xs px-3',
+                            isSelected && `${config.bgColor} ${config.color} border-0 hover:opacity-80`
+                          )}
                           onClick={() => onUpdate?.({ loadType: isSelected ? null : lt })}
                         >
                           {t(`common:loadType.${lt}`)}
@@ -167,7 +175,7 @@ export function WeekSummary({
 
             {/* ── RIGHT: Performance ── */}
             <div className="px-6 pb-6 space-y-4">
-              <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground pt-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--foreground-tertiary)] pt-2">
                 {t('coach:weekSummary.performance')}
               </p>
 
@@ -204,9 +212,9 @@ export function WeekSummary({
                     <span>{stats.completedSessions}/{stats.totalSessions}</span>
                     <span>{Math.round(stats.completionPercentage)}%</span>
                   </div>
-                  <div className="h-2 bg-muted rounded-full overflow-hidden">
+                  <div className="h-2 bg-surface-2 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-green-500 rounded-full transition-all duration-500"
+                      className="h-full bg-foreground rounded-full transition-all duration-500"
                       style={{ width: `${stats.completionPercentage}%` }}
                     />
                   </div>

--- a/app/components/landing/ContactSection.tsx
+++ b/app/components/landing/ContactSection.tsx
@@ -42,23 +42,25 @@ export function ContactSection({ className }: ContactSectionProps) {
   }
 
   return (
-    <section id="contact" className={cn('bg-muted/40 px-4 py-16 sm:py-24', className)}>
+    <section id="contact" className={cn('bg-surface-2 px-4 py-16 sm:py-24', className)}>
       <div className="mx-auto max-w-md">
-        <div className="mb-8 text-center">
-          <h2 className="text-3xl font-bold tracking-tight">{t('contact.title')}</h2>
-          <p className="mt-2 text-muted-foreground">{t('contact.subtitle')}</p>
-          <p className="mt-1 text-sm font-medium text-primary">{t('contact.betaNote')}</p>
-        </div>
+        {!isSuccess && (
+          <div className="mb-8 text-center">
+            <h2 className="text-3xl font-bold tracking-tight">{t('contact.title')}</h2>
+            <p className="mt-2 text-muted-foreground">{t('contact.subtitle')}</p>
+            <p className="mt-1 text-sm font-medium text-primary">{t('contact.betaNote')}</p>
+          </div>
+        )}
 
         {isSuccess ? (
-          <div className="flex flex-col items-center gap-3 rounded-xl border bg-background p-8 text-center shadow-sm">
-            <CheckCircle2 className="h-10 w-10 text-primary" />
+          <div className="flex flex-col items-center gap-3 rounded-2xl bg-surface-1 p-8 text-center">
+            <CheckCircle2 className="h-10 w-10 text-muted-foreground" />
             <p className="font-medium">{t('contact.submitSuccess')}</p>
           </div>
         ) : (
           <form
             onSubmit={handleSubmit}
-            className="space-y-4 rounded-xl border bg-background p-6 shadow-sm sm:p-8"
+            className="space-y-4 rounded-2xl bg-surface-1 p-6 sm:p-8"
           >
             <div className="space-y-1">
               <label htmlFor="contact-name" className="text-sm font-medium">

--- a/app/components/landing/FeaturesSection.tsx
+++ b/app/components/landing/FeaturesSection.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next'
-import { CheckCircle2 } from 'lucide-react'
 import { cn } from '~/lib/utils'
 
 interface FeaturesSectionProps {
@@ -30,7 +29,7 @@ export function FeaturesSection({ className }: FeaturesSectionProps) {
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {items.map(({ n, title, desc }) => (
             <div key={n} className="flex gap-4">
-              <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+              <div className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/50" />
               <div>
                 <h3 className="font-semibold">{title}</h3>
                 <p className="mt-1 text-sm text-muted-foreground">{desc}</p>

--- a/app/components/landing/HeroSection.tsx
+++ b/app/components/landing/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { cn } from '~/lib/utils'
 import { Button } from '~/components/ui/button'
+import { Link, useParams } from 'react-router'
 
 interface HeroSectionProps {
   className?: string
@@ -8,6 +9,7 @@ interface HeroSectionProps {
 
 export function HeroSection({ className }: HeroSectionProps) {
   const { t } = useTranslation('landing')
+  const { locale = 'pl' } = useParams<{ locale: string }>()
 
   function scrollTo(id: string) {
     document.querySelector(id)?.scrollIntoView({ behavior: 'smooth' })
@@ -17,17 +19,17 @@ export function HeroSection({ className }: HeroSectionProps) {
     <section
       id="get-started"
       className={cn(
-        'flex min-h-screen flex-col items-center justify-center px-4 pt-14 text-center',
+        'flex min-h-screen flex-col items-center justify-center px-4 pt-14 text-center bg-background',
         className
       )}
     >
       <div className="mx-auto max-w-3xl space-y-6">
         {/* Beta badge */}
-        <span className="inline-block rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+        <span className="inline-block rounded-full border border-border bg-surface-2 px-3 py-1 text-xs text-muted-foreground">
           {t('hero.badge')}
         </span>
 
-        <h1 className="text-3xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+        <h1 className="text-4xl font-bold tracking-tight leading-none sm:text-6xl lg:text-7xl">
           {t('hero.headline')}
         </h1>
 
@@ -36,12 +38,12 @@ export function HeroSection({ className }: HeroSectionProps) {
         </p>
 
         <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-          <Button size="lg" onClick={() => scrollTo('#join-beta')}>
-            {t('hero.ctaJoinBeta')}
+          <Button asChild size="lg">
+            <Link to={`/${locale}/register`}>{t('beta.cta')}</Link>
           </Button>
           <button
             onClick={() => scrollTo('#log-in')}
-            className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+            className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
           >
             {t('hero.ctaLogIn')}
           </button>

--- a/app/components/landing/JoinBetaSection.tsx
+++ b/app/components/landing/JoinBetaSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router'
+import { Link, useParams } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { cn } from '~/lib/utils'
 
@@ -9,18 +9,22 @@ interface JoinBetaSectionProps {
 
 export function JoinBetaSection({ className }: JoinBetaSectionProps) {
   const { t } = useTranslation('landing')
+  const { locale = 'pl' } = useParams<{ locale: string }>()
 
   return (
-    <section id="join-beta" className={cn('bg-muted/40 px-4 py-16 sm:py-24', className)}>
+    <section
+      id="join-beta"
+      className={cn('bg-background border-t border-b border-[color:var(--separator)] px-4 py-16 sm:py-24', className)}
+    >
       <div className="mx-auto max-w-md text-center">
-        <span className="mb-3 inline-block rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+        <span className="mb-3 inline-block rounded-full border border-border bg-surface-2 px-3 py-1 text-xs text-muted-foreground">
           {t('beta.badge')}
         </span>
         <h2 className="text-3xl font-bold tracking-tight">{t('beta.title')}</h2>
         <p className="mt-2 text-muted-foreground">{t('beta.subtitle')}</p>
         <div className="mt-8">
           <Button asChild size="lg">
-            <Link to="/register">{t('beta.cta')}</Link>
+            <Link to={`/${locale}/register`}>{t('beta.cta')}</Link>
           </Button>
         </div>
       </div>

--- a/app/components/landing/LandingNav.tsx
+++ b/app/components/landing/LandingNav.tsx
@@ -1,23 +1,15 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Activity, Menu, X } from 'lucide-react'
-import { Link, useLocation } from 'react-router'
+import { Menu, X } from 'lucide-react'
+import { Link, useLocation, useParams } from 'react-router'
 import { cn } from '~/lib/utils'
 import { ThemeToggle } from '~/components/layout/ThemeToggle'
 import { LanguageToggle } from '~/components/layout/LanguageToggle'
+import { Logo } from '~/components/layout/Logo'
 
 type AnchorLink = { key: string; href: string; route?: never }
-type RouteLink = { key: string; route: string; href?: never }
+type RouteLink = { key: string; routeKey: string; href?: never }
 type NavLink = AnchorLink | RouteLink
-
-const NAV_LINKS: NavLink[] = [
-  { key: 'getStarted', href: '#get-started' },
-  { key: 'whySynek', href: '#why-synek' },
-  { key: 'features', href: '#features' },
-  { key: 'logIn', route: '/login' },
-  { key: 'joinBeta', route: '/register' },
-  { key: 'contact', href: '#contact' },
-]
 
 interface LandingNavProps {
   className?: string
@@ -26,8 +18,23 @@ interface LandingNavProps {
 export function LandingNav({ className }: LandingNavProps) {
   const { t } = useTranslation('landing')
   const { pathname } = useLocation()
-  const isLanding = pathname === '/'
+  const { locale = 'pl' } = useParams<{ locale: string }>()
   const [menuOpen, setMenuOpen] = useState(false)
+
+  const MARKETING_LINKS: NavLink[] = [
+    { key: 'getStarted', href: '#get-started' },
+    { key: 'whySynek', href: '#why-synek' },
+    { key: 'features', href: '#features' },
+    { key: 'contact', href: '#contact' },
+  ]
+
+  const AUTH_LINKS: NavLink[] = [
+    { key: 'logIn', routeKey: `/${locale}/login` },
+    { key: 'joinBeta', routeKey: `/${locale}/register` },
+  ]
+
+  // Landing is at /:locale (only one path segment after root)
+  const isLanding = pathname.split('/').filter(Boolean).length === 1
 
   function handleNavClick(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
     e.preventDefault()
@@ -40,31 +47,12 @@ export function LandingNav({ className }: LandingNavProps) {
     return isLanding ? href : `/${href}`
   }
 
-  function renderLink(link: NavLink, mobile = false) {
+  function renderMarketingLink(link: NavLink, mobile = false) {
     const baseClass = mobile
       ? 'block py-2 text-base font-medium text-muted-foreground hover:text-foreground'
       : 'text-sm font-medium text-muted-foreground transition-colors hover:text-foreground'
 
-    if (link.route) {
-      return (
-        <Link
-          key={link.key}
-          to={link.route}
-          onClick={() => setMenuOpen(false)}
-          className={cn(
-            baseClass,
-            link.key === 'joinBeta' && !mobile &&
-              'rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground',
-            link.key === 'joinBeta' && mobile &&
-              'font-semibold text-primary hover:text-primary'
-          )}
-        >
-          {t(`nav.${link.key}` as never)}
-        </Link>
-      )
-    }
-
-    if (isLanding) {
+    if (isLanding && 'href' in link) {
       return (
         <a
           key={link.key}
@@ -77,12 +65,49 @@ export function LandingNav({ className }: LandingNavProps) {
       )
     }
 
+    const href = 'href' in link ? resolveHref(link.href!) : (link as RouteLink).routeKey
     return (
       <Link
         key={link.key}
-        to={resolveHref(link.href!)}
+        to={href}
         onClick={() => setMenuOpen(false)}
         className={baseClass}
+      >
+        {t(`nav.${link.key}` as never)}
+      </Link>
+    )
+  }
+
+  function renderAuthLink(link: RouteLink, mobile = false) {
+    if (mobile) {
+      return (
+        <Link
+          key={link.key}
+          to={link.routeKey}
+          onClick={() => setMenuOpen(false)}
+          className={cn(
+            'block py-2 text-base font-medium',
+            link.key === 'joinBeta'
+              ? 'font-semibold text-primary hover:text-primary'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {t(`nav.${link.key}` as never)}
+        </Link>
+      )
+    }
+
+    return (
+      <Link
+        key={link.key}
+        to={link.routeKey}
+        onClick={() => setMenuOpen(false)}
+        className={cn(
+          'text-sm font-medium transition-colors',
+          link.key === 'joinBeta'
+            ? 'rounded-md bg-primary px-3 py-1.5 text-primary-foreground hover:bg-primary/90'
+            : 'rounded-md border border-border px-3 py-1.5 text-foreground hover:bg-muted'
+        )}
       >
         {t(`nav.${link.key}` as never)}
       </Link>
@@ -92,30 +117,34 @@ export function LandingNav({ className }: LandingNavProps) {
   return (
     <header
       className={cn(
-        'fixed inset-x-0 top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60',
+        'fixed inset-x-0 top-0 z-50 border-b border-[color:var(--separator)] bg-surface-1/80 backdrop-blur-md',
         className
       )}
     >
-      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+      <div className="mx-auto flex h-14 max-w-6xl items-center px-4">
         {/* Logo */}
-        <div className="flex items-center gap-2 font-bold">
-          <Activity className="h-5 w-5 text-primary" />
-          <span>Synek</span>
-        </div>
+        <Logo size="sm" />
 
-        {/* Desktop nav + controls */}
-        <div className="hidden items-center gap-6 md:flex">
-          <nav className="flex items-center gap-6">
-            {NAV_LINKS.map((link) => renderLink(link))}
+        {/* Desktop: marketing links centred, auth links + controls on far right */}
+        <div className="hidden flex-1 items-center md:flex">
+          <nav className="ml-8 flex items-center gap-6">
+            {MARKETING_LINKS.map((link) => renderMarketingLink(link))}
           </nav>
-          <div className="flex items-center gap-2">
-            <ThemeToggle />
-            <LanguageToggle />
+
+          {/* Pushes auth group to the far right */}
+          <div className="ml-auto flex items-center gap-2">
+            {/* Subtle separator */}
+            <div className="mr-2 h-4 w-px bg-border" />
+            {AUTH_LINKS.map((link) => renderAuthLink(link as RouteLink))}
+            <div className="ml-2 flex items-center gap-1">
+              <ThemeToggle />
+              <LanguageToggle />
+            </div>
           </div>
         </div>
 
         {/* Mobile: toggles + hamburger */}
-        <div className="flex items-center gap-1 md:hidden">
+        <div className="ml-auto flex items-center gap-1 md:hidden">
           <ThemeToggle />
           <LanguageToggle />
           <button
@@ -131,9 +160,13 @@ export function LandingNav({ className }: LandingNavProps) {
 
       {/* Mobile dropdown menu */}
       {menuOpen && (
-        <div className="border-t bg-background px-4 pb-4 md:hidden">
-          <nav className="flex flex-col divide-y divide-border/50">
-            {NAV_LINKS.map((link) => renderLink(link, true))}
+        <div className="border-t border-[color:var(--separator)] bg-surface-1 px-4 pb-4 md:hidden">
+          <nav className="flex flex-col divide-y divide-[color:var(--separator)]">
+            {MARKETING_LINKS.map((link) => renderMarketingLink(link, true))}
+            {/* Auth links in their own group with a heavier divider */}
+            <div className="pt-2 flex flex-col gap-0">
+              {AUTH_LINKS.map((link) => renderAuthLink(link as RouteLink, true))}
+            </div>
           </nav>
         </div>
       )}

--- a/app/components/landing/WhySynekSection.tsx
+++ b/app/components/landing/WhySynekSection.tsx
@@ -21,7 +21,7 @@ export function WhySynekSection({ className }: WhySynekSectionProps) {
   return (
     <section
       id="why-synek"
-      className={cn('bg-muted/40 px-4 py-16 sm:py-24', className)}
+      className={cn('bg-surface-2 px-4 py-16 sm:py-24', className)}
     >
       <div className="mx-auto max-w-6xl">
         <div className="mb-12 text-center">
@@ -37,9 +37,9 @@ export function WhySynekSection({ className }: WhySynekSectionProps) {
           {cards.map(({ n, Icon, title, desc }) => (
             <div
               key={n}
-              className="rounded-xl border bg-background p-6 shadow-sm"
+              className="rounded-2xl bg-surface-1 p-6"
             >
-              <Icon className="mb-4 h-8 w-8 text-primary" />
+              <Icon className="mb-4 h-5 w-5 text-muted-foreground" />
               <h3 className="mb-2 font-semibold">{title}</h3>
               <p className="text-sm text-muted-foreground">{desc}</p>
             </div>

--- a/app/components/layout/BottomNav.tsx
+++ b/app/components/layout/BottomNav.tsx
@@ -1,0 +1,77 @@
+import { CalendarDays, Settings, Users } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { NavLink, useLocation } from 'react-router'
+import { cn } from '~/lib/utils'
+import { useAuth } from '~/lib/context/AuthContext'
+import { useLocalePath } from '~/lib/hooks/useLocalePath'
+
+interface NavItemProps {
+  to: string
+  icon: React.ElementType
+  label: string
+  isActive: boolean
+}
+
+function NavItem({ to, icon: Icon, label, isActive }: NavItemProps) {
+  return (
+    <NavLink
+      to={to}
+      className="flex flex-col items-center justify-center gap-1 flex-1 min-h-[44px] py-2"
+    >
+      <Icon
+        className={cn(
+          'h-5 w-5 transition-colors',
+          isActive ? 'text-foreground' : 'text-[color:var(--foreground-tertiary)]'
+        )}
+        strokeWidth={isActive ? 2 : 1.5}
+      />
+      <span
+        className={cn(
+          'text-[10px] font-medium transition-colors',
+          isActive ? 'text-foreground' : 'text-[color:var(--foreground-tertiary)]'
+        )}
+      >
+        {label}
+      </span>
+    </NavLink>
+  )
+}
+
+export function BottomNav() {
+  const { t } = useTranslation('common')
+  const { user } = useAuth()
+  const localePath = useLocalePath()
+  const { pathname } = useLocation()
+
+  if (!user) return null
+
+  const isWeekActive = pathname.includes('/week')
+  const isSettingsActive = pathname.includes('/settings')
+
+  return (
+    <nav className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-[color:var(--separator)] bg-surface-1/90 backdrop-blur-md pb-safe">
+      <div className="flex items-stretch h-14">
+        <NavItem
+          to={localePath(`/${user.role}/week`)}
+          icon={CalendarDays}
+          label={t('nav.week')}
+          isActive={isWeekActive}
+        />
+        {user.role === 'coach' && (
+          <NavItem
+            to={localePath('/settings')}
+            icon={Users}
+            label={t('nav.team')}
+            isActive={isSettingsActive}
+          />
+        )}
+        <NavItem
+          to={localePath('/settings')}
+          icon={Settings}
+          label={t('nav.settings')}
+          isActive={isSettingsActive && user.role !== 'coach'}
+        />
+      </div>
+    </nav>
+  )
+}

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,27 +1,26 @@
-import { useTranslation } from 'react-i18next';
-import { Activity } from 'lucide-react';
 import { Link, useParams } from 'react-router';
 import { LanguageToggle } from './LanguageToggle';
 import { ThemeToggle } from './ThemeToggle';
 import { UserMenu } from './UserMenu';
+import { Logo } from './Logo';
 import { useAuth } from '~/lib/context/AuthContext';
 
 export function Header() {
-  const { t } = useTranslation();
   const { user } = useAuth();
   const { locale } = useParams<{ locale?: string }>();
   const resolvedLocale = locale ?? localStorage.getItem('locale') ?? 'pl';
   const logoHref = user ? `/${resolvedLocale}/${user.role}` : '/';
 
   return (
-    <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-40 border-b border-[color:var(--separator)] bg-surface-1/80 backdrop-blur-md">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Link to={logoHref} className="flex items-center gap-2">
-          <Activity className="h-5 w-5 text-primary" />
-          <span className="font-semibold">{t('appName')}</span>
+          <Logo size="sm" />
         </Link>
         <div className="flex items-center gap-2">
-          {user && <UserMenu />}
+          <div className="hidden md:block">
+            {user && <UserMenu />}
+          </div>
           <ThemeToggle />
           <LanguageToggle />
         </div>

--- a/app/components/layout/Logo.tsx
+++ b/app/components/layout/Logo.tsx
@@ -1,0 +1,64 @@
+import { cn } from '~/lib/utils'
+
+interface LogoProps {
+  size?: 'sm' | 'md' | 'lg'
+  showWordmark?: boolean
+  className?: string
+}
+
+const sizeMap = {
+  sm: { mark: 'h-4 w-auto', text: 'text-sm tracking-[0.15em]' },
+  md: { mark: 'h-5 w-auto', text: 'text-base tracking-[0.15em]' },
+  lg: { mark: 'h-8 w-auto', text: 'text-2xl tracking-[0.15em]' },
+}
+
+// Three ascending forward-lean stripes — viewBox "0 0 20 16"
+//
+// All three parallelograms share the exact same lean angle (arctan(2/16) ≈ 7°).
+// Height grows left→right: 8 → 12 → 16 px.
+// Opacity builds left→right: 0.35 → 0.65 → 1.0.
+//
+// The ascending silhouette reads as pace building / acceleration.
+// The uniform lean reads as disciplined forward drive.
+// At sm (h-4, 16px rendered): shortest stripe is 8px — clearly legible.
+// At lg (h-8, 32px rendered): all three stripes are crisp and bold.
+//
+// S1: points "0,16 1,8 4,8 3,16"      — 8px tall,  lean 1px, width 3px
+// S2: points "7,16 8.5,4 11.5,4 10,16" — 12px tall, lean 1.5px, width 3px
+// S3: points "14,16 16,0 19,0 17,16"   — 16px tall, lean 2px,  width 3px
+// Gap between each stripe: 4px (consistent at bottom edge)
+
+export function Logo({ size = 'md', showWordmark = true, className }: LogoProps) {
+  const s = sizeMap[size]
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <svg
+        className={cn(s.mark, 'shrink-0')}
+        viewBox="0 0 20 16"
+        fill="none"
+        aria-hidden="true"
+      >
+        {/* Trailing stripe — shortest, lightest */}
+        <polygon
+          points="0,16 1,8 4,8 3,16"
+          fill="currentColor"
+          opacity="0.35"
+        />
+        {/* Mid stripe */}
+        <polygon
+          points="7,16 8.5,4 11.5,4 10,16"
+          fill="currentColor"
+          opacity="0.65"
+        />
+        {/* Lead stripe — full height, full opacity, the pace setter */}
+        <polygon
+          points="14,16 16,0 19,0 17,16"
+          fill="currentColor"
+        />
+      </svg>
+      {showWordmark && (
+        <span className={cn('font-bold', s.text)}>SYNEK</span>
+      )}
+    </div>
+  )
+}

--- a/app/components/layout/UserMenu.tsx
+++ b/app/components/layout/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { LogOut, Settings, User } from 'lucide-react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
 import { useLocalePath } from '~/lib/hooks/useLocalePath';
@@ -18,12 +18,13 @@ export function UserMenu() {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const localePath = useLocalePath();
+  const { locale = 'pl' } = useParams<{ locale?: string }>();
 
   if (!user) return null;
 
   function handleLogout() {
     logout();
-    navigate('/login', { replace: true });
+    navigate(`/${locale}/login`, { replace: true });
   }
 
   const roleLabel = user.role === 'coach' ? t('roles.coach') : t('roles.athlete');

--- a/app/components/training/SessionForm.tsx
+++ b/app/components/training/SessionForm.tsx
@@ -5,10 +5,16 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
-  SheetFooter,
 } from '~/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
 import { Button } from '~/components/ui/button';
-import { SessionFormFields } from './SessionFormFields';
+import { SessionFormFields, type FormTab } from './SessionFormFields';
+import { useIsMobile } from '~/lib/hooks/useIsMobile';
 import {
   type TrainingType,
   type DayOfWeek,
@@ -25,6 +31,8 @@ interface SessionFormProps {
   day?: DayOfWeek;
   session?: TrainingSession | null;
   onSubmit: (data: CreateSessionInput | UpdateSessionInput) => void;
+  isCoach?: boolean;
+  className?: string;
 }
 
 export function SessionForm({
@@ -34,8 +42,10 @@ export function SessionForm({
   day,
   session,
   onSubmit,
+  isCoach = false,
 }: SessionFormProps) {
   const { t } = useTranslation(['coach', 'common']);
+  const isMobile = useIsMobile();
   const isEditing = !!session;
 
   const [trainingType, setTrainingType] = useState<TrainingType>(
@@ -65,6 +75,11 @@ export function SessionForm({
   const [coachPostFeedback, setCoachPostFeedback] = useState(
     session?.coachPostFeedback ?? ''
   );
+  const [activeTab, setActiveTab] = useState<FormTab>('plan');
+
+  useEffect(() => {
+    setActiveTab('plan');
+  }, [open]);
 
   useEffect(() => {
     if (session) {
@@ -144,53 +159,96 @@ export function SessionForm({
     onClose();
   };
 
+  const formFields = (
+    <SessionFormFields
+      trainingType={trainingType}
+      onTypeChange={handleTypeChange}
+      description={description}
+      onDescriptionChange={setDescription}
+      coachComments={coachComments}
+      onCoachCommentsChange={setCoachComments}
+      durationMinutes={durationMinutes}
+      onDurationChange={setDurationMinutes}
+      distanceKm={distanceKm}
+      onDistanceChange={setDistanceKm}
+      typeData={typeData}
+      onTypeDataChange={setTypeData}
+      actualDuration={actualDuration}
+      onActualDurationChange={setActualDuration}
+      actualDistance={actualDistance}
+      onActualDistanceChange={setActualDistance}
+      actualPace={actualPace}
+      onActualPaceChange={setActualPace}
+      avgHr={avgHr}
+      onAvgHrChange={setAvgHr}
+      maxHr={maxHr}
+      onMaxHrChange={setMaxHr}
+      rpe={rpe}
+      onRpeChange={setRpe}
+      coachPostFeedback={coachPostFeedback}
+      onCoachPostFeedbackChange={setCoachPostFeedback}
+      isCoach={isCoach}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+    />
+  );
+
+  const title = isEditing ? t('coach:session.edit') : t('coach:session.create');
+  const saveLabel = isEditing ? t('common:actions.save') : t('coach:session.create');
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          className="rounded-t-2xl max-h-[92vh] flex flex-col gap-0 p-0"
+        >
+          {/* Drag handle */}
+          <div className="flex justify-center pt-3 pb-1 shrink-0">
+            <div className="h-1 w-10 rounded-full bg-border" />
+          </div>
+
+          <SheetHeader className="px-5 pt-3 pb-3 border-b shrink-0">
+            <SheetTitle>{title}</SheetTitle>
+          </SheetHeader>
+
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {formFields}
+          </div>
+
+          <div className="px-5 pt-4 pb-4 border-t flex gap-2 justify-end shrink-0">
+            <Button variant="outline" onClick={onClose}>
+              {t('common:actions.cancel')}
+            </Button>
+            <Button onClick={handleSubmit}>{saveLabel}</Button>
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
   return (
-    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
-      <SheetContent className="overflow-y-auto sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle>
-            {isEditing ? t('coach:session.edit') : t('coach:session.create')}
-          </SheetTitle>
-        </SheetHeader>
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-lg max-h-[85vh] flex flex-col p-0 gap-0"
+      >
+        <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
 
-        <SessionFormFields
-          trainingType={trainingType}
-          onTypeChange={handleTypeChange}
-          description={description}
-          onDescriptionChange={setDescription}
-          coachComments={coachComments}
-          onCoachCommentsChange={setCoachComments}
-          durationMinutes={durationMinutes}
-          onDurationChange={setDurationMinutes}
-          distanceKm={distanceKm}
-          onDistanceChange={setDistanceKm}
-          typeData={typeData}
-          onTypeDataChange={setTypeData}
-          actualDuration={actualDuration}
-          onActualDurationChange={setActualDuration}
-          actualDistance={actualDistance}
-          onActualDistanceChange={setActualDistance}
-          actualPace={actualPace}
-          onActualPaceChange={setActualPace}
-          avgHr={avgHr}
-          onAvgHrChange={setAvgHr}
-          maxHr={maxHr}
-          onMaxHrChange={setMaxHr}
-          rpe={rpe}
-          onRpeChange={setRpe}
-          coachPostFeedback={coachPostFeedback}
-          onCoachPostFeedbackChange={setCoachPostFeedback}
-        />
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {formFields}
+        </div>
 
-        <SheetFooter>
+        <div className="px-6 py-4 border-t flex gap-2 justify-end shrink-0">
           <Button variant="outline" onClick={onClose}>
             {t('common:actions.cancel')}
           </Button>
-          <Button onClick={handleSubmit}>
-            {isEditing ? t('common:actions.save') : t('coach:session.create')}
-          </Button>
-        </SheetFooter>
-      </SheetContent>
-    </Sheet>
+          <Button onClick={handleSubmit}>{saveLabel}</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/app/components/training/SessionFormFields.tsx
+++ b/app/components/training/SessionFormFields.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from 'react-i18next';
 import { Input } from '~/components/ui/input';
 import { Textarea } from '~/components/ui/textarea';
 import { Badge } from '~/components/ui/badge';
-import { Separator } from '~/components/ui/separator';
 import { trainingTypeConfig } from '~/lib/utils/training-types';
+import { cn } from '~/lib/utils';
 import { RunFields } from './type-fields/RunFields';
 import { CyclingFields } from './type-fields/CyclingFields';
 import { StrengthFields } from './type-fields/StrengthFields';
@@ -23,6 +23,8 @@ import {
   type WalkData,
   type RestDayData,
 } from '~/types/training';
+
+export type FormTab = 'plan' | 'details' | 'results';
 
 interface SessionFormFieldsProps {
   trainingType: TrainingType;
@@ -51,6 +53,9 @@ interface SessionFormFieldsProps {
   onRpeChange: (v: string) => void;
   coachPostFeedback: string;
   onCoachPostFeedbackChange: (v: string) => void;
+  isCoach: boolean;
+  activeTab: FormTab;
+  onTabChange: (tab: FormTab) => void;
 }
 
 export function SessionFormFields({
@@ -80,6 +85,9 @@ export function SessionFormFields({
   onRpeChange,
   coachPostFeedback,
   onCoachPostFeedbackChange,
+  isCoach,
+  activeTab,
+  onTabChange,
 }: SessionFormFieldsProps) {
   const { t } = useTranslation(['coach', 'common', 'training']);
 
@@ -107,190 +115,215 @@ export function SessionFormFields({
   };
 
   return (
-    <div className="space-y-4 py-4">
-      {/* Training Type Selector */}
-      <div>
-        <label className="text-sm font-medium mb-2 block">
-          {t('coach:session.type')}
-        </label>
-        <div className="flex flex-wrap gap-1.5">
-          {TRAINING_TYPES.map((tt) => {
-            const config = trainingTypeConfig[tt];
-            const isSelected = trainingType === tt;
-            return (
-              <Badge
-                key={tt}
-                variant={isSelected ? 'default' : 'outline'}
-                className={`cursor-pointer transition-colors ${
-                  isSelected
-                    ? `${config.bgColor} ${config.color} border-0`
-                    : 'hover:bg-muted'
-                }`}
-                onClick={() => onTypeChange(tt)}
-              >
-                {t(`common:trainingTypes.${tt}`)}
-              </Badge>
-            );
-          })}
-        </div>
+    <div>
+      {/* Tab Navigation */}
+      <div className="flex gap-1 p-1 bg-muted rounded-xl mb-6">
+        {(['plan', 'details', 'results'] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => onTabChange(tab)}
+            className={cn(
+              'flex-1 py-2.5 text-xs font-semibold rounded-lg transition-colors',
+              activeTab === tab
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t(`coach:session.tabs.${tab}` as never)}
+          </button>
+        ))}
       </div>
 
-      {/* Common Fields */}
-      <div>
-        <label className="text-sm font-medium">
-          {t('coach:session.description')}
-        </label>
-        <Textarea
-          placeholder={t('coach:session.descriptionPlaceholder')}
-          value={description}
-          onChange={(e) => onDescriptionChange(e.target.value)}
-          rows={2}
-        />
-      </div>
-
-      <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="text-sm font-medium">
-            {t('coach:session.duration')}
-          </label>
-          <Input
-            type="number"
-            placeholder="0"
-            value={durationMinutes}
-            onChange={(e) => onDurationChange(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="text-sm font-medium">
-            {t('coach:session.distance')}
-          </label>
-          <Input
-            type="number"
-            step="0.1"
-            placeholder="0"
-            value={distanceKm}
-            onChange={(e) => onDistanceChange(e.target.value)}
-          />
-        </div>
-      </div>
-
-      <div>
-        <label className="text-sm font-medium">
-          {t('coach:session.coachComments')}
-        </label>
-        <Textarea
-          placeholder={t('coach:session.coachCommentsPlaceholder')}
-          value={coachComments}
-          onChange={(e) => onCoachCommentsChange(e.target.value)}
-          rows={2}
-        />
-      </div>
-
-      {/* Type-specific fields */}
-      <>
-        <Separator />
-        <div>
-          <h4 className="text-sm font-semibold mb-3">
-            {t(`common:trainingTypes.${trainingType}`)} details
-          </h4>
-          {renderTypeFields()}
-        </div>
-      </>
-
-      {/* Actual Performance */}
-      <Separator />
-      <div className="space-y-3">
-        <h4 className="text-sm font-semibold">
-          {t('training:actualPerformance.title')}
-        </h4>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-sm font-medium">
-              {t('training:actualPerformance.duration')} ({t('training:units.min')})
+      {/* Plan Tab */}
+      {activeTab === 'plan' && (
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              {t('coach:session.type')}
             </label>
-            <Input
-              type="number"
-              placeholder="0"
-              value={actualDuration}
-              onChange={(e) => onActualDurationChange(e.target.value)}
+            <div className="flex flex-wrap gap-2">
+              {TRAINING_TYPES.map((tt) => {
+                const config = trainingTypeConfig[tt];
+                const isSelected = trainingType === tt;
+                return (
+                  <Badge
+                    key={tt}
+                    variant={isSelected ? 'default' : 'outline'}
+                    className={cn(
+                      'cursor-pointer transition-colors',
+                      isSelected
+                        ? `${config.bgColor} ${config.color} border-0`
+                        : 'hover:bg-muted'
+                    )}
+                    onClick={() => onTypeChange(tt)}
+                  >
+                    {t(`common:trainingTypes.${tt}`)}
+                  </Badge>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              {t('coach:session.description')}
+            </label>
+            <Textarea
+              placeholder={t('coach:session.descriptionPlaceholder')}
+              value={description}
+              onChange={(e) => onDescriptionChange(e.target.value)}
+              rows={3}
             />
           </div>
-          <div>
-            <label className="text-sm font-medium">
-              {t('training:actualPerformance.distance')} ({t('training:units.km')})
-            </label>
-            <Input
-              type="number"
-              step="0.01"
-              placeholder="0"
-              value={actualDistance}
-              onChange={(e) => onActualDistanceChange(e.target.value)}
-            />
-          </div>
-        </div>
 
-        <div>
-          <label className="text-sm font-medium">
-            {t('training:actualPerformance.pace')} ({t('training:units.perKm')})
-          </label>
-          <Input
-            placeholder="5:30"
-            value={actualPace}
-            onChange={(e) => onActualPaceChange(e.target.value)}
-          />
-        </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('coach:session.duration')}
+              </label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={durationMinutes}
+                onChange={(e) => onDurationChange(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('coach:session.distance')}
+              </label>
+              <Input
+                type="number"
+                step="0.1"
+                placeholder="0"
+                value={distanceKm}
+                onChange={(e) => onDistanceChange(e.target.value)}
+              />
+            </div>
+          </div>
 
-        <div className="grid grid-cols-3 gap-3">
-          <div>
-            <label className="text-sm font-medium">
-              {t('training:actualPerformance.avgHr')} ({t('training:units.bpm')})
-            </label>
-            <Input
-              type="number"
-              placeholder="0"
-              value={avgHr}
-              onChange={(e) => onAvgHrChange(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium">
-              {t('training:actualPerformance.maxHr')} ({t('training:units.bpm')})
-            </label>
-            <Input
-              type="number"
-              placeholder="0"
-              value={maxHr}
-              onChange={(e) => onMaxHrChange(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium">
-              {t('training:actualPerformance.rpe')} (1–10)
-            </label>
-            <Input
-              type="number"
-              min="1"
-              max="10"
-              placeholder="–"
-              value={rpe}
-              onChange={(e) => onRpeChange(e.target.value)}
-            />
-          </div>
+          {isCoach && (
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('coach:session.coachComments')}
+              </label>
+              <Textarea
+                placeholder={t('coach:session.coachCommentsPlaceholder')}
+                value={coachComments}
+                onChange={(e) => onCoachCommentsChange(e.target.value)}
+                rows={3}
+              />
+            </div>
+          )}
         </div>
+      )}
 
-        <div>
-          <label className="text-sm font-medium">
-            {t('training:coachPostFeedback.label')}
-          </label>
-          <Textarea
-            placeholder={t('training:coachPostFeedback.placeholder')}
-            value={coachPostFeedback}
-            onChange={(e) => onCoachPostFeedbackChange(e.target.value)}
-            rows={2}
-          />
+      {/* Details Tab */}
+      {activeTab === 'details' && (
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              {t(`common:trainingTypes.${trainingType}`)}
+            </label>
+            {renderTypeFields()}
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* Results Tab */}
+      {activeTab === 'results' && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('training:actualPerformance.duration')} ({t('training:units.min')})
+              </label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={actualDuration}
+                onChange={(e) => onActualDurationChange(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('training:actualPerformance.distance')} ({t('training:units.km')})
+              </label>
+              <Input
+                type="number"
+                step="0.01"
+                placeholder="0"
+                value={actualDistance}
+                onChange={(e) => onActualDistanceChange(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              {t('training:actualPerformance.pace')} ({t('training:units.perKm')})
+            </label>
+            <Input
+              placeholder="5:30"
+              value={actualPace}
+              onChange={(e) => onActualPaceChange(e.target.value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('training:actualPerformance.avgHr')} ({t('training:units.bpm')})
+              </label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={avgHr}
+                onChange={(e) => onAvgHrChange(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('training:actualPerformance.maxHr')} ({t('training:units.bpm')})
+              </label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={maxHr}
+                onChange={(e) => onMaxHrChange(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('training:actualPerformance.rpe')} (1–10)
+              </label>
+              <Input
+                type="number"
+                min="1"
+                max="10"
+                placeholder="–"
+                value={rpe}
+                onChange={(e) => onRpeChange(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {isCoach && (
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {t('training:coachPostFeedback.label')}
+              </label>
+              <Textarea
+                placeholder={t('training:coachPostFeedback.placeholder')}
+                value={coachPostFeedback}
+                onChange={(e) => onCoachPostFeedbackChange(e.target.value)}
+                rows={3}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/i18n/resources/en/coach.json
+++ b/app/i18n/resources/en/coach.json
@@ -28,7 +28,12 @@
     "coachCommentsPlaceholder": "Add notes for the athlete...",
     "duration": "Duration (min)",
     "distance": "Distance (km)",
-    "markRestDay": "Mark as Rest Day"
+    "markRestDay": "Mark as Rest Day",
+    "tabs": {
+      "plan": "Plan",
+      "details": "Details",
+      "results": "Results"
+    }
   },
   "athletePicker": {
     "title": "Select an athlete",

--- a/app/i18n/resources/en/common.json
+++ b/app/i18n/resources/en/common.json
@@ -2,7 +2,10 @@
   "appName": "Synek",
   "nav": {
     "coach": "Coach",
-    "athlete": "Athlete"
+    "athlete": "Athlete",
+    "week": "Week",
+    "team": "Team",
+    "settings": "Settings"
   },
   "days": {
     "monday": "Monday",
@@ -74,6 +77,7 @@
     "invalidCredentials": "Invalid email or password",
     "demoCredentials": "Demo credentials",
     "registerAsCoach": "Register as Coach",
+    "registerAccount": "Register an account",
     "registerAsCoachSubtitle": "Create your coach account",
     "fullName": "Full Name",
     "createAccount": "Create Account",
@@ -150,5 +154,12 @@
     "notConnected": "Not connected",
     "syncedBadge": "Data from Strava",
     "sync": "Sync"
+  },
+  "actions": {
+    "edit": "Edit",
+    "delete": "Delete",
+    "save": "Save",
+    "cancel": "Cancel",
+    "add": "Add"
   }
 }

--- a/app/i18n/resources/en/landing.json
+++ b/app/i18n/resources/en/landing.json
@@ -8,43 +8,43 @@
     "contact": "Contact"
   },
   "hero": {
-    "badge": "Public Beta — Free Account",
-    "headline": "Effortless training management for coaches and athletes",
-    "subheadline": "The Synek app gives coaches a structured way to plan weekly training, and athletes can easily track and update their progress.",
-    "ctaJoinBeta": "Join the Beta — It's Free",
+    "badge": "Public beta — free access",
+    "headline": "Training plans that coaches build and athletes actually follow",
+    "subheadline": "Synek organises your coaching week — athlete by athlete, session by session. Your athletes see exactly what's ahead.",
+    "ctaJoinBeta": "Create your free account",
     "ctaLogIn": "Already have an account?",
-    "betaNote": "We're in beta and your feedback shapes what we build next."
+    "betaNote": "Your feedback shapes what we build next."
   },
   "whySynek": {
-    "title": "Why synek.app?",
-    "subtitle": "Simple and intuitive. Built from real collaboration between coaches and athletes.",
+    "title": "How it works",
+    "subtitle": "Built around the coaching week, not around features.",
     "card1": {
-      "title": "Structured weekly planning",
-      "desc": "Plan each week as a whole — load, type, and daily sessions — not just a list of workouts."
+      "title": "Weekly structure",
+      "desc": "Plan each week as a complete unit — sessions, load, rest. See the whole picture before athletes start."
     },
     "card2": {
-      "title": "Full coach visibility",
-      "desc": "Coaches see what athletes complete, how they feel, and where the plan needs adjusting."
+      "title": "Coach visibility",
+      "desc": "See what every athlete completes, how they feel, and where the plan needs adjusting."
     },
     "card3": {
-      "title": "Athlete autonomy",
-      "desc": "Athletes can self-plan and log notes on every session."
+      "title": "Athlete buy-in",
+      "desc": "Athletes can log sessions, add notes, and optionally plan their own weeks."
     },
     "card4": {
-      "title": "Beta built by users",
-      "desc": "We're actively building with early users. Your feedback directly drives what we add next."
+      "title": "Built with early users",
+      "desc": "This is beta. Every piece of feedback you send changes what we build next."
     }
   },
   "features": {
-    "title": "What's inside",
-    "subtitle": "Everything you need to run a structured training programme — nothing you don't.",
+    "title": "Everything you need",
+    "subtitle": "Structured training tools for coaches. No extra features, no clutter.",
     "item1": {
-      "title": "Weekly training planning",
-      "desc": "Plans are organised by training week. Add sessions by day, set load, and leave coaching notes."
+      "title": "Weekly planning",
+      "desc": "Organise sessions by day, set weekly load, and leave coaching notes — all in one view."
     },
     "item2": {
       "title": "Sport-specific sessions",
-      "desc": "Run, cycling, strength, yoga, swimming, mobility, and rest — each with relevant fields."
+      "desc": "Run, cycling, strength, yoga, swimming, mobility, rest — each with the right fields."
     },
     "item3": {
       "title": "Coach & athlete roles",
@@ -52,11 +52,11 @@
     },
     "item4": {
       "title": "Self-planning mode",
-      "desc": "Coaches can enable athletes to plan their own weeks — useful for experienced athletes."
+      "desc": "Let experienced athletes plan their own weeks. You still see everything."
     },
     "item5": {
       "title": "Strava sync",
-      "desc": "Connect Strava to pull completed activities directly into your training log."
+      "desc": "Link Strava and completed activities fill in automatically."
     }
   },
   "login": {
@@ -70,34 +70,34 @@
     "noAccountCta": "Join the beta →"
   },
   "beta": {
-    "title": "Join the Beta",
-    "subtitle": "Free access during beta. No credit card. No expiry.",
-    "badge": "Beta — Free",
-    "betaNote": "You're joining during our public beta. That means free access and a direct line to the team — we read every piece of feedback.",
+    "title": "Create your free account",
+    "subtitle": "Free during beta. No credit card. No expiry.",
+    "badge": "Public beta",
+    "betaNote": "You're joining our public beta. Free access, and a direct line to the team — we read every piece of feedback.",
     "roleLabel": "I am a...",
     "roleCoach": "Coach",
     "roleAthlete": "Athlete",
     "name": "Full name",
     "email": "Email",
     "password": "Password",
-    "passwordHint": "At least 8 characters, one uppercase, one number",
+    "passwordHint": "At least 8 characters, one uppercase letter, one number",
     "submit": "Create free account",
-    "selectRole": "Please select Coach or Athlete before continuing",
-    "emailAlreadyRegistered": "This email is already registered. Try logging in instead.",
+    "selectRole": "Pick Coach or Athlete to continue",
+    "emailAlreadyRegistered": "That email is already registered. Try logging in instead.",
     "alreadyHaveAccount": "Already have an account?",
     "alreadyHaveAccountCta": "Log in →",
     "cta": "Join the beta"
   },
   "contact": {
-    "title": "Get in touch",
+    "title": "Write to us",
     "subtitle": "Got feedback, a question, or an idea? We're a small team and we read everything.",
     "betaNote": "This is the fastest way to shape what we build next.",
     "name": "Your name",
     "email": "Your email",
     "message": "Your message",
-    "messagePlaceholder": "Tell us what you think, what's missing, or what could be better...",
+    "messagePlaceholder": "Tell us what's missing, what's broken, or what could be better...",
     "submit": "Send message",
     "submitSuccess": "Message sent — thank you! We'll get back to you soon.",
-    "submitError": "Something went wrong. Please try again in a moment."
+    "submitError": "Something went wrong. Please try again."
   }
 }

--- a/app/i18n/resources/pl/coach.json
+++ b/app/i18n/resources/pl/coach.json
@@ -28,7 +28,12 @@
     "coachCommentsPlaceholder": "Dodaj notatki dla zawodnika...",
     "duration": "Czas trwania (min)",
     "distance": "Dystans (km)",
-    "markRestDay": "Oznacz jako Dzień Odpoczynku"
+    "markRestDay": "Oznacz jako Dzień Odpoczynku",
+    "tabs": {
+      "plan": "Plan",
+      "details": "Szczegóły",
+      "results": "Wyniki"
+    }
   },
   "athletePicker": {
     "title": "Wybierz zawodnika",

--- a/app/i18n/resources/pl/common.json
+++ b/app/i18n/resources/pl/common.json
@@ -2,7 +2,10 @@
   "appName": "Synek",
   "nav": {
     "coach": "Trener",
-    "athlete": "Zawodnik"
+    "athlete": "Zawodnik",
+    "week": "Tydzień",
+    "team": "Zespół",
+    "settings": "Ustawienia"
   },
   "days": {
     "monday": "Poniedziałek",
@@ -74,6 +77,7 @@
     "invalidCredentials": "Nieprawidłowy email lub hasło",
     "demoCredentials": "Dane testowe",
     "registerAsCoach": "Zarejestruj się jako trener",
+    "registerAccount": "Zarejestruj konto",
     "registerAsCoachSubtitle": "Utwórz konto trenera",
     "fullName": "Imię i nazwisko",
     "createAccount": "Utwórz konto",
@@ -150,5 +154,12 @@
     "notConnected": "Nie połączono",
     "syncedBadge": "Dane ze Strava",
     "sync": "Synchronizuj"
+  },
+  "actions": {
+    "edit": "Edytuj",
+    "delete": "Usuń",
+    "save": "Zapisz",
+    "cancel": "Anuluj",
+    "add": "Dodaj"
   }
 }

--- a/app/i18n/resources/pl/landing.json
+++ b/app/i18n/resources/pl/landing.json
@@ -1,62 +1,62 @@
 {
   "nav": {
-    "getStarted": "Zacznij",
+    "getStarted": "Start",
     "whySynek": "Dlaczego Synek",
     "features": "Funkcje",
     "logIn": "Zaloguj się",
-    "joinBeta": "Dołącz do Bety",
+    "joinBeta": "Dołącz do bety",
     "contact": "Kontakt"
   },
   "hero": {
-    "badge": "Publiczna Beta - Bezpłatne Konto",
-    "headline": "Wygodne prowadzenie treningów dla trenerów i zawodników",
-    "subheadline": "Aplikacja Synek daje trenerom ustrukturyzowany sposób planowania tygodniowych treningów, a zawodnicy mogą z łatwością aktualizować swoje postępy.",
-    "ctaJoinBeta": "Dołącz do Bety — To Bezpłatne",
+    "badge": "Publiczna beta — bezpłatny dostęp",
+    "headline": "Plany treningowe, które trenerzy tworzą, a zawodnicy realizują",
+    "subheadline": "Synek porządkuje Twój tydzień coachingu — zawodnik po zawodniku, sesja po sesji. Zawodnicy wiedzą dokładnie, co przed nimi.",
+    "ctaJoinBeta": "Załóż darmowe konto",
     "ctaLogIn": "Masz już konto?",
-    "betaNote": "Jesteśmy w fazie beta i Twoje opinie kształtują to, co budujemy."
+    "betaNote": "Twoje opinie kształtują to, co budujemy."
   },
   "whySynek": {
-    "title": "Dlaczego synek.app?",
-    "subtitle": "Prosty i intuicyjny. Zbudowany na podstawie współpracy trenerów i zawodników.",
+    "title": "Jak to działa",
+    "subtitle": "Zbudowane wokół tygodnia treningowego, nie wokół funkcji.",
     "card1": {
-      "title": "Ustrukturyzowane planowanie tygodniowe",
-      "desc": "Planuj każdy tydzień jako całość — obciążenie, typ i dzienne sesje — nie tylko listę treningów."
+      "title": "Tygodniowa struktura",
+      "desc": "Planuj każdy tydzień jako całość — sesje, obciążenie, odpoczynek. Pełny obraz zanim zawodnicy zaczną."
     },
     "card2": {
-      "title": "Pełna widoczność trenera",
-      "desc": "Trenerzy widzą co zawodnicy wykonują, jak się czują i gdzie plan wymaga korekty."
+      "title": "Kontrola trenera",
+      "desc": "Widzisz co każdy zawodnik wykonał, jak się czuł i gdzie plan wymaga korekty."
     },
     "card3": {
-      "title": "Autonomia zawodnika",
-      "desc": "Zawodnicy mogą samodzielnie planować i dodawać notatki do każdej sesji."
+      "title": "Zaangażowanie zawodnika",
+      "desc": "Zawodnicy logują sesje, dodają notatki i — opcjonalnie — planują własne tygodnie."
     },
     "card4": {
-      "title": "Beta budowana przez użytkowników",
-      "desc": "Aktywnie budujemy z wczesnymi użytkownikami. Twoje opinie bezpośrednio wpływają na to, co dodajemy."
+      "title": "Budowane z użytkownikami",
+      "desc": "Jesteśmy w becie. Każda opinia, którą wyślesz, zmienia to, co budujemy."
     }
   },
   "features": {
-    "title": "Co znajdziesz w środku",
-    "subtitle": "Wszystko czego potrzebujesz do prowadzenia ustrukturyzowanego programu treningowego — nic więcej.",
+    "title": "Wszystko czego potrzebujesz",
+    "subtitle": "Narzędzia do planowania treningów dla trenerów. Bez zbędnych funkcji.",
     "item1": {
-      "title": "Planowanie treningów tygodniowo",
-      "desc": "Plany są zorganizowane wg tygodnia treningowego. Dodawaj sesje według dnia, ustaw obciążenie i zostaw notatki."
+      "title": "Planowanie tygodniowe",
+      "desc": "Sesje według dni, tygodniowe obciążenie, notatki trenerskie — wszystko w jednym widoku."
     },
     "item2": {
-      "title": "Sesje specyficzne dla sportu",
-      "desc": "Bieg, kolarstwo, siłownia, joga, pływanie, mobilność i odpoczynek — każde z odpowiednimi polami."
+      "title": "Sesje dopasowane do sportu",
+      "desc": "Bieg, kolarstwo, siłownia, joga, pływanie, mobilność, odpoczynek — każda z odpowiednimi polami."
     },
     "item3": {
       "title": "Role trenera i zawodnika",
       "desc": "Trenerzy zarządzają wieloma zawodnikami. Każdy zawodnik widzi tylko swój plan."
     },
     "item4": {
-      "title": "Tryb samodzielnego planowania",
-      "desc": "Trenerzy mogą umożliwić zawodnikom planowanie własnych tygodni — przydatne dla doświadczonych."
+      "title": "Tryb samodzielny",
+      "desc": "Daj doświadczonym zawodnikom wolną rękę w planowaniu. Ty nadal widzisz wszystko."
     },
     "item5": {
       "title": "Synchronizacja ze Stravą",
-      "desc": "Połącz Stravę, aby pobierać ukończone aktywności bezpośrednio do dziennika treningowego."
+      "desc": "Połącz Stravę, a zakończone aktywności uzupełnią się automatycznie."
     }
   },
   "login": {
@@ -70,10 +70,10 @@
     "noAccountCta": "Dołącz do bety →"
   },
   "beta": {
-    "title": "Dołącz do Bety",
-    "subtitle": "Bezpłatny dostęp przez cały czas trwania bety. Bez karty. Bez wygaśnięcia.",
-    "badge": "Beta — Bezpłatna",
-    "betaNote": "Dołączasz w trakcie publicznej bety. Oznacza to bezpłatny dostęp i bezpośredni kontakt z zespołem — czytamy każdą opinię.",
+    "title": "Załóż darmowe konto",
+    "subtitle": "Bezpłatnie przez cały czas trwania bety. Bez karty kredytowej. Bez wygasania.",
+    "badge": "Publiczna beta",
+    "betaNote": "Dołączasz do publicznej bety. Bezpłatny dostęp i bezpośredni kontakt z zespołem — czytamy każdą opinię.",
     "roleLabel": "Jestem...",
     "roleCoach": "Trenerem",
     "roleAthlete": "Zawodnikiem",
@@ -81,23 +81,23 @@
     "email": "E-mail",
     "password": "Hasło",
     "passwordHint": "Co najmniej 8 znaków, jedna wielka litera, jedna cyfra",
-    "submit": "Utwórz bezpłatne konto",
-    "selectRole": "Wybierz Trener lub Zawodnik przed kontynuowaniem",
+    "submit": "Utwórz darmowe konto",
+    "selectRole": "Wybierz Trener lub Zawodnik, żeby kontynuować",
     "emailAlreadyRegistered": "Ten e-mail jest już zarejestrowany. Spróbuj się zalogować.",
     "alreadyHaveAccount": "Masz już konto?",
     "alreadyHaveAccountCta": "Zaloguj się →",
     "cta": "Dołącz do bety"
   },
   "contact": {
-    "title": "Skontaktuj się",
-    "subtitle": "Masz opinię, pytanie lub pomysł? Jesteśmy małym zespołem i czytamy wszystko.",
-    "betaNote": "To najszybszy sposób na wpłynięcie na to, co budujemy.",
+    "title": "Napisz do nas",
+    "subtitle": "Masz feedback, pytanie lub pomysł? Jesteśmy małym zespołem i czytamy wszystko.",
+    "betaNote": "To najszybszy sposób, żeby wpłynąć na to, co budujemy.",
     "name": "Twoje imię",
     "email": "Twój e-mail",
     "message": "Twoja wiadomość",
-    "messagePlaceholder": "Powiedz nam co myślisz, czego brakuje lub co można poprawić...",
+    "messagePlaceholder": "Powiedz nam co brakuje, co nie działa, albo co możemy zrobić lepiej...",
     "submit": "Wyślij wiadomość",
-    "submitSuccess": "Wiadomość wysłana — dziękujemy! Odpiszemy wkrótce.",
-    "submitError": "Coś poszło nie tak. Spróbuj ponownie za chwilę."
+    "submitSuccess": "Wiadomość wysłana — dziękujemy! Odezwiemy się wkrótce.",
+    "submitError": "Coś poszło nie tak. Spróbuj ponownie."
   }
 }

--- a/app/i18n/resources/pl/training.json
+++ b/app/i18n/resources/pl/training.json
@@ -90,7 +90,7 @@
   "units": {
     "km": "km",
     "min": "min",
-    "bpm": "ud/min",
+    "bpm": "bpm",
     "perKm": "/km"
   }
 }

--- a/app/lib/hooks/useIsMobile.ts
+++ b/app/lib/hooks/useIsMobile.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint = 768): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== 'undefined' && window.innerWidth < breakpoint
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [breakpoint]);
+  return isMobile;
+}

--- a/app/lib/queries/feedback.ts
+++ b/app/lib/queries/feedback.ts
@@ -29,7 +29,7 @@ export async function createFeedback(
     return submission
   }
 
-  const { data, error } = await supabase
+  const { error } = await supabase
     .from('feedback_submissions')
     .insert({
       name: input.name,
@@ -37,9 +37,14 @@ export async function createFeedback(
       message: input.message,
       user_id: input.userId ?? null,
     })
-    .select('id, name, email, message, user_id, created_at')
-    .single()
 
   if (error) throw error
-  return toFeedbackSubmission(data as Record<string, unknown>)
+  return {
+    id: crypto.randomUUID(),
+    name: input.name,
+    email: input.email,
+    message: input.message,
+    userId: input.userId ?? null,
+    createdAt: new Date().toISOString(),
+  }
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -25,18 +25,6 @@ const queryClient = new QueryClient({
   },
 });
 
-export const links: Route.LinksFunction = () => [
-  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-  {
-    rel: 'preconnect',
-    href: 'https://fonts.gstatic.com',
-    crossOrigin: 'anonymous',
-  },
-  {
-    rel: 'stylesheet',
-    href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
-  },
-];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -7,36 +7,38 @@ import {
 } from '@react-router/dev/routes';
 
 export default [
-  // Public landing page — no auth required
-  index('routes/landing.tsx'),
+  // Root: redirect / → /:locale
+  index('routes/root-redirect.tsx'),
 
-  // Login is public and outside the locale wrapper
-  route('login', 'routes/login.tsx'),
-
-  // Register is public and outside the locale wrapper
-  route('register', 'routes/register.tsx'),
-
-  // Invite landing page — public, no locale prefix
+  // Invite landing page — stays at top level (links sent via email, locale-independent)
   route('invite/:token', 'routes/invite.$token.tsx'),
 
-  // All authenticated routes live under /:locale (pl or en)
-  route(':locale', 'routes/locale-layout.tsx', [
-    index('routes/home.tsx'),
+  // All routes under /:locale
+  route(':locale', 'routes/locale-bare-layout.tsx', [
+    // Public pages — each has its own nav (LandingNav), no app chrome
+    index('routes/landing.tsx'),
+    route('login', 'routes/login.tsx'),
+    route('register', 'routes/register.tsx'),
 
-    ...prefix('coach', [
-      layout('routes/coach/layout.tsx', [
-        index('routes/coach/week.tsx'),
-        route('week/:weekId', 'routes/coach/week.$weekId.tsx'),
+    // App pages — wrapped with Header + BottomNav
+    layout('routes/locale-layout.tsx', [
+      route('home', 'routes/home.tsx'),
+
+      ...prefix('coach', [
+        layout('routes/coach/layout.tsx', [
+          index('routes/coach/week.tsx'),
+          route('week/:weekId', 'routes/coach/week.$weekId.tsx'),
+        ]),
       ]),
-    ]),
 
-    ...prefix('athlete', [
-      layout('routes/athlete/layout.tsx', [
-        index('routes/athlete/week.tsx'),
-        route('week/:weekId', 'routes/athlete/week.$weekId.tsx'),
+      ...prefix('athlete', [
+        layout('routes/athlete/layout.tsx', [
+          index('routes/athlete/week.tsx'),
+          route('week/:weekId', 'routes/athlete/week.$weekId.tsx'),
+        ]),
       ]),
-    ]),
 
-    route('settings', 'routes/settings.tsx'),
+      route('settings', 'routes/settings.tsx'),
+    ]),
   ]),
 ] satisfies RouteConfig;

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -210,6 +210,7 @@ export default function AthleteWeekView() {
           day={formDay}
           session={editingSession}
           onSubmit={handleFormSubmit}
+          isCoach={false}
         />
       )}
     </div>

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -151,8 +151,8 @@ export default function CoachWeekView() {
   return (
     <div className="space-y-6">
       {/* Header with navigation */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <h1 className="text-xl sm:text-2xl font-bold whitespace-nowrap">{t('title')}</h1>
+      <div className="flex items-center gap-2">
+        <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
         <WeekNavigation weekId={weekId} basePath="coach" />
       </div>
 
@@ -187,6 +187,7 @@ export default function CoachWeekView() {
         day={formDay}
         session={editingSession}
         onSubmit={handleFormSubmit}
+        isCoach={true}
       />
     </div>
   );

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -14,7 +14,7 @@ export default function Home() {
 
   if (isLoading) return null;
 
-  if (!user) return <Navigate to="/login" replace />;
+  if (!user) return <Navigate to={`/${locale}/login`} replace />;
 
   const target = user.role === 'coach' ? `/${locale}/coach` : `/${locale}/athlete`;
   return <Navigate to={target} replace />;

--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { useAuth } from '~/lib/context/AuthContext'
 import { LandingNav } from '~/components/landing/LandingNav'
 import { HeroSection } from '~/components/landing/HeroSection'
@@ -18,13 +18,13 @@ export function meta() {
 export default function LandingPage() {
   const { user } = useAuth()
   const navigate = useNavigate()
+  const { locale = 'pl' } = useParams<{ locale: string }>()
 
   useEffect(() => {
     if (user) {
-      const locale = localStorage.getItem('locale') ?? 'pl'
       navigate(`/${locale}/${user.role}`, { replace: true })
     }
-  }, [user, navigate])
+  }, [user, navigate, locale])
 
   return (
     <div className="min-h-screen bg-background">

--- a/app/routes/locale-bare-layout.tsx
+++ b/app/routes/locale-bare-layout.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { Navigate, Outlet, useLocation, useParams } from 'react-router';
+import { useTranslation } from 'react-i18next';
+
+const SUPPORTED_LOCALES = ['pl', 'en'] as const;
+type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+function isSupportedLocale(v: string): v is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(v);
+}
+
+export default function LocaleBareLayout() {
+  const { locale } = useParams<{ locale: string }>();
+  const { pathname } = useLocation();
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    if (locale && isSupportedLocale(locale)) {
+      i18n.changeLanguage(locale);
+      localStorage.setItem('locale', locale);
+    }
+  }, [locale, i18n]);
+
+  if (!locale || !isSupportedLocale(locale)) {
+    const pathAfterLocale = pathname.replace(/^\/[^/]*/, '');
+    return <Navigate to={`/pl${pathAfterLocale}`} replace />;
+  }
+
+  return <Outlet />;
+}

--- a/app/routes/locale-layout.tsx
+++ b/app/routes/locale-layout.tsx
@@ -1,39 +1,15 @@
-import { useEffect } from 'react';
-import { Navigate, Outlet, useLocation, useParams } from 'react-router';
-import { useTranslation } from 'react-i18next';
+import { Outlet } from 'react-router';
 import { Header } from '~/components/layout/Header';
-
-const SUPPORTED_LOCALES = ['pl', 'en'] as const;
-type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
-
-function isSupportedLocale(v: string): v is SupportedLocale {
-  return (SUPPORTED_LOCALES as readonly string[]).includes(v);
-}
+import { BottomNav } from '~/components/layout/BottomNav';
 
 export default function LocaleLayout() {
-  const { locale } = useParams<{ locale: string }>();
-  const { pathname } = useLocation();
-  const { i18n } = useTranslation();
-
-  useEffect(() => {
-    if (locale && isSupportedLocale(locale)) {
-      i18n.changeLanguage(locale);
-      localStorage.setItem('locale', locale);
-    }
-  }, [locale, i18n]);
-
-  if (!locale || !isSupportedLocale(locale)) {
-    // Strip the unsupported locale segment and redirect to /pl/...
-    const pathAfterLocale = pathname.replace(/^\/[^/]*/, '');
-    return <Navigate to={`/pl${pathAfterLocale}`} replace />;
-  }
-
   return (
     <>
       <Header />
-      <main className="container mx-auto px-4 py-6">
+      <main className="container mx-auto px-4 py-6 pb-24 md:pb-6">
         <Outlet />
       </main>
+      <BottomNav />
     </>
   );
 }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,51 +1,35 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useParams, Link } from 'react-router';
 import { LandingNav } from '~/components/landing/LandingNav';
 import { Activity, Eye, EyeOff } from 'lucide-react';
-import { useTranslation, Trans } from 'react-i18next';
-import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
-import { supabase, isMockMode } from '~/lib/supabase';
-import { mockRegisterCoach, mockLogin } from '~/lib/auth';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
+import { isMockMode } from '~/lib/supabase';
 
 export function meta() {
   return [{ title: 'Login — Synek' }];
 }
 
-const registerSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  password: z
-    .string()
-    .min(8)
-    .regex(/[A-Z]/, 'Must contain uppercase')
-    .regex(/[0-9]/, 'Must contain a number'),
-});
-
 export default function LoginPage() {
   const { login, user } = useAuth();
   const navigate = useNavigate();
+  const { locale = 'pl' } = useParams<{ locale: string }>();
   const { t } = useTranslation('common');
 
-  const [mode, setMode] = useState<'login' | 'register'>('login');
-  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [honeypot, setHoneypot] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
-  // Redirect when user becomes authenticated
   useEffect(() => {
     if (user) {
-      const locale = localStorage.getItem('locale') ?? 'pl';
       const target = user.role === 'coach' ? `/${locale}/coach` : `/${locale}/athlete`;
       navigate(target, { replace: true });
     }
-  }, [user, navigate]);
+  }, [user, navigate, locale]);
 
   async function handleLoginSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -59,83 +43,20 @@ export default function LoginPage() {
     }
   }
 
-  async function handleRegisterSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    // Honeypot — silently reject bot submissions
-    if (honeypot) return;
-
-    const result = registerSchema.safeParse({ name: name.trim(), email: email.trim(), password });
-    if (!result.success) {
-      setError(result.error.issues[0]?.message ?? 'Invalid input');
-      return;
-    }
-
-    setError(null);
-    setIsPending(true);
-    try {
-      if (isMockMode) {
-        // Mock mode: registration limit intentionally not enforced in local dev
-        const registered = mockRegisterCoach(result.data.email, result.data.password, result.data.name);
-        // Sign in with the newly created mock user
-        await mockLogin(registered.email, result.data.password);
-        await login(registered.email, result.data.password);
-      } else {
-        const res = await fetch(
-          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/register-coach`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-            },
-            body: JSON.stringify({ name: result.data.name, email: result.data.email, password: result.data.password }),
-          }
-        );
-        const payload = await res.json() as { success?: boolean; error?: string };
-
-        if (!res.ok) {
-          if (payload.error === 'coach_limit_reached') {
-            setError(t('auth.coachLimitReached'));
-            setIsPending(false);
-            return;
-          }
-          throw new Error(payload.error ?? 'internal_error');
-        }
-
-        // Fresh session after account creation (prevents session fixation)
-        const { error: signInError } = await supabase.auth.signInWithPassword({
-          email: result.data.email,
-          password: result.data.password,
-        });
-        if (signInError) throw signInError;
-      }
-    } catch {
-      // Generic error — never reveal if email is already taken
-      setError(t('auth.invalidCredentials'));
-      setIsPending(false);
-    }
-  }
-
-  const privacyNoticeUrl = import.meta.env.VITE_PRIVACY_NOTICE_URL ?? '/privacy';
-
   return (
     <div className="min-h-screen bg-background">
       <LandingNav />
       <main className="flex min-h-screen items-center justify-center px-4 pt-14">
-      <div className="w-full max-w-sm space-y-8">
-        {/* Logo */}
-        <div className="flex flex-col items-center gap-2">
-          <div className="flex items-center gap-2">
-            <Activity className="h-7 w-7 text-primary" />
-            <span className="text-2xl font-bold">Synek</span>
+        <div className="w-full max-w-sm space-y-8">
+          {/* Logo */}
+          <div className="flex flex-col items-center gap-2">
+            <div className="flex items-center gap-2">
+              <Activity className="h-7 w-7 text-primary" />
+              <span className="text-2xl font-bold">Synek</span>
+            </div>
+            <p className="text-sm text-muted-foreground">{t('auth.signInSubtitle')}</p>
           </div>
-          <p className="text-sm text-muted-foreground">
-            {mode === 'register' ? t('auth.registerAsCoachSubtitle') : t('auth.signInSubtitle')}
-          </p>
-        </div>
 
-        {mode === 'login' ? (
-          /* ── Login Form ── */
           <form onSubmit={handleLoginSubmit} className="space-y-4">
             <div className="space-y-2">
               <label htmlFor="email" className="text-sm font-medium leading-none">
@@ -190,148 +111,34 @@ export default function LoginPage() {
             </Button>
 
             <p className="text-center text-sm text-muted-foreground">
-              <button
-                type="button"
+              <Link
+                to={`/${locale}/register`}
                 className="underline hover:text-foreground"
-                onClick={() => { setMode('register'); setError(null); }}
               >
-                {t('auth.registerAsCoach')}
-              </button>
+                {t('auth.registerAccount')}
+              </Link>
             </p>
           </form>
-        ) : (
-          /* ── Register Form ── */
-          <form onSubmit={handleRegisterSubmit} className="space-y-4">
-            {/* Honeypot — invisible to real users */}
-            <input
-              name="website"
-              tabIndex={-1}
-              className="sr-only"
-              aria-hidden="true"
-              value={honeypot}
-              onChange={(e) => setHoneypot(e.target.value)}
-            />
 
-            <div className="space-y-2">
-              <label htmlFor="name" className="text-sm font-medium leading-none">
-                {t('auth.fullName')}
-              </label>
-              <Input
-                id="name"
-                type="text"
-                autoComplete="name"
-                required
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Jane Smith"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label htmlFor="reg-email" className="text-sm font-medium leading-none">
-                {t('auth.email')}
-              </label>
-              <Input
-                id="reg-email"
-                type="email"
-                autoComplete="email"
-                required
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@example.com"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label htmlFor="reg-password" className="text-sm font-medium leading-none">
-                {t('auth.password')}
-              </label>
-              <div className="relative">
-                <Input
-                  id="reg-password"
-                  type={showPassword ? 'text' : 'password'}
-                  autoComplete="new-password"
-                  required
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••"
-                  className="pr-10"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground hover:text-foreground"
-                  tabIndex={-1}
-                  aria-label={showPassword ? t('auth.hidePassword') : t('auth.showPassword')}
-                >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              <p className="text-xs text-muted-foreground">{t('auth.passwordRequirements')}</p>
-            </div>
-
-            {error && (
-              <p className="text-sm text-destructive" role="alert">
-                {error}
+          {/* Mock mode hint */}
+          {isMockMode && (
+            <div className="rounded-md border border-muted bg-muted/40 p-4 text-xs text-muted-foreground space-y-1">
+              <p className="font-semibold text-foreground">{t('auth.demoCredentials')}</p>
+              <p>
+                <span className="font-medium">Coach:</span>{' '}
+                coach@synek.app / coach123
               </p>
-            )}
-
-            <p className="text-xs text-muted-foreground">
-              <Trans
-                i18nKey="auth.privacyNoticeAgree"
-                ns="common"
-                values={{ link: t('auth.privacyNotice') }}
-                components={{
-                  1: (
-                    <a
-                      href={privacyNoticeUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline hover:text-foreground"
-                    >
-                      {t('auth.privacyNotice')}
-                    </a>
-                  ),
-                }}
-              />
-            </p>
-
-            <Button type="submit" className="w-full" disabled={isPending}>
-              {isPending ? t('auth.creatingAccount') : t('auth.createAccount')}
-            </Button>
-
-            <p className="text-center text-sm text-muted-foreground">
-              {t('auth.alreadyHaveAccount')}{' '}
-              <button
-                type="button"
-                className="underline hover:text-foreground"
-                onClick={() => { setMode('login'); setError(null); }}
-              >
-                {t('auth.signInInstead')}
-              </button>
-            </p>
-          </form>
-        )}
-
-        {/* Mock mode hint */}
-        {isMockMode && mode === 'login' && (
-          <div className="rounded-md border border-muted bg-muted/40 p-4 text-xs text-muted-foreground space-y-1">
-            <p className="font-semibold text-foreground">{t('auth.demoCredentials')}</p>
-            <p>
-              <span className="font-medium">Coach:</span>{' '}
-              coach@synek.app / coach123
-            </p>
-            <p>
-              <span className="font-medium">Alice (athlete):</span>{' '}
-              alice@synek.app / alice123
-            </p>
-            <p>
-              <span className="font-medium">Bob (athlete):</span>{' '}
-              bob@synek.app / bob123
-            </p>
-          </div>
-        )}
-      </div>
+              <p>
+                <span className="font-medium">Alice (athlete):</span>{' '}
+                alice@synek.app / alice123
+              </p>
+              <p>
+                <span className="font-medium">Bob (athlete):</span>{' '}
+                bob@synek.app / bob123
+              </p>
+            </div>
+          )}
+        </div>
       </main>
     </div>
   );

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate, Link } from 'react-router'
+import { useNavigate, Link, useParams } from 'react-router'
 import { Eye, EyeOff } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { z } from 'zod'
@@ -30,6 +30,7 @@ export default function RegisterPage() {
   const { t } = useTranslation('landing')
   const { login } = useAuth()
   const navigate = useNavigate()
+  const { locale = 'pl' } = useParams<{ locale: string }>()
 
   const [role, setRole] = useState<UserRole | null>(null)
   const [name, setName] = useState('')
@@ -110,7 +111,6 @@ export default function RegisterPage() {
         if (signInError) throw signInError
       }
 
-      const locale = localStorage.getItem('locale') ?? 'pl'
       navigate(`/${locale}/${role}`, { replace: true })
     } catch {
       setError(t('beta.selectRole'))
@@ -242,7 +242,7 @@ export default function RegisterPage() {
 
             <p className="text-center text-sm text-muted-foreground">
               {t('beta.alreadyHaveAccount')}{' '}
-              <Link to="/login" className="font-medium text-primary hover:underline">
+              <Link to={`/${locale}/login`} className="font-medium text-primary hover:underline">
                 {t('beta.alreadyHaveAccountCta')}
               </Link>
             </p>

--- a/app/routes/root-redirect.tsx
+++ b/app/routes/root-redirect.tsx
@@ -1,0 +1,6 @@
+import { Navigate } from 'react-router';
+
+export default function RootRedirect() {
+  const locale = localStorage.getItem('locale') ?? 'pl';
+  return <Navigate to={`/${locale}`} replace />;
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams, useParams, Link } from 'react-router';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, LogOut } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '~/lib/context/AuthContext';
 import { useConnectStrava } from '~/lib/hooks/useStravaConnection';
 import { queryKeys } from '~/lib/queries/keys';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { Button } from '~/components/ui/button';
 import { UserTab } from '~/components/settings/UserTab';
 import { IntegrationsTab } from '~/components/settings/IntegrationsTab';
 import { AthletesTab } from '~/components/settings/AthletesTab';
@@ -19,7 +20,7 @@ type CallbackState = 'connecting' | 'success' | 'error';
 
 export default function SettingsPage() {
   const { t } = useTranslation('common');
-  const { user, isLoading: authLoading } = useAuth();
+  const { user, isLoading: authLoading, logout } = useAuth();
   const navigate = useNavigate();
   const { locale = 'pl' } = useParams<{ locale?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -39,9 +40,9 @@ export default function SettingsPage() {
   // Redirect unauthenticated users (wait for auth to finish loading first)
   useEffect(() => {
     if (!authLoading && !user && !isOAuthCallback.current) {
-      navigate('/login', { replace: true });
+      navigate(`/${locale}/login`, { replace: true });
     }
-  }, [authLoading, user, navigate]);
+  }, [authLoading, user, navigate, locale]);
 
   // Listen for localStorage signal from the OAuth popup
   useEffect(() => {
@@ -141,13 +142,24 @@ export default function SettingsPage() {
 
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">
-      <Link
-        to={backHref}
-        className="mb-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        {t('settings.back')}
-      </Link>
+      <div className="mb-6 flex items-center justify-between">
+        <Link
+          to={backHref}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t('settings.back')}
+        </Link>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-destructive"
+          onClick={() => { logout(); navigate(`/${locale}/login`, { replace: true }); }}
+        >
+          <LogOut className="h-4 w-4 mr-1.5" />
+          {t('auth.signOut')}
+        </Button>
+      </div>
       <h1 className="mb-6 text-2xl font-semibold">{t('settings.title')}</h1>
 
       <Tabs

--- a/app/test/integration/LandingNav.test.tsx
+++ b/app/test/integration/LandingNav.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * LandingNav navigation tests
+ *
+ * Covers:
+ * - Auth links (logIn → /pl/login, joinBeta → /pl/register) always present with correct hrefs
+ * - On landing page (/pl): marketing items render as <a> anchor tags with #hash hrefs
+ * - On non-landing page (/pl/login): marketing items render as <Link> with full paths
+ * - Mobile hamburger opens/closes and shows all links
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { LandingNav } from '~/components/landing/LandingNav';
+
+// ---------------------------------------------------------------------------
+// Mocks for context-dependent layout widgets
+// ---------------------------------------------------------------------------
+
+vi.mock('~/components/layout/ThemeToggle', () => ({
+  ThemeToggle: () => <button aria-label="toggle theme" />,
+}));
+
+vi.mock('~/components/layout/LanguageToggle', () => ({
+  LanguageToggle: () => <button aria-label="toggle language" />,
+}));
+
+// Control pathname + params per test
+const mockLocation = { pathname: '/pl' };
+const mockParams = { locale: 'pl' };
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useLocation: () => mockLocation,
+    useParams: () => mockParams,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderNav() {
+  return render(
+    <MemoryRouter>
+      <LandingNav />
+    </MemoryRouter>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LandingNav — auth links', () => {
+  beforeEach(() => {
+    mockLocation.pathname = '/pl';
+    mockParams.locale = 'pl';
+  });
+
+  it('renders a Log In link pointing to /pl/login', () => {
+    renderNav();
+    const loginLinks = screen.getAllByRole('link', { name: 'nav.logIn' });
+    // At least one (desktop); href must be /pl/login
+    expect(loginLinks[0]).toHaveAttribute('href', '/pl/login');
+  });
+
+  it('renders a Join Beta link pointing to /pl/register', () => {
+    renderNav();
+    const betaLinks = screen.getAllByRole('link', { name: 'nav.joinBeta' });
+    expect(betaLinks[0]).toHaveAttribute('href', '/pl/register');
+  });
+
+  it('uses the locale param in auth link hrefs — en locale', () => {
+    mockParams.locale = 'en';
+    mockLocation.pathname = '/en';
+    renderNav();
+    const loginLinks = screen.getAllByRole('link', { name: 'nav.logIn' });
+    expect(loginLinks[0]).toHaveAttribute('href', '/en/login');
+    const betaLinks = screen.getAllByRole('link', { name: 'nav.joinBeta' });
+    expect(betaLinks[0]).toHaveAttribute('href', '/en/register');
+  });
+});
+
+describe('LandingNav — marketing links on landing page (/pl)', () => {
+  beforeEach(() => {
+    mockLocation.pathname = '/pl';
+    mockParams.locale = 'pl';
+  });
+
+  it('renders marketing items as anchor tags with hash hrefs', () => {
+    renderNav();
+    // anchor tags — not router Links (no /pl prefix)
+    expect(screen.getByRole('link', { name: 'nav.getStarted' })).toHaveAttribute(
+      'href',
+      '#get-started'
+    );
+    expect(screen.getByRole('link', { name: 'nav.whySynek' })).toHaveAttribute(
+      'href',
+      '#why-synek'
+    );
+    expect(screen.getByRole('link', { name: 'nav.features' })).toHaveAttribute(
+      'href',
+      '#features'
+    );
+    expect(screen.getByRole('link', { name: 'nav.contact' })).toHaveAttribute(
+      'href',
+      '#contact'
+    );
+  });
+});
+
+describe('LandingNav — marketing links on non-landing page (/pl/login)', () => {
+  beforeEach(() => {
+    mockLocation.pathname = '/pl/login';
+    mockParams.locale = 'pl';
+  });
+
+  it('renders marketing items as router Links with full paths', () => {
+    renderNav();
+    // resolveHref prepends "/" to the anchor href
+    expect(screen.getByRole('link', { name: 'nav.getStarted' })).toHaveAttribute(
+      'href',
+      '/#get-started'
+    );
+    expect(screen.getByRole('link', { name: 'nav.whySynek' })).toHaveAttribute(
+      'href',
+      '/#why-synek'
+    );
+  });
+
+  it('auth links still point to /pl/login and /pl/register', () => {
+    renderNav();
+    const loginLinks = screen.getAllByRole('link', { name: 'nav.logIn' });
+    expect(loginLinks[0]).toHaveAttribute('href', '/pl/login');
+    const betaLinks = screen.getAllByRole('link', { name: 'nav.joinBeta' });
+    expect(betaLinks[0]).toHaveAttribute('href', '/pl/register');
+  });
+});
+
+describe('LandingNav — mobile hamburger menu', () => {
+  beforeEach(() => {
+    mockLocation.pathname = '/pl';
+    mockParams.locale = 'pl';
+  });
+
+  it('mobile menu is hidden by default', () => {
+    renderNav();
+    // Mobile dropdown only renders when menuOpen === true
+    // Auth links appear twice when open (desktop + mobile); once when closed
+    const loginLinks = screen.getAllByRole('link', { name: 'nav.logIn' });
+    expect(loginLinks).toHaveLength(1);
+  });
+
+  it('opens mobile menu on hamburger click and shows all links', async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    // After open, each nav link appears twice (desktop hidden + mobile visible)
+    const loginLinks = screen.getAllByRole('link', { name: 'nav.logIn' });
+    expect(loginLinks.length).toBeGreaterThanOrEqual(2);
+
+    const betaLinks = screen.getAllByRole('link', { name: 'nav.joinBeta' });
+    expect(betaLinks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('closes mobile menu on hamburger click when already open', async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    await user.click(screen.getByRole('button', { name: 'Close menu' }));
+
+    // Back to single (desktop only)
+    expect(screen.getAllByRole('link', { name: 'nav.logIn' })).toHaveLength(1);
+  });
+});

--- a/app/test/integration/login.test.tsx
+++ b/app/test/integration/login.test.tsx
@@ -5,6 +5,12 @@ import { MemoryRouter } from 'react-router';
 import LoginPage from '~/routes/login';
 import { createTestQueryClient } from '~/test/utils/query-client';
 
+// LandingNav uses ThemeToggle/LanguageToggle which need context providers not
+// relevant to login form tests — stub it out.
+vi.mock('~/components/landing/LandingNav', () => ({
+  LandingNav: () => <nav data-testid="landing-nav" />,
+}));
+
 // ---------------------------------------------------------------------------
 // Auth mock — track login calls and simulate success/failure
 // ---------------------------------------------------------------------------
@@ -39,7 +45,7 @@ function renderLogin() {
   const queryClient = createTestQueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/login']}>
+      <MemoryRouter initialEntries={['/pl/login']}>
         <LoginPage />
       </MemoryRouter>
     </QueryClientProvider>
@@ -54,7 +60,6 @@ describe('LoginPage', () => {
 
   it('renders the login form with email and password fields', () => {
     renderLogin();
-    // Use placeholders (hardcoded, not i18n keys) as stable selectors
     expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('••••••••')).toBeInTheDocument();
   });
@@ -66,7 +71,6 @@ describe('LoginPage', () => {
 
     await user.type(screen.getByPlaceholderText('you@example.com'), 'coach@synek.app');
     await user.type(screen.getByPlaceholderText('••••••••'), 'coach123');
-    // In tests, t('auth.signIn') returns the key 'auth.signIn'
     await user.click(screen.getByRole('button', { name: 'auth.signIn' }));
 
     await waitFor(() =>
@@ -91,5 +95,18 @@ describe('LoginPage', () => {
   it('does not show an error initially', () => {
     renderLogin();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders a link to the register page', () => {
+    renderLogin();
+    const registerLink = screen.getByRole('link', { name: 'auth.registerAccount' });
+    expect(registerLink).toBeInTheDocument();
+    expect(registerLink).toHaveAttribute('href', '/pl/register');
+  });
+
+  it('does not render a register form', () => {
+    renderLogin();
+    // No name field should exist — register form is on /register
+    expect(screen.queryByPlaceholderText('Jane Smith')).not.toBeInTheDocument();
   });
 });

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -1,4 +1,20 @@
 import '@testing-library/jest-dom';
+
+// JSDOM does not implement window.matchMedia — stub it globally so hooks like
+// useIsMobile don't throw in any test that renders components using it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 

--- a/supabase/migrations/015_feedback_grant_anon.sql
+++ b/supabase/migrations/015_feedback_grant_anon.sql
@@ -1,0 +1,4 @@
+-- Grant INSERT permission to anon role so unauthenticated visitors can submit feedback.
+-- The RLS policy alone is not sufficient — the role also needs table-level permission.
+grant insert on table feedback_submissions to anon;
+grant insert on table feedback_submissions to authenticated;


### PR DESCRIPTION
## Summary
- Redesign of calendar, landing page, training form, and layout components with mobile-first improvements
- Add `BottomNav`, `Logo`, `useIsMobile` hook, and `locale-bare-layout` route
- Fix feedback form: drop `.select().single()` after insert to avoid RLS violation on anon SELECT; add migration 015 granting INSERT to `anon` role
- Hide contact section heading/subtitle after successful form submission

## Test plan
- [ ] Submit feedback form as unauthenticated user — should succeed and show only the confirmation state (no heading)
- [ ] Check calendar and training form on mobile viewport
- [ ] Verify landing page renders correctly on both EN and PL locales
- [x] Run `pnpm typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)