### PR TITLE
docs: optimise CLAUDE.md, README, and constitution

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,27 +1,33 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: [template] → 1.0.0
-Bump rationale: MINOR — first population of all placeholder tokens; principles added and governance defined.
+Version change: 1.0.0 → 2.0.0
+Bump rationale: MAJOR — all five principles renamed and redefined (backward-incompatible
+  replacement of principle set); Development Workflow expanded with feature-branch,
+  CI, commit-convention, and breaking-change requirements; Technology & Constraints
+  expanded with security rules and secret-handling policy.
 
 Modified principles:
-  - [PRINCIPLE_1_NAME] → I. Code Quality & Maintainability (new)
-  - [PRINCIPLE_2_NAME] → II. Testing Standards (new)
-  - [PRINCIPLE_3_NAME] → III. User Experience Consistency (new)
-  - [PRINCIPLE_4_NAME] → IV. Performance Requirements (new)
-  - [PRINCIPLE_5_NAME] → V. Simplicity & Anti-Complexity (new)
+  - I. Code Quality & Maintainability → I. Lean & Purposeful
+  - II. Testing Standards → II. Configuration Over Hardcoding
+  - III. User Experience Consistency → III. Type Safety & Boundary Validation
+  - IV. Performance Requirements → IV. Modularity & Testability
+  - V. Simplicity & Anti-Complexity → V. Performance & Operational Discipline
 
-Added sections:
-  - "Technology & Stack Constraints" (replaces [SECTION_2_NAME])
-  - "Development Workflow & Quality Gates" (replaces [SECTION_3_NAME])
-  - Governance (populated)
+Added sections / subsections:
+  - "Security & Secret Handling" subsection under Technology & Constraints
+  - Feature-branch and CI requirements under Development Workflow
+  - Commit conventions and breaking-change documentation requirements
 
 Removed sections: none
 
 Templates requiring updates:
-  ✅ .specify/templates/plan-template.md — "Constitution Check" section already generic; gates should reference the five principles by name when filling out for Synek features.
-  ✅ .specify/templates/spec-template.md — "Success Criteria" section aligns with Principle IV performance targets; no structural change needed.
-  ✅ .specify/templates/tasks-template.md — Task categories (setup, foundational, user-story, polish) remain unchanged; testing tasks MUST follow Principle II when included.
+  ✅ .specify/templates/plan-template.md — "Constitution Check" section is generic;
+     gates should reference the five new principle names when filling out for Synek features.
+  ✅ .specify/templates/spec-template.md — no structural changes required; Success Criteria
+     section aligns with Principle V performance targets.
+  ✅ .specify/templates/tasks-template.md — task categories unchanged; Polish phase tasks
+     MUST include a quality-gate verification step per Principle V.
   ⚠  No command files found in .specify/templates/commands/ — nothing to update.
 
 Deferred items: none
@@ -31,90 +37,111 @@ Deferred items: none
 
 ## Core Principles
 
-### I. Code Quality & Maintainability
+### I. Lean & Purposeful
 
-All code MUST follow the conventions defined in `CLAUDE.md` without exception:
+Every feature MUST map to a concrete user, business, or operational need before work begins:
 
-- Components MUST use named exports only; no default exports.
-- TypeScript strict mode MUST be satisfied — `any` is forbidden; use `unknown` and narrow explicitly.
-- All conditional class merging MUST use `cn()` from `~/lib/utils`.
-- Path alias `~/` MUST be used for all intra-app imports; relative paths only within the same directory.
-- DB column names MUST be mapped snake_case → camelCase via explicit row-mapper functions in query files.
-- No inline queries or direct `supabase.from()` calls outside `app/lib/queries/` — all DB access is mediated through the query layer.
-- Component props interfaces MUST be declared in the same file, above the component, and MUST include `className?: string` for composability.
+- Features without a documented user, business, or operational justification MUST NOT be
+  implemented.
+- Speculative abstractions are forbidden — code is written for today's requirement, not
+  imagined future ones (YAGNI).
+- Any added complexity MUST be explicitly justified in the feature plan before implementation.
+  "Nice to have" is not a justification.
+- Helpers, utilities, and abstractions created for a single call site are forbidden — inline
+  the logic instead.
+- Backwards-compatibility shims, dead code, and unused exports MUST be removed completely
+  rather than retained for hypothetical callers.
 
-**Rationale**: Consistent, predictable structure reduces cognitive load and prevents regressions as the
-codebase grows. Strict typing surfaces bugs at compile time before they reach users.
+**Rationale**: Synek is a focused training planning tool. Keeping scope tight reduces maintenance
+burden, accelerates delivery, and prevents the codebase from accumulating weight that slows
+future changes.
 
-### II. Testing Standards
+### II. Configuration Over Hardcoding
 
-Every feature that touches data MUST include both a real and a mock implementation:
+Behavior that is expected to vary across environments, use cases, or supported variants MUST be
+driven by configuration rather than embedded in core logic:
 
-- Query files MUST export mock functions usable for isolated testing.
-- Mock mode MUST activate automatically when Supabase credentials are absent/placeholder — no manual flag.
+- Sport colors, labels, and metadata MUST live in `app/lib/utils/training-types.ts` — inventing
+  inline color literals is forbidden.
+- Environment-specific behavior (mock mode, Supabase credentials, feature URLs) MUST be
+  controlled via `import.meta.env.VITE_*` variables, not compile-time conditionals in logic.
+- Mock mode MUST activate automatically when Supabase credentials are absent/placeholder —
+  no manual flag or code branch needed.
+- Adding a new training type (sport) MUST require changes only to the configuration layer
+  (`training-types.ts`, `training.ts`, type-fields, i18n) — no changes to rendering or
+  routing scaffolding.
+- i18n keys MUST be added to both `en/` and `pl/` namespaces simultaneously; partial
+  translation ships are not acceptable.
+
+**Rationale**: Configuration-driven extension keeps the core logic stable as the supported
+feature set grows. It also makes the system testable in isolation (mock mode) without
+environment dependencies.
+
+### III. Type Safety & Boundary Validation
+
+Strict typing MUST be enabled and preserved throughout the codebase:
+
+- TypeScript strict mode MUST be satisfied at all times — `any` is forbidden; use `unknown`
+  and narrow explicitly.
+- Unsafe escape hatches (`as any`, `@ts-ignore`) are forbidden unless accompanied by an
+  explicit comment explaining why the type system cannot be satisfied and reviewed in PR.
+  The only accepted exception pattern is `as never` for dynamic i18n template-literal keys
+  that TypeScript cannot verify.
+- All external inputs (user forms, Supabase responses, Edge Function payloads, URL params)
+  MUST be validated with Zod 4 at the system boundary before entering core logic.
+- DB responses MUST pass through explicit row-mapper functions (`toMyType(row)`) that
+  perform snake_case → camelCase mapping and type narrowing — raw DB rows MUST NOT flow
+  into domain types.
+- `pnpm typecheck` MUST pass with exit code 0 before any feature is considered complete.
+
+**Rationale**: Type errors caught at compile time are orders of magnitude cheaper than bugs
+caught in production. Strict boundary validation prevents malformed external data from
+corrupting application state.
+
+### IV. Modularity & Testability
+
+Code units MUST be small, focused, and independently testable:
+
+- Side effects (data fetching, mutations, subscriptions) MUST be isolated from presentation
+  logic — all server state goes through `lib/hooks/` → `lib/queries/` → Supabase; no
+  `useEffect` fetching and no `supabase.from()` calls in components.
+- Every query file MUST export both a real Supabase implementation and a mock implementation
+  usable for isolated testing — the mock MUST be the first implementation written.
 - All React Query mutations MUST implement the full optimistic-update cycle:
   `onMutate` (cancel + snapshot) → `onError` (rollback) → `onSettled` (invalidate).
-- Acceptance scenarios in specs MUST follow Given/When/Then format and be independently testable.
-- `pnpm typecheck` MUST pass before any feature is considered complete.
+- State and responsibility MUST live at the lowest sensible scope — lift state only when
+  genuinely shared across siblings; do not hoist to global context prematurely.
+- Mock stores MUST use deep clones on reset (`SEED.map(i => ({ ...i }))`) to prevent
+  mutation bleed between test cases.
 
-**Rationale**: Reliable mock coverage enables development and CI without live credentials. Optimistic
-updates guarantee UI correctness under network failure. Type-checking is a first-class quality gate.
+**Rationale**: Decoupled, independently testable units allow parallel development, reliable
+CI, and confident refactoring. Optimistic updates guarantee UI correctness under network
+failure without coupling UI state to network timing.
 
-### III. User Experience Consistency
+### V. Performance & Operational Discipline
 
-All UI MUST conform to the established design system without deviation:
+Performance MUST be considered at design time, not retrofitted after delivery:
 
-- Sport color tokens MUST be taken from `app/lib/utils/training-types.ts` — inventing new colors is
-  forbidden.
-- All user-visible strings MUST be translated via `t('key')` using i18next; hardcoded English in JSX
-  is a blocking defect.
-- Translations MUST be added to both `en/` and `pl/` namespaces simultaneously — partial translation
-  ships are not acceptable.
-- shadcn/ui components MUST be added only via `pnpm dlx shadcn@latest add <name>`; files in
-  `app/components/ui/` MUST NOT be edited manually.
-- Date display MUST use utilities from `app/lib/utils/date.ts` and `date-fns` — raw `new Date()`
-  arithmetic is forbidden.
+- **Bundle discipline**: New dependencies MUST be evaluated for bundle impact before
+  adoption; adding a package that increases the production bundle by more than 50 KB
+  (gzipped) requires explicit documentation in the feature plan.
+- **Query efficiency**: Supabase queries MUST select only required columns;
+  `select('*')` is acceptable only in prototypes and MUST be removed before merge.
+- **Interaction latency**: Optimistic updates MUST reflect user actions within one render
+  frame (~16 ms) — no waiting on network for UI feedback.
+- **Build and delivery gates**: `pnpm typecheck` and all tests MUST pass before merge;
+  a PR that fails any quality gate MUST NOT be merged regardless of feature completeness.
+- **Dependency policy**: Tree-shakeable packages are strongly preferred. Any major new
+  framework or library requires a constitution amendment updating the Technology section.
 
-**Rationale**: Visual and linguistic consistency builds user trust. A shared color system and i18n
-discipline prevent fragmentation as the feature set expands.
+**Rationale**: Athletes and coaches often use the platform on mobile or variable connections.
+Fast, disciplined delivery directly affects training adherence. Enforcing gates at merge time
+prevents regressions from accumulating.
 
-### IV. Performance Requirements
+## Technology & Constraints
 
-The application MUST meet the following baseline targets:
-
-- **Initial load**: Time-to-interactive on a modern desktop MUST be under 3 seconds on a standard
-  broadband connection (measured with production build).
-- **Interaction latency**: Optimistic updates MUST reflect user actions within one render frame
-  (~16 ms) — no waiting on network for UI feedback.
-- **Bundle discipline**: New dependencies MUST be justified; tree-shakeable packages are strongly
-  preferred. Adding a package that increases the production bundle by more than 50 KB (gzipped)
-  requires explicit documentation in the feature plan.
-- **Query efficiency**: Supabase queries MUST select only required columns; wildcard `select('*')`
-  is acceptable only in prototypes and MUST be removed before merge.
-- **Mock parity**: Mock implementations MUST replicate the timing characteristics of real queries
-  (use realistic delays if needed) so performance regressions are detectable in mock mode.
-
-**Rationale**: Athletes and coaches often use the platform on mobile or variable connections. Fast,
-snappy UI directly affects training adherence and platform adoption.
-
-### V. Simplicity & Anti-Complexity
-
-The minimum amount of code and abstraction necessary for the current requirement MUST be used:
-
-- No `useEffect` for data fetching — React Query hooks in `lib/hooks/` MUST be used instead.
-- No premature abstractions: three similar lines of code are preferred over an abstraction used
-  once.
-- No helpers or utilities created for single-use operations — inline the logic.
-- No backwards-compatibility shims or dead code — remove unused code completely.
-- No feature flags or configuration knobs for functionality that can simply be changed in code.
-- YAGNI (You Aren't Gonna Need It) applies to all design decisions.
-
-**Rationale**: Over-engineering increases maintenance burden without delivering user value. Synek is
-a focused planning tool; keeping the codebase lean accelerates future feature delivery.
-
-## Technology & Stack Constraints
-
-The following stack versions are locked and MUST NOT be changed without a constitution amendment:
+The following stack versions are locked and MUST NOT be changed without a constitution
+amendment:
 
 | Layer | Technology | Version |
 |---|---|---|
@@ -130,46 +157,95 @@ The following stack versions are locked and MUST NOT be changed without a consti
 | Package Manager | pnpm | always — npm and yarn are forbidden |
 | Date Operations | date-fns | 4 |
 
-New dependencies MUST be evaluated against bundle impact (Principle IV) and simplicity (Principle V)
-before adoption. Any addition of a major new framework or library requires updating this section.
+New dependencies MUST be evaluated against bundle impact (Principle V) and lean scope
+(Principle I) before adoption. Any addition of a major new framework or library requires
+updating this table via a constitution amendment.
+
+### Security & Secret Handling
+
+- Supabase credentials and all `VITE_*` secrets MUST NOT be committed to the repository.
+  Use `.env.local` (gitignored) for local development.
+- Public-facing registration and action forms MUST include a honeypot field to silently
+  reject bot submissions (see `CLAUDE.md` security conventions).
+- After invite-based registration, `signInWithPassword` MUST be called to issue a fresh
+  session and discard any invite-page state (prevents session fixation).
+- Edge Function callers MUST be verified via `anonClient.auth.getUser(jwt)` before any
+  mutation; service-role client is restricted to admin operations only.
+- Two-step confirmation is REQUIRED for destructive actions (e.g. account deletion):
+  step 1 explains consequences; step 2 requires typing an exact confirmation value.
+- Prefer `ON DELETE SET NULL` over `ON DELETE CASCADE` for audit-sensitive foreign keys
+  to preserve history after user deletion.
 
 ## Development Workflow & Quality Gates
 
-The following gates MUST be satisfied before a feature branch is merged:
+All work MUST follow the feature-branch workflow:
+
+1. **Feature branch**: All work happens on a named branch (`###-feature-name`); direct
+   commits to `main` are forbidden.
+2. **Passing CI**: `pnpm typecheck` MUST exit with code 0; all tests MUST pass.
+3. **Review approval**: At least one review approval is required before merge.
+4. **Releasable main**: The `main` branch MUST be in a releasable state at all times;
+   incomplete features MUST be gated behind a flag or kept off `main` until ready.
+
+### Merge Gates (all MUST be satisfied)
 
 1. **Type check passes**: `pnpm typecheck` exits with code 0 — no TypeScript errors.
 2. **Mock parity**: Every new Supabase query has a corresponding mock implementation.
-3. **i18n complete**: All new user-facing strings appear in both `en/` and `pl/` translation files.
+3. **i18n complete**: All new user-facing strings appear in both `en/` and `pl/` translation
+   files.
 4. **Optimistic updates**: Every mutation implements `onMutate`/`onError`/`onSettled`.
 5. **No hardcoded colors**: All sport colors reference `training-types.ts` tokens.
-6. **No direct DB access in components**: All data fetching goes through `lib/hooks/` → `lib/queries/`.
-7. **Constitution check passed**: The plan.md for the feature documents how each relevant principle
-   is satisfied or explicitly justified if violated.
+6. **No direct DB access in components**: All data fetching goes through `lib/hooks/` →
+   `lib/queries/`.
+7. **Constitution check passed**: The `plan.md` for the feature documents how each relevant
+   principle is satisfied, or explicitly justifies any violation.
 
-Code review MUST verify all seven gates. A PR that fails any gate MUST NOT be merged regardless of
-feature completeness.
+Code review MUST verify all seven gates. A PR that fails any gate MUST NOT be merged
+regardless of feature completeness.
+
+### Commit Conventions
+
+Commits MUST follow the Conventional Commits format:
+
+```
+<type>(<scope>): <short summary>
+```
+
+Accepted types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`, `ci`.
+Scope is optional but encouraged (e.g., `strength`, `auth`, `i18n`).
+
+### Breaking Changes
+
+Breaking changes (DB schema changes, API contract changes, removed exports, behavior
+changes visible to users) MUST be documented in the PR description with an explicit
+`BREAKING CHANGE:` footer in the commit message. Releases containing breaking changes
+MUST increment the `CONSTITUTION_VERSION` MAJOR digit when they affect governed constraints.
 
 ## Governance
 
-This constitution is the highest-authority document for Synek engineering decisions. It supersedes
-any conflicting practice described elsewhere unless that practice is explicitly referenced here.
+This constitution is the highest-authority document for Synek engineering decisions. It
+supersedes any conflicting practice described elsewhere unless that practice is explicitly
+referenced here.
 
 **Amendment procedure**:
 1. Propose the change in a PR with a clear rationale.
 2. Bump the version according to semantic versioning rules:
-   - MAJOR: principle removed, redefined in a backward-incompatible way, or governance restructured.
+   - MAJOR: principle removed, redefined in a backward-incompatible way, governance
+     restructured, or stack constraint changed.
    - MINOR: new principle added, new section added, or existing principle materially expanded.
    - PATCH: clarifications, wording improvements, typo fixes.
 3. Update `LAST_AMENDED_DATE` to the date the amendment is merged.
-4. Run the consistency propagation checklist: verify plan-template.md, spec-template.md,
-   tasks-template.md, and CLAUDE.md for conflicts.
+4. Run the consistency propagation checklist: verify `plan-template.md`, `spec-template.md`,
+   `tasks-template.md`, and `CLAUDE.md` for conflicts.
 5. Include a Sync Impact Report (HTML comment at top of this file) summarising all changes.
 
-**Compliance review**: Every feature plan (`plan.md`) MUST contain a "Constitution Check" section
-that gates implementation. Reviewers are responsible for verifying compliance at PR time.
+**Compliance review**: Every feature plan (`plan.md`) MUST contain a "Constitution Check"
+section that gates implementation. Reviewers are responsible for verifying compliance at
+PR time. Constitution violations are blocking unless explicitly approved with documented
+rationale.
 
 **Runtime guidance**: For day-to-day development patterns, refer to `CLAUDE.md`. For feature
 planning, follow the `/speckit.*` workflow. This constitution defines the non-negotiable rules
 that both documents must respect.
 
-**Version**: 1.0.0 | **Ratified**: 2026-03-08 | **Last Amended**: 2026-03-08
+**Version**: 2.0.0 | **Ratified**: 2026-03-08 | **Last Amended**: 2026-03-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,31 @@
 # Synek — Claude Code Instructions
 
 ## What This App Is
-An **athlete training planning platform** with coach/athlete roles. Coaches create ISO-week training plans; athletes view and complete sessions. Built SPA (no SSR).
-
-## Tech Stack (versions matter)
-- **React 19** + **React Router 7** (file-based routing, SPA mode — `ssr: false`)
-- **TypeScript 5** strict mode — path alias `~/` → `./app/`
-- **Tailwind CSS 4** via Vite plugin (not PostCSS)
-- **TanStack Query 5** — all server state via hooks, no `useEffect` fetching
-- **Supabase** (`@supabase/supabase-js 2`) — mock mode auto-activates when credentials are placeholders
-- **shadcn/ui** (New York style) + **Radix UI** — only add components via `pnpm dlx shadcn@latest add`
-- **i18next** + **react-i18next** — EN/PL, namespaces: `common`, `coach`, `athlete`, `training`
-- **Zod 4** for schema validation
-- **pnpm** (always, never npm or yarn)
-- **date-fns 4** for all date operations
+An **athlete training planning platform** with coach/athlete roles. Coaches create ISO-week training plans; athletes view and complete sessions. Built SPA (no SSR). See `.specify/memory/constitution.md` for approved tech stack versions, type safety rules, security policy, and performance targets.
 
 ## Commands
 ```bash
 pnpm dev          # dev server (localhost:5173)
 pnpm build        # production build
-pnpm typecheck    # react-router typegen + tsc
+pnpm typecheck    # react-router typegen + tsc (MUST pass before merge)
 pnpm dlx shadcn@latest add <component>  # add shadcn component
 ```
 
 ---
 
-## Architecture — Read Before Touching Code
+## Architecture
 
-### Directory Map
-```
-app/
-├── components/
-│   ├── ui/          # shadcn components — NEVER edit manually
-│   ├── calendar/    # week planning calendar widgets
-│   ├── training/    # session form + sport-specific type-fields/
-│   └── layout/      # Header, LanguageToggle, RoleSwitcher
-├── lib/
-│   ├── queries/     # Supabase CRUD (weeks.ts, sessions.ts) + keys.ts
-│   ├── hooks/       # React Query hooks (useWeekPlan.ts, useSessions.ts)
-│   └── utils/       # date.ts | week-view.ts | training-types.ts
-├── types/           # training.ts (domain models) | strava.ts
-├── i18n/            # config.ts + resources/en/ + resources/pl/
-└── routes/          # coach/ + athlete/ page components
-```
+### How Directories Relate
+- `app/routes/` — page components only; no DB access, no direct queries
+- `app/lib/hooks/` — React Query hooks (`useWeekPlan.ts`, `useSessions.ts`, etc.); the only place components touch server state
+- `app/lib/queries/` — Supabase CRUD functions (`sessions.ts`, `weeks.ts`) + `keys.ts` query key factory; real and mock implementations live side-by-side in the same file
+- `app/lib/utils/` — pure helpers: `date.ts`, `training-types.ts`, `week-view.ts`
+- `app/components/ui/` — shadcn-managed primitives; never edit manually
+- `app/components/calendar/` — week planning widgets
+- `app/components/training/` — session form + sport-specific `type-fields/`
+- `app/types/` — domain models in `training.ts`; Strava types in `strava.ts`
+- `app/i18n/resources/en/` and `app/i18n/resources/pl/` — translation namespaces: `common`, `coach`, `athlete`, `training`
+- `supabase/functions/` — Deno Edge Functions (one directory per function)
 
 ### Data Flow
 ```
@@ -56,64 +39,23 @@ routes/ → hooks/ → queries/ → Supabase (or mock)
 ## Patterns — Follow These Exactly
 
 ### 1. New Component
-```tsx
-// app/components/calendar/MyWidget.tsx
-import { useTranslation } from 'react-i18next'
-import { cn } from '~/lib/utils'
-
-interface MyWidgetProps {
-  onAction: (id: string) => void
-  className?: string
-}
-
-export function MyWidget({ onAction, className }: MyWidgetProps) {
-  const { t } = useTranslation('common')
-  return <div className={cn('...', className)}>{t('key')}</div>
-}
-```
-- Named exports only (no default exports for components)
-- Props interface above the component, in the same file
-- Always accept `className?: string` prop for composability
+- Named exports only — no default exports for components (routes are the exception)
+- Props interface in the same file, above the component
+- Always accept `className?: string` for composability
 - Handler props named `on[Action]`
+- Always use `cn()` from `~/lib/utils` for conditional classes
+- Always use `useTranslation` — no hardcoded English strings
+
+See `app/components/calendar/SessionCard.tsx` for a full example.
 
 ### 2. New React Query Hook
-```typescript
-// app/lib/hooks/useMyData.ts
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { myKeys } from '~/lib/queries/keys'
-import { fetchMyData, updateMyData } from '~/lib/queries/myData'
+Four mandatory rules for every mutation:
+1. `onMutate`: call `qc.cancelQueries`, snapshot previous data, apply optimistic update
+2. `onError`: rollback to snapshot from context
+3. `onSettled` (not `onSuccess`): call `qc.invalidateQueries`
+4. `enabled: !!id` guard on queries that depend on a runtime value
 
-export function useMyData(id: string) {
-  return useQuery({
-    queryKey: myKeys.byId(id),
-    queryFn: () => fetchMyData(id),
-    enabled: !!id,
-  })
-}
-
-export function useUpdateMyData() {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: updateMyData,
-    onMutate: async (input) => {
-      await qc.cancelQueries({ queryKey: myKeys.byId(input.id) })
-      const prev = qc.getQueryData(myKeys.byId(input.id))
-      qc.setQueryData(myKeys.byId(input.id), (old) => ({ ...old, ...input }))
-      return { prev }
-    },
-    onError: (_err, input, ctx) => {
-      if (ctx?.prev) qc.setQueryData(myKeys.byId(input.id), ctx.prev)
-    },
-    onSettled: (_data, _err, input) => {
-      qc.invalidateQueries({ queryKey: myKeys.byId(input.id) })
-    },
-  })
-}
-```
-- Always implement optimistic updates on mutations
-- Always cancel in-flight queries in `onMutate`
-- Always rollback in `onError` using saved context
-- Always invalidate in `onSettled` (not `onSuccess`)
+See `app/lib/hooks/useWeekPlan.ts` and `app/lib/hooks/useSessions.ts` for full examples.
 
 ### 3. New Query Key
 ```typescript
@@ -125,55 +67,28 @@ export const myKeys = {
 ```
 
 ### 4. New Supabase Query
-```typescript
-// app/lib/queries/myData.ts
-import { supabase, isMockMode } from '~/lib/supabase'
-import type { MyType } from '~/types/training'
+- Every query file MUST export both a real and a mock implementation
+- Gate on `isMockMode`: `if (isMockMode) return mockFetch(id)`
+- Use a `toMyType(row)` row mapper for snake_case → camelCase transformation
+- Never use `select('*')` — always list columns explicitly; use `.maybeSingle()` for nullable results
 
-function toMyType(row: Record<string, unknown>): MyType {
-  return {
-    id: row.id as string,
-    myField: row.my_field as string,  // snake_case → camelCase
-  }
-}
-
-export async function fetchMyData(id: string): Promise<MyType | null> {
-  if (isMockMode) return mockFetchMyData(id)
-  const { data, error } = await supabase
-    .from('my_table')
-    .select('id, my_field')  // never use select('*') — list columns explicitly
-    .eq('id', id)
-    .maybeSingle()
-  if (error) throw error
-  return data ? toMyType(data) : null
-}
-```
-- Every query file MUST have both real and mock implementations
-- Use `toMyType()` row mappers for DB → TS transformation (snake → camel)
-- Export mock functions so they can be unit-tested independently
-- Never use `select('*')` — always list columns explicitly
+See `app/lib/queries/sessions.ts` or `app/lib/queries/weeks.ts` for a complete example.
 
 ### 5. New Training Type (sport-specific fields)
 1. Add variant to `TypeSpecificData` in `app/types/training.ts`
 2. Add color config in `app/lib/utils/training-types.ts`
 3. Create `app/components/training/type-fields/MyTypeFields.tsx`
-4. Add translation keys to `app/i18n/resources/en/training.json` and `pl/training.json`
+4. Add translation keys to both `app/i18n/resources/en/training.json` and `pl/training.json`
 5. Render the field component in `SessionForm.tsx` via switch/conditional
 
 ### 6. New Route
-```typescript
-// app/routes/coach/my-page.tsx  (or athlete/)
-import { useTranslation } from 'react-i18next'
+- Place in `app/routes/coach/` or `app/routes/athlete/` as appropriate
+- Register in `app/routes.ts` under the correct layout
+- Routes inside `/:locale` get locale prefix automatically (`/pl/coach/...`)
+- Public routes without a locale (e.g. invite pages) register at the top level alongside `login`, outside the `':locale'` layout wrapper
+- Run `pnpm typecheck` after adding routes to generate types
 
-export default function MyPage() {
-  const { t } = useTranslation('coach')
-  return <div>{t('my-page.title')}</div>
-}
-```
-Register in `app/routes.ts` under the correct layout.
-- Routes inside `/:locale` layout get locale prefix automatically (`/pl/coach/...`)
-- Public routes that must work without locale (e.g. invite pages) register at the **top level** alongside `login`, outside the `':locale'` layout wrapper
-Run `pnpm typecheck` after adding routes to generate types.
+See `app/routes/invite.$token.tsx` for a locale-free public route example.
 
 ### 7. Adding Translations
 Always add to BOTH language files simultaneously:
@@ -188,71 +103,61 @@ Use namespace prefix in `useTranslation`: `useTranslation('training')` → `t('k
 
 ### Domain Types (`app/types/training.ts`)
 - **PascalCase** for all types: `WeekPlan`, `TrainingSession`
-- **Discriminated unions** keyed on `type` field:
-  ```typescript
-  type TypeSpecificData = RunData | CyclingData | ...
-  // Each has: { type: 'run' | 'cycling' | ... , ...fields }
-  ```
-- **Input types** suffixed with `Input`: `CreateSessionInput`, `UpdateSessionInput`
-- **JSONB fields** typed as `Record<string, unknown>` at DB boundary, narrowed via mappers
+- **Discriminated unions** keyed on `type` field: `type TypeSpecificData = RunData | CyclingData | ...` — each variant carries `{ type: 'run' | 'cycling' | ... }`
+- **Input types** suffixed `Input`: `CreateSessionInput`, `UpdateSessionInput`
+- **JSONB fields** typed as `Record<string, unknown>` at DB boundary, narrowed via row mappers
 
 ### TypeScript Rules
-- Prefer `type` over `interface` for unions and computed types
-- Use `interface` for component props and plain object shapes
-- Never use `any` — use `unknown` and narrow
-- Use `as const` on query keys
+- Prefer `type` over `interface` for unions and computed types; use `interface` for component props and plain object shapes
 - Import types with `import type { }` syntax
-- `import.meta.env.VITE_X` — use directly, no casting required (Vite types it automatically)
-- Dynamic i18n template literal keys that TypeScript cannot verify: cast to `as never`
-  ```typescript
-  t(`invite.invalid${capitalize(reason)}` as never)
-  ```
-- **Zod 4**: use `.issues[0]?.message` (not `.errors[0].message` — `.errors` was removed in v4)
+- `import.meta.env.VITE_X` — no casting needed; Vite types it automatically
+- Dynamic i18n template-literal keys TypeScript cannot verify: cast `as never`
+- **Zod 4**: use `.issues[0]?.message` (`.errors` was removed in v4)
+- `as const` on all query keys
 
 ---
 
 ## Styling Rules
 
 ### Tailwind
-- Use `cn()` from `~/lib/utils` for all conditional class merging
-- Follow sport color system (do NOT invent new colors):
-  ```
-  run       → blue-700 / bg-blue-100
-  cycling   → green-700 / bg-green-100
-  strength  → orange-700 / bg-orange-100
-  yoga      → purple-700 / bg-purple-100
-  mobility  → teal-700 / bg-teal-100
-  swimming  → cyan-700 / bg-cyan-100
-  rest_day  → gray-500 / bg-gray-100
-  ```
-- Look up existing color config in `app/lib/utils/training-types.ts` before adding colors
+Use `cn()` from `~/lib/utils` for all conditional class merging. Follow the sport color system — do NOT invent new color literals:
+
+| Sport | Text | Background |
+|---|---|---|
+| run | `blue-700` | `bg-blue-100` |
+| cycling | `green-700` | `bg-green-100` |
+| strength | `orange-700` | `bg-orange-100` |
+| yoga | `purple-700` | `bg-purple-100` |
+| mobility | `teal-700` | `bg-teal-100` |
+| swimming | `cyan-700` | `bg-cyan-100` |
+| rest_day | `gray-500` | `bg-gray-100` |
+
+Look up the full config in `app/lib/utils/training-types.ts` before touching colors.
 
 ### shadcn/ui
 - Import from `~/components/ui/...`
-- Never modify files in `app/components/ui/` — they are shadcn-managed
-- Add new shadcn components only via `pnpm dlx shadcn@latest add <name>`
+- Never modify files in `app/components/ui/` — shadcn-managed
+- Add new components only via `pnpm dlx shadcn@latest add <name>`
 
 ---
 
 ## Mock Mode
-Mock mode activates automatically when Supabase credentials are missing/placeholder.
-- Mock data lives in `app/lib/mock-data/` (split by domain: sessions, weeks, profile, strava)
-- Both real and mock implementations live in the same query file
-- When adding new DB features: implement mock version first, then real Supabase version
-- Each mock-data module exports a `resetMockX()` function; call it in `beforeEach` to prevent state bleed between tests
-- Mock store must use **deep clones** on reset: `SEED.map(i => ({ ...i }))` — shallow copies leave shared object references that mutate across tests
+Mock mode activates automatically when Supabase credentials are missing or placeholders — no manual flag needed.
+- Mock data lives in `app/lib/mock-data/` (split by domain: `sessions.ts`, `weeks.ts`, `profile.ts`, etc.)
+- Implement the mock version first, then the real Supabase version
+- Each mock module exports a `resetMockX()` function — call it in `beforeEach`; use deep clones on reset (`SEED.map(i => ({ ...i }))`) to prevent mutation bleed between tests
 
 ---
 
 ## Testing Patterns
 
 ### File Organisation
-- `app/test/unit/` — pure function / mapper tests (no React, no mocks of modules)
+- `app/test/unit/` — pure function / mapper tests (no React, no module mocks)
 - `app/test/integration/` — hook and component tests (render + TanStack Query wrapper)
 
 ### Mocking Supabase / Query Modules
 ```typescript
-// ✅ Use vi.fn() inside the factory — avoids hoisting ReferenceError
+// Use vi.fn() inside the factory — avoids hoisting ReferenceError
 vi.mock('~/lib/supabase', () => ({
   supabase: {
     auth: {
@@ -263,49 +168,48 @@ vi.mock('~/lib/supabase', () => ({
   isMockMode: true,
 }))
 
-// Then assign return values in beforeEach (not at module scope)
+// Assign return values in beforeEach, not at module scope
 beforeEach(() => {
-  vi.mocked(supabase.auth.getSession).mockResolvedValue({ data: { session: { access_token: 'tok' } } } as never)
+  vi.mocked(supabase.auth.getSession).mockResolvedValue({
+    data: { session: { access_token: 'tok' } },
+  } as never)
 })
 ```
 - Never reference top-level variables inside `vi.mock()` factories — they run before initialisation
-- Use `vi.spyOn(module, 'fn').mockRejectedValueOnce(...)` for per-test overrides; `vi.doMock` does not affect already-loaded modules
+- For per-test overrides use `vi.spyOn(module, 'fn').mockRejectedValueOnce(...)` — `vi.doMock` does not affect already-loaded modules
 
 ### Mock Context
 ```typescript
-// Module-level variable, read by the mock
 let mockUser: AuthUser | null = null
 
 vi.mock('~/lib/context/AuthContext', () => ({
   useAuth: () => ({ user: mockUser, logout: vi.fn() }),
 }))
 
-// In tests, set before render:
+// Set before render:
 mockUser = { id: '1', role: 'coach', name: 'Jane' }
 ```
 
 ### Interacting with `aria-hidden` Fields
-`userEvent.type` skips elements with `aria-hidden="true"` (e.g. honeypot inputs).
-Use `fireEvent.change` instead:
+`userEvent.type` skips elements with `aria-hidden="true"` (e.g. honeypot inputs). Use `fireEvent.change` instead:
 ```typescript
-fireEvent.change(screen.getByRole('...'), { target: { value: 'value' } })
-// or by querySelector for hidden elements:
-fireEvent.change(container.querySelector('[name="website"]')!, { target: { value: 'bot' } })
+fireEvent.change(container.querySelector('[name="website"]')!, {
+  target: { value: 'bot' },
+})
 ```
 
 ### TDD Approach
-1. Write the test → confirm it **fails** (red)
-2. Implement the minimal code → confirm it **passes** (green)
+1. Write the test → confirm it fails (red)
+2. Implement minimal code → confirm it passes (green)
 3. Refactor if needed
 
 ---
 
 ## Supabase Edge Functions
 
-Pattern: follow `supabase/functions/strava-auth/index.ts` exactly.
+Pattern — follow `supabase/functions/strava-auth/index.ts` exactly:
 
 ```typescript
-// supabase/functions/my-function/index.ts
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
@@ -330,55 +234,52 @@ serve(async (req) => {
 - Use service role client only for admin operations (`createUser`, `deleteUser`, etc.)
 - Always handle `OPTIONS` preflight for CORS
 
+---
+
 ## Security Conventions
 
-### Forms
-- Add a honeypot field to all public-facing registration forms:
-  ```tsx
-  <input name="website" tabIndex={-1} className="sr-only" aria-hidden="true"
-         value={honeypot} onChange={(e) => setHoneypot(e.target.value)} />
-  ```
-  Silently reject submissions where honeypot is non-empty.
+### Honeypot (all public-facing registration/action forms)
+```tsx
+<input name="website" tabIndex={-1} className="sr-only" aria-hidden="true"
+       value={honeypot} onChange={(e) => setHoneypot(e.target.value)} />
+```
+Silently reject submissions where honeypot is non-empty.
 
-### Auth
-- After invite-based registration, always call `signInWithPassword` to issue a **fresh session** (prevents session fixation — discards any state from the invite page).
-- Two-step destructive actions (e.g. account deletion): step 1 explains consequences, step 2 requires typing exact confirmation value before enabling submit.
-
-### Database FK Design
-- Prefer `ON DELETE SET NULL` over `ON DELETE CASCADE` for audit-sensitive FKs to preserve history after user deletion.
+### Auth & Destructive Actions
+- After invite-based registration, call `signInWithPassword` to issue a fresh session (prevents session fixation)
+- Two-step destructive actions (e.g. account deletion): step 1 explains consequences, step 2 requires typing the exact confirmation value before enabling submit
 
 ---
 
 ## Anti-Patterns (Never Do These)
 
-- **No `useEffect` for data fetching** — use React Query hooks in `lib/hooks/`
-- **No default exports for components** — named exports only
-- **No inline SQL/queries in route files** — all DB access goes through `lib/queries/`
-- **No direct `supabase.from()` calls in components or hooks** — only in `lib/queries/`
-- **No hardcoded English strings in JSX** — always use `t('key')` from i18next
-- **No mutations without optimistic updates** — implement `onMutate`/`onError`/`onSettled`
-- **No new shadcn components edited manually** — always use CLI
-- **No CSS modules or styled-components** — Tailwind only
-- **No date manipulation outside `date-fns`** — never use `new Date()` arithmetic directly
-- **No `npm` or `yarn`** — always `pnpm`
-- **No `select('*')` in Supabase queries** — always list columns explicitly
-- **No top-level variable references inside `vi.mock()` factories** — use `vi.fn()` inside factory, assign values in `beforeEach`
-- **No `vi.doMock` for per-test overrides** — use `vi.spyOn` instead
-- **No shallow array copy in mock resets** — use `.map(i => ({ ...i }))` deep clone to prevent mutation bleed
+- No `useEffect` for data fetching — use React Query hooks in `lib/hooks/`
+- No default exports for components — named exports only (routes are the exception)
+- No inline SQL or `supabase.from()` calls in components or hooks — only in `lib/queries/`
+- No hardcoded English strings in JSX — always use `t('key')` from i18next
+- No mutations without optimistic updates — `onMutate`/`onError`/`onSettled` are mandatory
+- No manual edits to `app/components/ui/` — always use shadcn CLI
+- No CSS modules or styled-components — Tailwind only
+- No date arithmetic outside `date-fns` — never `new Date()` math directly
+- No `npm` or `yarn` — always `pnpm`
+- No `select('*')` in Supabase queries — always list columns explicitly
+- No top-level variable references inside `vi.mock()` factories — `vi.fn()` inside factory, assign in `beforeEach`
+- No `vi.doMock` for per-test overrides — use `vi.spyOn` instead
+- No shallow array copies in mock resets — `.map(i => ({ ...i }))` deep clone required
 
 ---
 
 ## File & Naming Conventions
 
 | Thing | Convention | Example |
-|-------|-----------|---------|
+|---|---|---|
 | Components | PascalCase | `SessionCard.tsx` |
 | UI primitives (shadcn) | lowercase | `button.tsx` |
 | Hooks | camelCase, `use` prefix | `useWeekPlan.ts` |
 | Query files | kebab-case | `sessions.ts`, `week-view.ts` |
 | Utility files | kebab-case | `training-types.ts` |
 | Types | PascalCase | `WeekPlan`, `RunData` |
-| DB columns | snake_case (mapped to camelCase in TS) | `week_start` → `weekStart` |
+| DB columns | snake_case → camelCase in TS | `week_start` → `weekStart` |
 | Route files | kebab-case, param with `$` | `week.$weekId.tsx` |
 | i18n keys | kebab-case | `session-form.title` |
 | Handler props | `on` prefix | `onAddSession`, `onClose` |
@@ -397,50 +298,3 @@ getWeekDateRange(monday) // → "Mar 2 – Mar 8, 2026"
 - Week IDs are ISO 8601 format: `YYYY-WWW`
 - `weekStart` fields are always Monday's date in `YYYY-MM-DD`
 - Use `date-fns` functions for all other date operations
-
----
-
-## Supabase Schema Notes
-
-Tables: `week_plans`, `training_sessions`, `strava_activities`, `strava_tokens`
-
-Key constraints:
-- `week_plans.week_start` is UNIQUE
-- `training_sessions.sort_order` controls display order within a day
-- `type_specific_data` is JSONB — validate with Zod before inserting
-- Strava tables are provisioned but integration not yet implemented
-
-When writing new migrations, place in `supabase/migrations/` with prefix `00N_`.
-
-## Active Technologies
-- TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, Zod 4, date-fns 4, papaparse (devDependency — migration script only) (001-sheets-data-migration)
-- Supabase (PostgreSQL) — `training_sessions` and `week_plans` tables extended (001-sheets-data-migration)
-- TypeScript 5 (strict) + React 19 + React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui (New York), i18next, Zod 4, date-fns 4 (004-settings-strava)
-- PostgreSQL via Supabase; Supabase Storage for avatars; Supabase Edge Functions for Strava OAuth (004-settings-strava)
-- TypeScript 5 (strict), React 19 + React Router 7 (SPA, `ssr: false`), TanStack Query 5, Supabase JS 2, i18next + react-i18next, Zod 4, date-fns 4 (005-tests-refactor)
-- Vitest 4, @testing-library/react 16, jsdom — test suite covering unit + integration layers (005-tests-refactor)
-- release-it + @release-it/conventional-changelog — automated versioning and CHANGELOG on merge to main (005-tests-refactor)
-- URL-based locale routing (`/:locale/...`), Polish default (`pl`), English toggle (`en`) (005-tests-refactor)
-- Supabase (PostgreSQL) — mock mode used in all tests (005-tests-refactor)
-- TypeScript 5 stric + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui, i18next, Zod 4 (006-coach-athlete-invite)
-- Supabase PostgreSQL — new `invites` table; no schema changes to existing tables (006-coach-athlete-invite)
-- TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui, i18nex (007-athlete-planning)
-- PostgreSQL via Supabase — one new column `profiles.can_self_plan boolean DEFAULT false` (007-athlete-planning)
-- TypeScript 5 (strict) + React 19 + React Router 7, TanStack Query 5, Supabase JS 2, shadcn/ui, i18next, Zod 4 (008-landing-page)
-- Supabase PostgreSQL — new `feedback_submissions` table (migration 014); no changes to existing tables (008-landing-page)
-- TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui (New York), i18next, Zod 4, date-fns 4 (010-strava-run-intervals)
-- PostgreSQL via Supabase — new `strava_laps` table; `workout_type` column added to `strava_activities`; `secure_training_sessions` view updated (010-strava-run-intervals)
-- TypeScript 5 (strict) — React 19 frontend, Deno Edge Functions + `@tryvital/vital-link` (1.7 KB gzipped, new), `svix` via esm.sh (Deno, Edge Function only — not a frontend bundle concern) (011-junction-garmin-poc)
-- Supabase PostgreSQL — three new isolated tables (`junction_poc_connections`, `junction_poc_events`, `junction_poc_workouts`) (011-junction-garmin-poc)
-- TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, @dnd-kit/core + @dnd-kit/sortable (new, ~20 KB gzipped), date-fns 4, shadcn/ui (New York), i18nex (012-multi-week-planning)
-- PostgreSQL via Supabase — two new stored procedures in migration 021 (additive only; no schema changes) (012-multi-week-planning)
-- TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui (New York), i18next, Zod 4, date-fns 4; + `recharts` via `shadcn add chart` (~50 KB gzipped, lazy-loaded in progress tab) (013-strength-workout-module)
-- PostgreSQL via Supabase — 3 new tables (`strength_variants`, `strength_variant_exercises`, `strength_session_exercises`) + 1 RPC (`get_last_session_exercises`) in migration 022 (013-strength-workout-module)
-- PostgreSQL via Supabase — `superset_group integer` column added to `strength_variant_exercises` in migration 023 (013-strength-workout-module UX polish)
-
-## Recent Changes
-- 001-sheets-data-migration: Added TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, Supabase JS 2, Zod 4, date-fns 4, papaparse (devDependency — migration script only)
-- 010-strava-run-intervals: Added lazy-loaded interval lap data to run session cards. Intervals button appears in the performance section (under MAX HR) only for runs with ≥2 interval laps. New files: `supabase/migrations/018_strava_laps.sql`, `supabase/functions/strava-fetch-laps/index.ts`, `app/types/strava.ts` (StravaLap + StravaLapSegmentType), `app/lib/queries/strava-laps.ts`, `app/lib/hooks/useSessionLaps.ts`, `app/lib/mock-data/strava-laps.ts`, `app/lib/utils/lap-classification.ts` (classifyLaps + formatPaceSpeed), `app/components/training/IntervalChart.tsx`, `app/components/training/LapTable.tsx`, `app/components/training/IntervalDetailsModal.tsx`, `app/components/training/StravaLogo.tsx` (shared dark/light Strava badge). Updated: `app/types/training.ts` (stravaWorkoutType field), `app/lib/queries/sessions.ts` (toSession mapper), `app/lib/queries/keys.ts` (sessionLaps factory), `app/components/calendar/SessionCard.tsx`, `app/components/landing/FeaturesSection.tsx` (StravaLogo), i18n `training` namespace (EN+PL `intervals.*` keys). Lap names use Strava's device name when meaningful; auto-lap names ("Lap N") fall back to generated segment labels.
-- 011-junction-garmin-poc (extended): Added `junction_poc_workouts` table (migration 020) to normalise Garmin workout data from webhooks. Webhook handler (`junction-webhook`) now parses `daily.data.workouts.created` events into the new table. Frontend: `JunctionPocWorkout` type, `fetchJunctionWorkoutForSession` query with sport-slug→training-type mapping, `useJunctionWorkout` hook, `GarminBadge` component, `SessionDetailModal` shows Garmin performance chips (duration, distance, HR, calories) in ACTUAL section when `junctionConnected=true` and a matching workout exists. Prop `junctionConnected` threads from athlete route → WeekGrid → DayColumn → SessionCard → SessionDetailModal.
-- 013-strength-workout-module UX polish: Three exercise editor improvements. (1) Optional reps range — ExerciseRow defaults to single reps input with "Add range →" toggle; "Remove range ×" collapses back and sets repsMax = repsMin. Display helpers `formatRepsTarget` in VariantExerciseList and SessionExerciseLogger show "8 reps" instead of "8–8 reps" when min = max. (2) 6+ sets fix — "6+" is now a text link (progressive disclosure) instead of an adjacent pill, showing a number input when clicked with a "×" reset. (3) Supersets — exercises can be grouped via "Link/Unlink" connector buttons between rows in VariantForm; `links: boolean[]` state is maintained alongside exercises, with `computeSupersetGroups` converting it to `supersetGroup: number | null` before save. Superset groups render inside an orange-bordered container with "Superset"/"Superseria" header in both VariantExerciseList and SessionExerciseLogger. DB: migration 023 adds nullable `superset_group integer` to `strength_variant_exercises`. Types updated: `StrengthVariantExercise.supersetGroup`, `CreateStrengthVariantInput`, `UpsertVariantExercisesInput`. i18n: `strength.superset.*` (label/link/unlink) and `strength.exercise.addRange/removeRange` added to EN + PL.
-- feat/session-detail-modal: Added fully-actionable `SessionDetailModal` that opens by clicking anywhere on a `SessionCard` (except interactive elements). New file: `app/components/training/SessionDetailModal.tsx`. Deleted: `IntervalButton.tsx`, `IntervalDetailsModal.tsx` (absorbed into modal). Modal shows: Planned section (type-specific fields per sport, coach comments), Actual section (performance chips, Strava link + StravaLogo, inline IntervalChart+LapTable for Strava runs), Actions section (CompletionToggle, PerformanceEntry, Strava sync/confirm — athleteMode only), Notes & Feedback (coach post-training notes editable/read-only, athlete notes for coach). Card simplified: removed PerformanceEntry, AthleteFeedback, coach textarea, IntervalButton. On-card quick actions remain: CompletionToggle, Strava sync, Confirm&Share, actual chips, Strava link. Added `weekStart` prop to SessionCard (forwarded from DayColumn) for date display in modal header. i18n: `training.sessionDetail.*` keys added (EN+PL).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synek
 
-Athlete training planning platform with coach and athlete roles. Coaches create ISO-week training plans; athletes view and complete sessions.
+Athlete training planning platform with coach and athlete roles. Coaches create ISO-week training plans; athletes view and complete sessions. Built as a SPA (no SSR).
 
 ## Tech Stack
 
@@ -62,6 +62,14 @@ pnpm start      # serve the production build
 pnpm typecheck  # react-router typegen + tsc
 ```
 
+### Tests
+
+```bash
+pnpm test           # watch mode
+pnpm test:run       # single run
+pnpm test:coverage  # coverage report
+```
+
 ## Project Structure
 
 ```
@@ -78,37 +86,32 @@ app/
 ├── types/            # Domain types (training.ts, strava.ts)
 ├── i18n/             # config + resources/en/ + resources/pl/
 └── routes/
-    ├── home.tsx
-    ├── coach/        # week.$weekId.tsx
-    └── athlete/      # week.$weekId.tsx
+    ├── landing.tsx
+    ├── login.tsx / register.tsx / invite.$token.tsx
+    ├── settings.tsx
+    ├── coach/        # week.$weekId.tsx, strength.tsx, strength.$variantId.tsx
+    └── athlete/      # week.$weekId.tsx, strength.tsx, strength.$variantId.tsx
 
 supabase/
-└── migrations/       # SQL migrations (week_plans, training_sessions, strava tables)
+├── functions/        # Deno Edge Functions (strava-auth, strava-webhook, etc.)
+└── migrations/       # SQL migrations — source of truth for schema
 ```
 
 ## Roles
 
 | Role | Access |
 |---|---|
-| Coach | Create and edit ISO-week training plans; add/remove sessions per day |
-| Athlete | View the plan for the current week; mark sessions complete |
+| Coach | Create and edit ISO-week training plans; manage sessions per day; build strength variants |
+| Athlete | View assigned weekly plans; mark sessions complete; log performance; self-plan if `can_self_plan` is enabled |
 
 Use the role switcher in the header to toggle between roles during development.
 
 ## Supported Training Types
 
-`run` · `cycling` · `strength` · `yoga` · `mobility` · `swimming` · `rest_day`
+`run` · `cycling` · `strength` · `yoga` · `mobility` · `swimming` · `walk` · `hike` · `rest_day`
 
 Each type has sport-specific fields and a colour token defined in
 `app/lib/utils/training-types.ts`.
-
-## Adding shadcn Components
-
-```bash
-pnpm dlx shadcn@latest add <component-name>
-```
-
-Never edit files in `app/components/ui/` manually.
 
 ## Database
 
@@ -118,9 +121,11 @@ Migrations live in `supabase/migrations/`. Apply them via the Supabase CLI:
 supabase db push
 ```
 
-Tables: `week_plans`, `training_sessions`, `strava_activities`, `strava_tokens`
+Core tables: `week_plans`, `training_sessions`, `invites`, `strength_variants`,
+`strength_variant_exercises`, `strength_session_exercises`, `strava_activities`,
+`strava_tokens`, `strava_laps`. See `supabase/migrations/` for the full schema.
 
-## Supabase Deploy (Strava Changes)
+## Supabase Deploy
 
 Required environment variables:
 


### PR DESCRIPTION
- CLAUDE.md: 447 → 300 lines; remove stale changelog sections (Active Technologies, Recent Changes), replace full code templates with key rules + file pointers, remove content duplicated in constitution
- README: add tests section, update routes tree, roles, training types (add walk/hike), database tables, fix deploy section title
- constitution: bump to v2.0.0; replace all five principles with Lean & Purposeful, Configuration Over Hardcoding, Type Safety & Boundary Validation, Modularity & Testability, Performance & Operational Discipline; expand workflow with feature-branch/CI/ commit-convention rules and security & secret-handling subsection