### PR TITLE
feat: unified loading experience with stagger animations

### DIFF
--- a/app/components/calendar/HistoryWeekRow.tsx
+++ b/app/components/calendar/HistoryWeekRow.tsx
@@ -27,6 +27,7 @@ interface HistoryWeekRowProps {
   onCopyDay: (input: CopyDayInput) => void;
   onCopySession: (session: TrainingSession, targetDay: DayOfWeek) => void;
   targetWeekPlanId: string;
+  targetRestDays?: Set<DayOfWeek>;
   selectedDay?: DayOfWeek;
   onSelectDay?: (day: DayOfWeek) => void;
   className?: string;
@@ -43,6 +44,7 @@ export function HistoryWeekRow({
   onCopyDay,
   onCopySession,
   targetWeekPlanId,
+  targetRestDays,
   selectedDay,
   onSelectDay,
   className,
@@ -64,16 +66,6 @@ export function HistoryWeekRow({
   const sessionCount = sessions.length;
   const copyableCount = sessions.filter((s) => s.trainingType !== 'rest_day').length;
   const canCopyWeek = !!weekPlan && copyableCount > 0;
-
-  // Close session picker on Escape
-  useEffect(() => {
-    if (!copyPickSession) return;
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setCopyPickSession(null);
-    }
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [copyPickSession]);
 
   const sessionsByDay: SessionsByDay = DAYS_OF_WEEK.reduce(
     (acc, day) => ({
@@ -167,30 +159,6 @@ export function HistoryWeekRow({
                     onSelectDay={onSelectDay}
                   />
 
-                  {/* Inline day-picker for copy session */}
-                  {copyPickSession && (
-                    <div
-                      data-testid="session-day-picker"
-                      className="mt-2 p-2 rounded-lg border border-[color:var(--border)] bg-surface-1 flex flex-wrap gap-1"
-                    >
-                      <p className="w-full text-xs text-[color:var(--foreground-secondary)] mb-1">
-                        {t('history.copySession')} →
-                      </p>
-                      {DAYS_OF_WEEK.map((day) => (
-                        <button
-                          key={day}
-                          data-testid={`day-pick-${day}`}
-                          className="px-2 py-1 text-xs rounded-md bg-surface-2 hover:bg-primary/10 hover:text-primary transition-colors capitalize"
-                          onClick={() => {
-                            onCopySession(copyPickSession, day);
-                            setCopyPickSession(null);
-                          }}
-                        >
-                          {day}
-                        </button>
-                      ))}
-                    </div>
-                  )}
                 </>
               )
             )}
@@ -198,12 +166,45 @@ export function HistoryWeekRow({
         </div>
       </div>
 
+      {/* Copy Session day-picker dialog */}
+      <Dialog open={!!copyPickSession} onOpenChange={(open) => { if (!open) setCopyPickSession(null); }}>
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t('history.copySession')}</DialogTitle>
+            <DialogDescription>{t('history.copySessionPickDay')}</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-wrap gap-2 py-2">
+            {DAYS_OF_WEEK.map((day) => {
+              const isRestDay = targetRestDays?.has(day) ?? false;
+              return (
+                <Button
+                  key={day}
+                  variant="outline"
+                  size="sm"
+                  disabled={isRestDay}
+                  onClick={() => { onCopySession(copyPickSession!, day); setCopyPickSession(null); }}
+                  className="capitalize"
+                  title={isRestDay ? t('history.copySessionRestDayBlocked') : undefined}
+                >
+                  {day}
+                </Button>
+              );
+            })}
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setCopyPickSession(null)}>
+              {tCommon('actions.cancel')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Copy Week confirmation dialog */}
       <Dialog open={copyWeekPending} onOpenChange={(open) => { if (!open) setCopyWeekPending(false); }}>
         <DialogContent showCloseButton={false} className="max-w-sm">
           <DialogHeader>
             <DialogTitle>
-              {t('history.copyWeekConfirmTitle', { week: weekNumber, range: dateRange })}
+              {t('history.copyWeekConfirmTitle', { week: weekNumber })}
             </DialogTitle>
             <DialogDescription>
               {t('history.copyWeekConfirmBody', { count: copyableCount })}

--- a/app/components/calendar/MultiWeekView.tsx
+++ b/app/components/calendar/MultiWeekView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { cn } from '~/lib/utils';
+import { StaggerIn } from '~/components/ui/stagger-in';
 import { WeekGrid } from './WeekGrid';
 import { HistoryWeekRow } from './HistoryWeekRow';
 import { useWeekHistory } from '~/lib/hooks/useWeekHistory';
@@ -104,11 +105,7 @@ export function MultiWeekView({
       {/* History weeks (oldest first) */}
       <div data-testid="history-section" className="flex flex-col gap-1.5">
         {reversedHistory.map((hw, i) => (
-          <div
-            key={hw.weekId}
-            className="animate-in fade-in slide-in-from-bottom-2 duration-500"
-            style={{ animationDelay: `${i * 60}ms`, animationFillMode: 'both' }}
-          >
+          <StaggerIn key={hw.weekId} delay={i * 60}>
             <HistoryWeekRow
               weekId={hw.weekId}
               weekPlan={hw.weekPlan}
@@ -130,7 +127,7 @@ export function MultiWeekView({
               selectedDay={selectedDay}
               onSelectDay={setSelectedDay}
             />
-          </div>
+          </StaggerIn>
         ))}
       </div>
 

--- a/app/components/calendar/MultiWeekView.tsx
+++ b/app/components/calendar/MultiWeekView.tsx
@@ -6,7 +6,7 @@ import { WeekGrid } from './WeekGrid';
 import { HistoryWeekRow } from './HistoryWeekRow';
 import { useWeekHistory } from '~/lib/hooks/useWeekHistory';
 import { useCopyWeekSessions, useCopyDaySessions, useCopySession, useUpdateSession } from '~/lib/hooks/useSessions';
-import { getWeekDateRange, getTodayDayOfWeek } from '~/lib/utils/date';
+import { getWeekDateRange, getTodayDayOfWeek, parseWeekId } from '~/lib/utils/date';
 import type { UserRole } from '~/lib/auth';
 import type {
   DayOfWeek,
@@ -56,6 +56,7 @@ export function MultiWeekView({
   }, [currentWeekId, location.state?.resetToToday]);
 
   const currentWeekLabel = getWeekDateRange(currentWeekId).formatted;
+  const { weekNumber: currentWeekNumber } = parseWeekId(currentWeekId);
 
   const copyWeekMutation = useCopyWeekSessions();
   const copyDayMutation = useCopyDaySessions();
@@ -63,6 +64,15 @@ export function MultiWeekView({
   const updateSessionMutation = useUpdateSession();
 
   const targetWeekPlanId = currentWeekPlan?.id ?? '';
+
+  const currentRestDays = useMemo(
+    () => new Set(
+      Object.entries(currentSessionsByDay)
+        .filter(([, sessions]) => sessions.some((s) => s.trainingType === 'rest_day'))
+        .map(([day]) => day as DayOfWeek)
+    ),
+    [currentSessionsByDay]
+  );
 
   function handleCopyWeek(sourceWeekPlanId: string) {
     if (!targetWeekPlanId) return;
@@ -77,7 +87,7 @@ export function MultiWeekView({
   }
 
   function handleCopySession(session: TrainingSession, targetDay: DayOfWeek) {
-    if (!targetWeekPlanId || session.trainingType === 'rest_day') return;
+    if (!targetWeekPlanId || session.trainingType === 'rest_day' || currentRestDays.has(targetDay)) return;
     copySessionMutation.mutate({ session, targetWeekPlanId, targetDay }, {
       onSuccess: () => setSelectedDay(targetDay),
     });
@@ -116,6 +126,7 @@ export function MultiWeekView({
               onCopyDay={handleCopyDay}
               onCopySession={handleCopySession}
               targetWeekPlanId={targetWeekPlanId}
+              targetRestDays={currentRestDays}
               selectedDay={selectedDay}
               onSelectDay={setSelectedDay}
             />
@@ -127,7 +138,7 @@ export function MultiWeekView({
       <div className="flex items-center gap-2 pt-1">
         <div className="h-px flex-1 bg-[color:var(--border)]" />
         <span className="text-[10px] font-semibold uppercase tracking-widest text-primary px-2">
-          {t('history.currentWeek')} — {currentWeekLabel}
+          {t('history.currentWeek')} {currentWeekNumber} · {currentWeekLabel}
         </span>
         <div className="h-px flex-1 bg-[color:var(--border)]" />
       </div>

--- a/app/components/calendar/WeekGrid.tsx
+++ b/app/components/calendar/WeekGrid.tsx
@@ -212,10 +212,7 @@ export function WeekGrid({
   };
 
   const gridContent = (
-    <div
-      className="animate-in fade-in duration-300"
-      style={{ animationDelay: '150ms', animationFillMode: 'both' }}
-    >
+    <div>
       {/* Mobile: day strip + single day view */}
       <div className="md:hidden">
         <MobileDayStrip

--- a/app/components/calendar/WeekGrid.tsx
+++ b/app/components/calendar/WeekGrid.tsx
@@ -212,7 +212,10 @@ export function WeekGrid({
   };
 
   const gridContent = (
-    <>
+    <div
+      className="animate-in fade-in duration-300"
+      style={{ animationDelay: '150ms', animationFillMode: 'both' }}
+    >
       {/* Mobile: day strip + single day view */}
       <div className="md:hidden">
         <MobileDayStrip
@@ -269,7 +272,7 @@ export function WeekGrid({
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 
   if (dndEnabled) {

--- a/app/components/calendar/WeekNavigation.tsx
+++ b/app/components/calendar/WeekNavigation.tsx
@@ -18,9 +18,10 @@ interface WeekNavigationProps {
   weekId: string;
   basePath: 'coach' | 'athlete';
   selectedDay?: DayOfWeek;
+  isLoading?: boolean;
 }
 
-export function WeekNavigation({ weekId, basePath, selectedDay }: WeekNavigationProps) {
+export function WeekNavigation({ weekId, basePath, selectedDay, isLoading }: WeekNavigationProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const localePath = useLocalePath();
@@ -38,6 +39,7 @@ export function WeekNavigation({ weekId, basePath, selectedDay }: WeekNavigation
       <Button
         variant="ghost"
         size="icon"
+        disabled={isLoading}
         className="h-11 w-11 rounded-full shrink-0"
         onClick={() => navigate(localePath(`/${basePath}/week/${getPrevWeekId(weekId)}`))}
       >
@@ -56,6 +58,7 @@ export function WeekNavigation({ weekId, basePath, selectedDay }: WeekNavigation
       <Button
         variant="ghost"
         size="icon"
+        disabled={isLoading}
         className="h-11 w-11 rounded-full shrink-0"
         onClick={() => navigate(localePath(`/${basePath}/week/${getNextWeekId(weekId)}`))}
       >

--- a/app/components/calendar/WeekSummary.tsx
+++ b/app/components/calendar/WeekSummary.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import { ChevronDown, ChevronUp, Pencil, X } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Textarea } from '~/components/ui/textarea';
@@ -46,6 +46,7 @@ export function WeekSummary({
 }: WeekSummaryProps) {
   const { t } = useTranslation(['coach', 'common']);
   const [isExpanded, setIsExpanded] = useState(true);
+  const [isEditingKm, setIsEditingKm] = useState(false);
 
   const [coachComments, setCoachComments] = useState(weekPlan.coachComments ?? '');
   const [plannedKm, setPlannedKm] = useState(weekPlan.totalPlannedKm?.toString() ?? '');
@@ -69,8 +70,8 @@ export function WeekSummary({
   const duration = formatDuration(stats.totalActualDurationMinutes);
 
   return (
-    <Card className="overflow-hidden border-border/50 shadow-sm">
-      <CardHeader className={cn("py-3 px-6 transition-all", !isExpanded && "pb-4")}>
+    <Card className="overflow-hidden border-border/50 shadow-sm py-0 gap-0 animate-in fade-in duration-300">
+      <CardHeader className={cn("py-4 px-6 transition-all", !isExpanded && "py-4")}>
         <div className="flex justify-between items-center">
           <CardTitle className="text-sm font-semibold text-foreground/80 uppercase tracking-wider">
             {t('coach:weekSummary.title')}
@@ -86,7 +87,11 @@ export function WeekSummary({
         </div>
       </CardHeader>
 
-      {isExpanded && (
+      <div
+        className="grid transition-[grid-template-rows] duration-300 ease-out"
+        style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
+      >
+        <div className={cn('overflow-hidden transition-opacity duration-300 ease-out', isExpanded ? 'opacity-100' : 'opacity-0')}>
         <CardContent className="p-0 border-t border-border/40">
           <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border/40 bg-muted/5">
 
@@ -156,24 +161,50 @@ export function WeekSummary({
                     ) : (
                       <StatValue value="—" />
                     )
+                  ) : isEditingKm ? (
+                    <div className="relative max-w-[100px]">
+                      <Input
+                        type="number"
+                        step="0.1"
+                        placeholder={stats.totalPlannedKm > 0 ? stats.totalPlannedKm.toFixed(1) : '0'}
+                        value={plannedKm}
+                        onChange={(e) => setPlannedKm(e.target.value)}
+                        onBlur={() => { handleBlur('totalPlannedKm', plannedKm); setIsEditingKm(false); }}
+                        autoFocus
+                        className="h-9 pr-8 text-sm font-bold tracking-tight bg-background border-border/60"
+                      />
+                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-bold text-muted-foreground/50 uppercase">km</span>
+                    </div>
+                  ) : weekPlan.totalPlannedKm != null ? (
+                    <div className="space-y-1">
+                      <div className="flex items-baseline gap-1">
+                        <span className="text-xl font-bold tracking-tight text-amber-500">{weekPlan.totalPlannedKm}</span>
+                        <span className="text-[10px] font-medium uppercase tracking-wider text-amber-500/70">km</span>
+                        <Button variant="ghost" size="icon" onClick={() => setIsEditingKm(true)} className="h-5 w-5 ml-0.5">
+                          <Pencil className="h-3 w-3" />
+                        </Button>
+                        <Button variant="ghost" size="icon" onClick={() => { setPlannedKm(''); onUpdate?.({ totalPlannedKm: null }); }} className="h-5 w-5">
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </div>
+                      <p className="text-[10px] text-amber-500/70 flex items-center gap-1">
+                        <Pencil className="h-2.5 w-2.5" /> {t('coach:weekSummary.manuallySet')}
+                      </p>
+                    </div>
                   ) : (
                     <div className="space-y-1">
-                      <div className="relative max-w-[100px]">
-                        <Input
-                          type="number"
-                          step="0.1"
-                          placeholder="0"
-                          value={plannedKm}
-                          onChange={(e) => setPlannedKm(e.target.value)}
-                          onBlur={() => handleBlur('totalPlannedKm', plannedKm)}
-                          className="h-9 pr-8 text-sm font-bold tracking-tight bg-background border-border/60"
-                        />
-                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-bold text-muted-foreground/50 uppercase">km</span>
+                      <div className="flex items-baseline gap-1.5">
+                        {stats.totalPlannedKm > 0 ? (
+                          <StatValue value={`~${stats.totalPlannedKm.toFixed(1)}`} unit="km" />
+                        ) : (
+                          <StatValue value="—" />
+                        )}
+                        <Button variant="ghost" size="icon" onClick={() => setIsEditingKm(true)} className="h-5 w-5">
+                          <Pencil className="h-3 w-3 text-muted-foreground" />
+                        </Button>
                       </div>
-                      {!plannedKm && stats.totalPlannedKm > 0 && (
-                        <p className="text-[10px] text-muted-foreground/60">
-                          Σ {stats.totalPlannedKm.toFixed(1)} km from sessions
-                        </p>
+                      {stats.totalPlannedKm > 0 && (
+                        <p className="text-[10px] text-muted-foreground/50">{t('coach:weekSummary.fromSessions')}</p>
                       )}
                     </div>
                   )}
@@ -273,7 +304,8 @@ export function WeekSummary({
 
           </div>
         </CardContent>
-      )}
+        </div>
+      </div>
     </Card>
   );
 }

--- a/app/components/calendar/WeekSummary.tsx
+++ b/app/components/calendar/WeekSummary.tsx
@@ -70,7 +70,7 @@ export function WeekSummary({
   const duration = formatDuration(stats.totalActualDurationMinutes);
 
   return (
-    <Card className="overflow-hidden border-border/50 shadow-sm py-0 gap-0 animate-in fade-in duration-300">
+    <Card className="overflow-hidden border-border/50 shadow-sm py-0 gap-0">
       <CardHeader className={cn("py-4 px-6 transition-all", !isExpanded && "py-4")}>
         <div className="flex justify-between items-center">
           <CardTitle className="text-sm font-semibold text-foreground/80 uppercase tracking-wider">

--- a/app/components/layout/BottomNav.tsx
+++ b/app/components/layout/BottomNav.tsx
@@ -41,11 +41,11 @@ function NavItem({ to, icon: Icon, label, isActive, onClick }: NavItemProps) {
 
 export function BottomNav() {
   const { t } = useTranslation('common')
-  const { user, selectedAthleteId, clearSelectedAthlete } = useAuth()
+  const { user, isLoading, selectedAthleteId, clearSelectedAthlete } = useAuth()
   const localePath = useLocalePath()
   const { pathname } = useLocation()
 
-  if (!user) return null
+  if (isLoading || !user) return null
 
   const isTeamActive = user.role === 'coach' && !selectedAthleteId && pathname.includes('/coach')
   const isWeekActive = pathname.includes('/week') && (user.role === 'athlete' || !!selectedAthleteId)

--- a/app/components/ui/app-loader.tsx
+++ b/app/components/ui/app-loader.tsx
@@ -1,0 +1,21 @@
+import { Logo } from '~/components/layout/Logo'
+
+interface AppLoaderProps {
+  className?: string
+}
+
+export function AppLoader({ className }: AppLoaderProps) {
+  return (
+    <div className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${className ?? ''}`}>
+      <style>{`
+        @keyframes app-loader-breathe {
+          0%, 100% { transform: scale(1); }
+          50%       { transform: scale(1.06); }
+        }
+      `}</style>
+      <div style={{ animation: 'app-loader-breathe 2s ease-in-out infinite' }}>
+        <Logo size="lg" showWordmark={true} />
+      </div>
+    </div>
+  )
+}

--- a/app/components/ui/stagger-in.tsx
+++ b/app/components/ui/stagger-in.tsx
@@ -1,0 +1,21 @@
+import { cn } from '~/lib/utils'
+
+interface StaggerInProps {
+  delay?: number
+  className?: string
+  children: React.ReactNode
+}
+
+export function StaggerIn({ delay = 0, className, children }: StaggerInProps) {
+  return (
+    <div
+      className={cn('animate-in fade-in slide-in-from-bottom-2 duration-500', className)}
+      style={{
+        animationFillMode: 'both',
+        ...(delay > 0 && { animationDelay: `${delay}ms` }),
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/app/i18n/resources/en/coach.json
+++ b/app/i18n/resources/en/coach.json
@@ -13,7 +13,9 @@
     "totalTime": "Total Time",
     "progress": "Progress",
     "coachComments": "Coach Notes",
-    "coachCommentsPlaceholder": "Add notes for the athlete..."
+    "coachCommentsPlaceholder": "Add notes for the athlete...",
+    "fromSessions": "from sessions",
+    "manuallySet": "manually set"
   },
   "session": {
     "add": "Add Session",
@@ -60,10 +62,12 @@
     "copyWeek": "Copy week ↓",
     "copyDay": "Copy day ↓",
     "copySession": "Copy",
+    "copySessionPickDay": "Choose a target day",
+    "copySessionRestDayBlocked": "Rest day planned",
     "expand": "Expand week",
     "collapse": "Collapse week",
     "currentWeek": "Current week",
-    "copyWeekConfirmTitle": "Copy Week {{week}} — {{range}} to current week?",
+    "copyWeekConfirmTitle": "Copy Week {{week}} to current week?",
     "copyWeekConfirmBody": "{{count}} sessions will be added to your current week."
   },
   "copy": {

--- a/app/i18n/resources/pl/coach.json
+++ b/app/i18n/resources/pl/coach.json
@@ -57,6 +57,8 @@
   "history": {
     "weekLabel": "Tydzień {{week}} — {{range}}",
     "sessionCount_one": "{{count}} trening",
+    "sessionCount_few": "{{count}} treningi",
+    "sessionCount_many": "{{count}} treningów",
     "sessionCount_other": "{{count}} treningów",
     "noSessions": "Brak treningów",
     "copyWeek": "Kopiuj tydzień ↓",

--- a/app/i18n/resources/pl/coach.json
+++ b/app/i18n/resources/pl/coach.json
@@ -13,7 +13,9 @@
     "totalTime": "Łączny Czas",
     "progress": "Postęp",
     "coachComments": "Notatki Trenera",
-    "coachCommentsPlaceholder": "Dodaj notatki dla zawodnika..."
+    "coachCommentsPlaceholder": "Dodaj notatki dla zawodnika...",
+    "fromSessions": "z treningów",
+    "manuallySet": "ustawiono ręcznie"
   },
   "session": {
     "add": "Dodaj Trening",
@@ -60,10 +62,12 @@
     "copyWeek": "Kopiuj tydzień ↓",
     "copyDay": "Kopiuj dzień ↓",
     "copySession": "Kopiuj",
+    "copySessionPickDay": "Wybierz dzień docelowy",
+    "copySessionRestDayBlocked": "Zaplanowany dzień odpoczynku",
     "expand": "Rozwiń tydzień",
     "collapse": "Zwiń tydzień",
     "currentWeek": "Bieżący tydzień",
-    "copyWeekConfirmTitle": "Skopiować Tydzień {{week}} — {{range}} do bieżącego tygodnia?",
+    "copyWeekConfirmTitle": "Skopiować Tydzień {{week}} do bieżącego tygodnia?",
     "copyWeekConfirmBody": "{{count}} treningów zostanie dodanych do bieżącego tygodnia."
   },
   "copy": {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from '~/components/ui/tooltip';
 import { Toaster } from '~/components/ui/sonner';
 import { AuthProvider } from '~/lib/context/AuthContext';
 import { ThemeProvider } from '~/lib/context/ThemeContext';
+import { AppLoader } from '~/components/ui/app-loader';
 
 import type { Route } from './+types/root';
 import './app.css';
@@ -47,7 +48,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export function HydrateFallback() {
-  return null;
+  return <AppLoader />;
 }
 
 export default function App() {

--- a/app/routes/athlete/layout.tsx
+++ b/app/routes/athlete/layout.tsx
@@ -1,11 +1,12 @@
 import { Navigate, Outlet, useParams } from 'react-router';
 import { useAuth } from '~/lib/context/AuthContext';
+import { AppLoader } from '~/components/ui/app-loader';
 
 export default function AthleteLayout() {
   const { user, isLoading } = useAuth();
   const { locale = 'pl' } = useParams<{ locale?: string }>();
 
-  if (isLoading) return null;
+  if (isLoading) return <AppLoader />;
 
   // FR-004: Unauthenticated → login
   if (!user) return <Navigate to="/login" replace />;

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -8,7 +8,7 @@ import {
 import { WeekNavigation } from '~/components/calendar/WeekNavigation';
 import { WeekGrid } from '~/components/calendar/WeekGrid';
 import { WeekSummary } from '~/components/calendar/WeekSummary';
-import { WeekSkeleton } from '~/components/calendar/WeekSkeleton';
+import { AppLoader } from '~/components/ui/app-loader';
 import { SessionForm } from '~/components/training/SessionForm';
 import { useWeekPlan, useGetOrCreateWeekPlan } from '~/lib/hooks/useWeekPlan';
 import {
@@ -188,8 +188,10 @@ export default function AthleteWeekView() {
   const showSkeleton = isInitialLoad || (canSelfPlan && getOrCreate.isPending && !weekPlan);
 
   return (
-    <div key={weekId} className="space-y-6 animate-in fade-in duration-200">
-      {showSkeleton ? <WeekSkeleton /> : !weekPlan ? (
+    <>
+      {showSkeleton && <AppLoader />}
+      <div key={weekId} className="space-y-6 animate-in fade-in duration-200">
+      {!showSkeleton && (!weekPlan ? (
         <>
           <div className="flex items-center gap-2">
             <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
@@ -255,7 +257,7 @@ export default function AthleteWeekView() {
             isSharePending={bulkConfirmStrava.isPending}
           />
         </>
-      )}
+      ))}
 
       {/* Delete session confirmation */}
       <Dialog open={!!deleteConfirmId} onOpenChange={(open) => { if (!open) setDeleteConfirmId(null); }}>
@@ -275,5 +277,6 @@ export default function AthleteWeekView() {
         </DialogContent>
       </Dialog>
     </div>
+    </>
   );
 }

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Button } from '~/components/ui/button';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from '~/components/ui/dialog';
 import { WeekNavigation } from '~/components/calendar/WeekNavigation';
 import { WeekGrid } from '~/components/calendar/WeekGrid';
 import { WeekSummary } from '~/components/calendar/WeekSummary';
@@ -77,6 +80,7 @@ export default function AthleteWeekView() {
   const [formOpen, setFormOpen] = useState(false);
   const [formDay, setFormDay] = useState<DayOfWeek | undefined>();
   const [editingSession, setEditingSession] = useState<TrainingSession | null>(null);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
   const stravaConnected = stravaStatus?.connected ?? false;
   const junctionConnected = junctionConnection?.status === 'active';
@@ -162,12 +166,8 @@ export default function AthleteWeekView() {
   }, []);
 
   const handleDeleteSession = useCallback(
-    (sessionId: string) => {
-      if (window.confirm(t('common:session.deleteConfirm' as never))) {
-        deleteSessionMut.mutate(sessionId);
-      }
-    },
-    [t, deleteSessionMut]
+    (sessionId: string) => { setDeleteConfirmId(sessionId); },
+    []
   );
 
   const handleFormSubmit = useCallback(
@@ -184,83 +184,96 @@ export default function AthleteWeekView() {
 
   if (!weekId) return null;
 
-  if (
-    weekLoading ||
-    (canSelfPlan && getOrCreate.isPending && !weekPlan) ||
-    (!!weekPlan && sessionsQuery.isPending)
-  ) {
-    return <WeekSkeleton />;
-  }
-
-  if (!weekPlan) {
-    return (
-      <div className="space-y-6">
-        <div className="flex items-center gap-2">
-          <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
-          <WeekNavigation weekId={weekId} basePath="athlete" selectedDay={selectedDay} />
-        </div>
-        <div className="text-center py-20 text-muted-foreground">
-          {t('noTrainingPlan')}
-        </div>
-      </div>
-    );
-  }
+  const isInitialLoad = weekLoading && !weekPlan && !(canSelfPlan && getOrCreate.isPending);
+  const showSkeleton = isInitialLoad || (canSelfPlan && getOrCreate.isPending && !weekPlan);
 
   return (
-    <div className="space-y-6">
-      {/* Header with navigation */}
-      <div className="flex items-center gap-2">
-        <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
-        <WeekNavigation weekId={weekId} basePath="athlete" selectedDay={selectedDay} />
-      </div>
+    <div key={weekId} className="space-y-6 animate-in fade-in duration-200">
+      {showSkeleton ? <WeekSkeleton /> : !weekPlan ? (
+        <>
+          <div className="flex items-center gap-2">
+            <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
+            <WeekNavigation weekId={weekId} basePath="athlete" selectedDay={selectedDay} />
+          </div>
+          <div className="text-center py-20 text-muted-foreground">
+            {t('noTrainingPlan')}
+          </div>
+        </>
+      ) : (
+        <>
+          {/* Header with navigation */}
+          <div className="flex items-center gap-2">
+            <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
+            <WeekNavigation weekId={weekId} basePath="athlete" selectedDay={selectedDay} isLoading={weekLoading} />
+          </div>
 
-      {/* Week Summary (readonly with progress bar) */}
-      <WeekSummary weekPlan={weekPlan} stats={stats} readonly />
+          {/* Week Summary (readonly with progress bar) */}
+          <WeekSummary weekPlan={weekPlan} stats={stats} readonly />
 
-      {/* Week Grid */}
-      <WeekGrid
-        sessionsByDay={sessionsByDay}
-        weekStart={weekStart}
-        athleteMode
-        onToggleComplete={handleToggleComplete}
-        onUpdateNotes={handleUpdateNotes}
-        onUpdatePerformance={handleUpdatePerformance}
-        stravaConnected={stravaConnected}
-        junctionConnected={junctionConnected}
-        onSyncStrava={handleSyncStrava}
-        onConfirmStrava={handleConfirmStrava}
-        userRole={user?.role}
-        selectedDay={selectedDay}
-        onSelectDay={setSelectedDay}
-        {...(canSelfPlan && {
-          onAddSession: handleAddSession,
-          onEditSession: handleEditSession,
-          onDeleteSession: handleDeleteSession,
-        })}
-      />
+          {/* Week Grid */}
+          <WeekGrid
+            sessionsByDay={sessionsByDay}
+            weekStart={weekStart}
+            athleteMode
+            onToggleComplete={handleToggleComplete}
+            onUpdateNotes={handleUpdateNotes}
+            onUpdatePerformance={handleUpdatePerformance}
+            stravaConnected={stravaConnected}
+            junctionConnected={junctionConnected}
+            onSyncStrava={handleSyncStrava}
+            onConfirmStrava={handleConfirmStrava}
+            userRole={user?.role}
+            selectedDay={selectedDay}
+            onSelectDay={setSelectedDay}
+            {...(canSelfPlan && {
+              onAddSession: handleAddSession,
+              onEditSession: handleEditSession,
+              onDeleteSession: handleDeleteSession,
+            })}
+          />
 
-      {/* Session Form — only shown when self-planning is enabled */}
-      {canSelfPlan && (
-        <SessionForm
-          open={formOpen}
-          onClose={() => setFormOpen(false)}
-          weekPlanId={weekPlan.id}
-          day={formDay}
-          session={editingSession}
-          onSubmit={handleFormSubmit}
-          isCoach={false}
-        />
+          {/* Session Form — only shown when self-planning is enabled */}
+          {canSelfPlan && (
+            <SessionForm
+              open={formOpen}
+              onClose={() => setFormOpen(false)}
+              weekPlanId={weekPlan.id}
+              day={formDay}
+              session={editingSession}
+              onSubmit={handleFormSubmit}
+              isCoach={false}
+            />
+          )}
+
+          {/* Floating Action Bar — Strava bulk sync + bulk share */}
+          <StravaActionsBar
+            unsyncedCount={stravaConnected ? sessions.filter(s => s.isCompleted && !s.stravaActivityId).length : 0}
+            unsharedCount={sessions.filter(s => s.stravaActivityId != null && !s.isStravaConfirmed).length}
+            onSyncAll={handleSyncAllStrava}
+            onShareAll={handleBulkConfirmStrava}
+            isSyncPending={stravaSyncBulk.isPending}
+            isSharePending={bulkConfirmStrava.isPending}
+          />
+        </>
       )}
 
-      {/* Floating Action Bar — Strava bulk sync + bulk share */}
-      <StravaActionsBar
-        unsyncedCount={stravaConnected ? sessions.filter(s => s.isCompleted && !s.stravaActivityId).length : 0}
-        unsharedCount={sessions.filter(s => s.stravaActivityId != null && !s.isStravaConfirmed).length}
-        onSyncAll={handleSyncAllStrava}
-        onShareAll={handleBulkConfirmStrava}
-        isSyncPending={stravaSyncBulk.isPending}
-        isSharePending={bulkConfirmStrava.isPending}
-      />
+      {/* Delete session confirmation */}
+      <Dialog open={!!deleteConfirmId} onOpenChange={(open) => { if (!open) setDeleteConfirmId(null); }}>
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t('common:session.delete' as never)}</DialogTitle>
+            <DialogDescription>{t('common:session.deleteConfirm' as never)}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setDeleteConfirmId(null)}>
+              {t('common:actions.cancel' as never)}
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => { deleteSessionMut.mutate(deleteConfirmId!); setDeleteConfirmId(null); }}>
+              {t('common:session.delete' as never)}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/routes/coach/layout.tsx
+++ b/app/routes/coach/layout.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet, useParams } from 'react-router';
+import { AppLoader } from '~/components/ui/app-loader';
 import { Users, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
@@ -21,7 +22,7 @@ export default function CoachLayout() {
   );
   const updateSelfPlan = useUpdateSelfPlanPermission();
 
-  if (isLoading) return null;
+  if (isLoading) return <AppLoader />;
 
   // FR-004: Unauthenticated → login
   if (!user) return <Navigate to="/login" replace />;

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -8,7 +8,8 @@ import { Button } from '~/components/ui/button';
 import { WeekNavigation } from '~/components/calendar/WeekNavigation';
 import { MultiWeekView } from '~/components/calendar/MultiWeekView';
 import { WeekSummary } from '~/components/calendar/WeekSummary';
-import { WeekSkeleton } from '~/components/calendar/WeekSkeleton';
+import { AppLoader } from '~/components/ui/app-loader';
+import { StaggerIn } from '~/components/ui/stagger-in';
 import { SessionForm } from '~/components/training/SessionForm';
 import { useWeekPlan, useGetOrCreateWeekPlan, useUpdateWeekPlan } from '~/lib/hooks/useWeekPlan';
 import { useSessions, useCreateSession, useUpdateSession, useDeleteSession, useUpdateAthleteSession } from '~/lib/hooks/useSessions';
@@ -148,35 +149,41 @@ export default function CoachWeekView() {
   const stats = !showSkeleton && weekPlan ? computeWeekStats(sessions) : null;
 
   return (
-    <div key={weekId} className="space-y-6 animate-in fade-in duration-200">
-      {showSkeleton ? <WeekSkeleton /> : weekPlan && sessionsByDay && stats && (
+    <>
+      {showSkeleton && <AppLoader />}
+      <div key={weekId} className="space-y-6 animate-in fade-in duration-200">
+      {!showSkeleton && weekPlan && sessionsByDay && stats && (
         <>
           {/* Header with navigation */}
-          <div className="flex items-center gap-2">
+          <StaggerIn className="flex items-center gap-2">
             <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
             <WeekNavigation weekId={weekId} basePath="coach" selectedDay={selectedDay} isLoading={weekLoading} />
-          </div>
+          </StaggerIn>
 
           {/* Week Summary */}
-          <WeekSummary
-            weekPlan={weekPlan}
-            stats={stats}
-            onUpdate={handleWeekUpdate}
-          />
+          <StaggerIn delay={60}>
+            <WeekSummary
+              weekPlan={weekPlan}
+              stats={stats}
+              onUpdate={handleWeekUpdate}
+            />
+          </StaggerIn>
 
           {/* Multi-Week View (current week + 4 history rows) */}
-          <MultiWeekView
-            currentWeekId={weekId}
-            currentWeekPlan={weekPlan}
-            currentSessions={sessions}
-            currentSessionsByDay={sessionsByDay}
-            onAddSession={handleAddSession}
-            onEditSession={handleEditSession}
-            onDeleteSession={handleDeleteSession}
-            onUpdateCoachPostFeedback={handleUpdateCoachPostFeedback}
-            userRole={user?.role}
-            showAthleteControls={isViewingSelf}
-          />
+          <StaggerIn delay={120}>
+            <MultiWeekView
+              currentWeekId={weekId}
+              currentWeekPlan={weekPlan}
+              currentSessions={sessions}
+              currentSessionsByDay={sessionsByDay}
+              onAddSession={handleAddSession}
+              onEditSession={handleEditSession}
+              onDeleteSession={handleDeleteSession}
+              onUpdateCoachPostFeedback={handleUpdateCoachPostFeedback}
+              userRole={user?.role}
+              showAthleteControls={isViewingSelf}
+            />
+          </StaggerIn>
 
           {/* Session Form Sheet */}
           <SessionForm
@@ -209,5 +216,6 @@ export default function CoachWeekView() {
         </DialogContent>
       </Dialog>
     </div>
+    </>
   );
 }

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from '~/components/ui/dialog';
+import { Button } from '~/components/ui/button';
 import { WeekNavigation } from '~/components/calendar/WeekNavigation';
 import { MultiWeekView } from '~/components/calendar/MultiWeekView';
 import { WeekSummary } from '~/components/calendar/WeekSummary';
@@ -64,9 +68,8 @@ export default function CoachWeekView() {
   // Form state
   const [formOpen, setFormOpen] = useState(false);
   const [formDay, setFormDay] = useState<DayOfWeek | undefined>();
-  const [editingSession, setEditingSession] = useState<TrainingSession | null>(
-    null
-  );
+  const [editingSession, setEditingSession] = useState<TrainingSession | null>(null);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
   const handleAddSession = useCallback((day: DayOfWeek) => {
     setEditingSession(null);
@@ -81,12 +84,8 @@ export default function CoachWeekView() {
   }, []);
 
   const handleDeleteSession = useCallback(
-    (sessionId: string) => {
-      if (window.confirm(t('session.deleteConfirm'))) {
-        deleteSessionMut.mutate(sessionId);
-      }
-    },
-    [t, deleteSessionMut]
+    (sessionId: string) => { setDeleteConfirmId(sessionId); },
+    []
   );
 
   const handleFormSubmit = useCallback(
@@ -142,58 +141,73 @@ export default function CoachWeekView() {
 
   if (!weekId) return null;
 
-  if (
-    weekLoading ||
-    (getOrCreate.isPending && !weekPlan) ||
-    (!!weekPlan && sessionsQuery.isPending)
-  ) {
-    return <WeekSkeleton />;
-  }
+  const isInitialLoad = weekLoading && !weekPlan && !getOrCreate.isPending;
+  const showSkeleton = isInitialLoad || (getOrCreate.isPending && !weekPlan);
 
-  if (!weekPlan) return null;
-
-  const sessionsByDay = groupSessionsByDay(sessions);
-  const stats = computeWeekStats(sessions);
+  const sessionsByDay = !showSkeleton && weekPlan ? groupSessionsByDay(sessions) : null;
+  const stats = !showSkeleton && weekPlan ? computeWeekStats(sessions) : null;
 
   return (
-    <div className="space-y-6">
-      {/* Header with navigation */}
-      <div className="flex items-center gap-2">
-        <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
-        <WeekNavigation weekId={weekId} basePath="coach" selectedDay={selectedDay} />
-      </div>
+    <div key={weekId} className="space-y-6 animate-in fade-in duration-200">
+      {showSkeleton ? <WeekSkeleton /> : weekPlan && sessionsByDay && stats && (
+        <>
+          {/* Header with navigation */}
+          <div className="flex items-center gap-2">
+            <h1 className="text-base sm:text-xl font-bold whitespace-nowrap shrink-0">{t('title')}</h1>
+            <WeekNavigation weekId={weekId} basePath="coach" selectedDay={selectedDay} isLoading={weekLoading} />
+          </div>
 
-      {/* Week Summary */}
-      <WeekSummary
-        weekPlan={weekPlan}
-        stats={stats}
-        onUpdate={handleWeekUpdate}
-      />
+          {/* Week Summary */}
+          <WeekSummary
+            weekPlan={weekPlan}
+            stats={stats}
+            onUpdate={handleWeekUpdate}
+          />
 
-      {/* Multi-Week View (current week + 4 history rows) */}
-      <MultiWeekView
-        currentWeekId={weekId}
-        currentWeekPlan={weekPlan}
-        currentSessions={sessions}
-        currentSessionsByDay={sessionsByDay}
-        onAddSession={handleAddSession}
-        onEditSession={handleEditSession}
-        onDeleteSession={handleDeleteSession}
-        onUpdateCoachPostFeedback={handleUpdateCoachPostFeedback}
-        userRole={user?.role}
-        showAthleteControls={isViewingSelf}
-      />
+          {/* Multi-Week View (current week + 4 history rows) */}
+          <MultiWeekView
+            currentWeekId={weekId}
+            currentWeekPlan={weekPlan}
+            currentSessions={sessions}
+            currentSessionsByDay={sessionsByDay}
+            onAddSession={handleAddSession}
+            onEditSession={handleEditSession}
+            onDeleteSession={handleDeleteSession}
+            onUpdateCoachPostFeedback={handleUpdateCoachPostFeedback}
+            userRole={user?.role}
+            showAthleteControls={isViewingSelf}
+          />
 
-      {/* Session Form Sheet */}
-      <SessionForm
-        open={formOpen}
-        onClose={() => setFormOpen(false)}
-        weekPlanId={weekPlan.id}
-        day={formDay}
-        session={editingSession}
-        onSubmit={handleFormSubmit}
-        isCoach={true}
-      />
+          {/* Session Form Sheet */}
+          <SessionForm
+            open={formOpen}
+            onClose={() => setFormOpen(false)}
+            weekPlanId={weekPlan.id}
+            day={formDay}
+            session={editingSession}
+            onSubmit={handleFormSubmit}
+            isCoach={true}
+          />
+        </>
+      )}
+
+      {/* Delete session confirmation */}
+      <Dialog open={!!deleteConfirmId} onOpenChange={(open) => { if (!open) setDeleteConfirmId(null); }}>
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t('session.delete')}</DialogTitle>
+            <DialogDescription>{t('session.deleteConfirm')}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setDeleteConfirmId(null)}>
+              {t('common:actions.cancel' as never)}
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => { deleteSessionMut.mutate(deleteConfirmId!); setDeleteConfirmId(null); }}>
+              {t('session.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -7,7 +7,7 @@ import { WhySynekSection } from '~/components/landing/WhySynekSection'
 import { FeaturesSection } from '~/components/landing/FeaturesSection'
 import { JoinBetaSection } from '~/components/landing/JoinBetaSection'
 import { ContactSection } from '~/components/landing/ContactSection'
-import { Logo } from '~/components/layout/Logo'
+import { AppLoader } from '~/components/ui/app-loader'
 
 export function meta() {
   return [
@@ -28,13 +28,7 @@ export default function LandingPage() {
   }, [user, isLoading, navigate, locale])
 
   if (isLoading || user) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="animate-pulse">
-          <Logo size="lg" showWordmark={true} />
-        </div>
-      </div>
-    )
+    return <AppLoader />
   }
 
   return (

--- a/app/test/integration/HistoryWeekRow.test.tsx
+++ b/app/test/integration/HistoryWeekRow.test.tsx
@@ -143,7 +143,7 @@ describe('HistoryWeekRow', () => {
     expect(screen.queryByRole('button', { name: /add session/i })).not.toBeInTheDocument();
   });
 
-  it('shows day-picker when copy icon is clicked on a session card', () => {
+  it('shows day-picker dialog when copy icon is clicked on a session card', () => {
     const onCopySession = vi.fn();
     const Wrapper = makeWrapper();
     render(
@@ -152,15 +152,17 @@ describe('HistoryWeekRow', () => {
       </Wrapper>
     );
 
-    // Click the copy icon on the session card (WeekGrid renders both mobile+desktop)
+    // Click the copy icon on the session card
     const copyBtns = screen.getAllByTestId('session-copy-btn');
     fireEvent.click(copyBtns[0]);
 
-    // Day picker should appear (7 day buttons)
-    expect(screen.getByTestId('session-day-picker')).toBeInTheDocument();
+    // Dialog should open with day buttons
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // All 7 day buttons should be present
+    expect(screen.getByRole('button', { name: /thursday/i })).toBeInTheDocument();
   });
 
-  it('calls onCopySession when a day is selected in the picker', () => {
+  it('calls onCopySession when a day is selected in the picker dialog', () => {
     const onCopySession = vi.fn();
     const Wrapper = makeWrapper();
     render(
@@ -170,15 +172,15 @@ describe('HistoryWeekRow', () => {
     );
 
     fireEvent.click(screen.getAllByTestId('session-copy-btn')[0]);
-    // Click 'thursday' in the day picker
-    fireEvent.click(screen.getByTestId('day-pick-thursday'));
+    // Click 'thursday' in the day picker dialog
+    fireEvent.click(screen.getByRole('button', { name: /thursday/i }));
 
     expect(onCopySession).toHaveBeenCalledWith(mockSession, 'thursday');
-    // Picker should close
-    expect(screen.queryByTestId('session-day-picker')).not.toBeInTheDocument();
+    // Dialog should close
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('closes day-picker on Escape without calling onCopySession', () => {
+  it('closes day-picker dialog when Cancel is clicked without calling onCopySession', () => {
     const onCopySession = vi.fn();
     const Wrapper = makeWrapper();
     render(
@@ -188,10 +190,11 @@ describe('HistoryWeekRow', () => {
     );
 
     fireEvent.click(screen.getAllByTestId('session-copy-btn')[0]);
-    expect(screen.getByTestId('session-day-picker')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
 
-    fireEvent.keyDown(document, { key: 'Escape' });
-    expect(screen.queryByTestId('session-day-picker')).not.toBeInTheDocument();
+    // Click Cancel button to close
+    fireEvent.click(screen.getByRole('button', { name: /cancel|anuluj/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(onCopySession).not.toHaveBeenCalled();
   });
 });

--- a/app/test/integration/MultiWeekView.test.tsx
+++ b/app/test/integration/MultiWeekView.test.tsx
@@ -176,11 +176,12 @@ describe('MultiWeekView', () => {
 
     // Find and click the first "Copy week" button (W11, which has sessions) — opens dialog
     // EN: "Copy week ↓", PL: "Kopiuj tydzień ↓"
-    const copyWeekBtns = await screen.findAllByRole('button', { name: /copy week|kopiuj tydzień/i });
+    // Generous timeout: button only appears after 2 sequential mock requests (each ~150ms) per week slot
+    const copyWeekBtns = await screen.findAllByRole('button', { name: /copy week|kopiuj tydzień/i }, { timeout: 5000 });
     fireEvent.click(copyWeekBtns[0]);
 
     // Confirm in the dialog — a second "Copy week" button appears inside the dialog footer
-    const confirmBtns = await screen.findAllByRole('button', { name: /copy week|kopiuj tydzień/i });
+    const confirmBtns = await screen.findAllByRole('button', { name: /copy week|kopiuj tydzień/i }, { timeout: 5000 });
     fireEvent.click(confirmBtns[confirmBtns.length - 1]);
 
     await waitFor(() =>

--- a/app/test/integration/athlete-week-loading.test.tsx
+++ b/app/test/integration/athlete-week-loading.test.tsx
@@ -103,7 +103,7 @@ describe('AthleteWeekView loading state', () => {
     useSelfPlanPermissionMock.mockReturnValue({ data: true })
   })
 
-  it('keeps the skeleton visible while sessions are still pending for a resolved week plan', () => {
+  it('renders the grid when weekPlan exists even if sessions are still loading', () => {
     useWeekPlanMock.mockReturnValue({
       data: { id: 'week-plan-1' },
       isLoading: false,
@@ -115,8 +115,8 @@ describe('AthleteWeekView loading state', () => {
 
     renderPage()
 
-    expect(screen.getByTestId('week-skeleton')).toBeInTheDocument()
-    expect(screen.queryByTestId('week-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('week-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('week-grid')).toBeInTheDocument()
   })
 
   it('renders the week layout after the sessions query settles, even for an empty week', () => {

--- a/app/test/integration/coach-week-loading.test.tsx
+++ b/app/test/integration/coach-week-loading.test.tsx
@@ -71,7 +71,7 @@ function renderPage() {
 }
 
 describe('CoachWeekView loading state', () => {
-  it('keeps the skeleton visible while sessions are still pending for a resolved week plan', () => {
+  it('renders the grid when weekPlan exists even if sessions are still loading', () => {
     useWeekPlanMock.mockReturnValue({
       data: { id: 'week-plan-1' },
       isLoading: false,
@@ -83,8 +83,8 @@ describe('CoachWeekView loading state', () => {
 
     renderPage()
 
-    expect(screen.getByTestId('week-skeleton')).toBeInTheDocument()
-    expect(screen.queryByTestId('week-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('week-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('week-grid')).toBeInTheDocument()
   })
 
   it('renders the week layout after the sessions query settles', () => {


### PR DESCRIPTION
## Summary

- **`<StaggerIn>` primitive** — reusable fade+slide wrapper with configurable delay; replaces inline animation divs in `MultiWeekView` and wraps the three content sections in the coach week route at 0/60/120ms cadence
- **`<AppLoader>` primitive** — pulsing Synek logo extracted from `landing.tsx` into a shared component; used as the single loading state across the entire app (HydrateFallback, auth loading in layouts, week data loading in routes)
- **Fixed `position: fixed` containment bug** — `AppLoader` now renders outside the `animate-in` wrapper div; CSS transforms on animated parents were trapping fixed children, causing the loader to appear at the wrong position
- **BottomNav hidden during auth load** — prevents the nav bar from popping up before the loader hands off to content
- **Fixed Polish plurals for session count in history week tabs** — added missing `_few` and `_many` forms so counts like 2–4 and 5+ no longer fall back to English

## Loading flow (after)

HydrateFallback (AppLoader) → auth loading (AppLoader) → week data loading (AppLoader) → stagger fade-in

## Test plan

- [x] Hard reload on fast 4G throttle — AppLoader appears immediately, no blank screen
- [x] Navigate to an uncached week — AppLoader shows, then header/summary/grid stagger in
- [x] Navigate between weeks — no position glitch, BottomNav stays hidden until content is ready
- [x] Mobile: BottomNav does not appear during any loading phase
- [x] History rows in MultiWeekView still stagger at 60ms cadence
- [x] Polish locale: session count in history week tabs shows "2 treningi", "5 treningów" (not English)

🤖 Generated with [Claude Code](https://claude.com/claude-code)