### PR TITLE
feat: global auth loader to eliminate per-layout duplication

### DIFF
--- a/app/components/ui/app-loader.tsx
+++ b/app/components/ui/app-loader.tsx
@@ -1,10 +1,17 @@
 import { Logo } from '~/components/layout/Logo'
 
+// Module-level timestamp so any remount offsets into the same animation cycle
+const ANIMATION_START = Date.now();
+const ANIMATION_DURATION_MS = 2000;
+
 interface AppLoaderProps {
-  className?: string
+  className?: string;
 }
 
 export function AppLoader({ className }: AppLoaderProps) {
+  const elapsed = Date.now() - ANIMATION_START;
+  const delay = -(elapsed % ANIMATION_DURATION_MS);
+
   return (
     <div className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${className ?? ''}`}>
       <style>{`
@@ -13,7 +20,7 @@ export function AppLoader({ className }: AppLoaderProps) {
           50%       { transform: scale(1.06); }
         }
       `}</style>
-      <div style={{ animation: 'app-loader-breathe 2s ease-in-out infinite' }}>
+      <div style={{ animation: `app-loader-breathe ${ANIMATION_DURATION_MS}ms ease-in-out infinite`, animationDelay: `${delay}ms` }}>
         <Logo size="lg" showWordmark={true} />
       </div>
     </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,18 +10,13 @@ import { useTranslation } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '~/components/ui/tooltip';
 import { Toaster } from '~/components/ui/sonner';
-import { AuthProvider, useAuth } from '~/lib/context/AuthContext';
+import { AuthProvider } from '~/lib/context/AuthContext';
 import { ThemeProvider } from '~/lib/context/ThemeContext';
 import { AppLoader } from '~/components/ui/app-loader';
 
 import type { Route } from './+types/root';
 import './app.css';
 import '~/i18n/config';
-
-function GlobalLoader() {
-  const { isLoading } = useAuth();
-  return isLoading ? <AppLoader /> : null;
-}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -66,7 +61,6 @@ export default function App() {
       <ThemeProvider>
         <AuthProvider>
           <TooltipProvider>
-            <GlobalLoader />
             <Outlet />
             <Toaster position="bottom-right" richColors />
           </TooltipProvider>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,13 +10,18 @@ import { useTranslation } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '~/components/ui/tooltip';
 import { Toaster } from '~/components/ui/sonner';
-import { AuthProvider } from '~/lib/context/AuthContext';
+import { AuthProvider, useAuth } from '~/lib/context/AuthContext';
 import { ThemeProvider } from '~/lib/context/ThemeContext';
 import { AppLoader } from '~/components/ui/app-loader';
 
 import type { Route } from './+types/root';
 import './app.css';
 import '~/i18n/config';
+
+function GlobalLoader() {
+  const { isLoading } = useAuth();
+  return isLoading ? <AppLoader /> : null;
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -61,6 +66,7 @@ export default function App() {
       <ThemeProvider>
         <AuthProvider>
           <TooltipProvider>
+            <GlobalLoader />
             <Outlet />
             <Toaster position="bottom-right" richColors />
           </TooltipProvider>

--- a/app/routes/athlete/layout.tsx
+++ b/app/routes/athlete/layout.tsx
@@ -1,11 +1,12 @@
 import { Navigate, Outlet, useParams } from 'react-router';
 import { useAuth } from '~/lib/context/AuthContext';
+import { AppLoader } from '~/components/ui/app-loader';
 
 export default function AthleteLayout() {
   const { user, isLoading } = useAuth();
   const { locale = 'pl' } = useParams<{ locale?: string }>();
 
-  if (isLoading) return null; // GlobalLoader in root.tsx covers this
+  if (isLoading) return <AppLoader />;
   if (!user) return <Navigate to="/login" replace />;
 
   if (user.role !== 'athlete') return <Navigate to={`/${locale}/coach`} replace />;

--- a/app/routes/athlete/layout.tsx
+++ b/app/routes/athlete/layout.tsx
@@ -1,13 +1,11 @@
 import { Navigate, Outlet, useParams } from 'react-router';
 import { useAuth } from '~/lib/context/AuthContext';
-import { AppLoader } from '~/components/ui/app-loader';
 
 export default function AthleteLayout() {
   const { user, isLoading } = useAuth();
   const { locale = 'pl' } = useParams<{ locale?: string }>();
 
-  if (isLoading) return <AppLoader />;
-
+  if (isLoading) return null; // GlobalLoader in root.tsx covers this
   if (!user) return <Navigate to="/login" replace />;
 
   if (user.role !== 'athlete') return <Navigate to={`/${locale}/coach`} replace />;

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -143,9 +143,9 @@ export default function AthleteWeekView() {
   return (
     <>
       {showSkeleton && <AppLoader />}
-      <div key={currentWeekId} className="animate-in space-y-6 duration-200 fade-in">
-        {!showSkeleton &&
-          (!weekPlan ? (
+      {!showSkeleton && (
+        <div key={currentWeekId} className="animate-in space-y-6 duration-200 fade-in">
+          {!weekPlan ? (
             <>
               <StaggerIn>
                 <div className="flex items-center gap-2">
@@ -247,26 +247,27 @@ export default function AthleteWeekView() {
                 isSharePending={bulkConfirmStrava.isPending}
               />
             </>
-          ))}
+          )}
+        </div>
+      )}
 
-        {/* Delete session confirmation */}
-        <DeleteConfirmationDialog
-          open={!!deleteConfirmId}
-          onOpenChange={(open) => {
-            if (!open) setDeleteConfirmId(null);
-          }}
-          title={t('common:session.delete' as never)}
-          description={t('common:session.deleteConfirm' as never)}
-          confirmLabel={t('common:session.delete' as never)}
-          cancelLabel={t('common:actions.cancel' as never)}
-          onConfirm={() => {
-            deleteSessionMut.mutate(deleteConfirmId!, {
-              onSettled: () => setDeleteConfirmId(null),
-            });
-          }}
-          isPending={deleteSessionMut.isPending}
-        />
-      </div>
+      {/* Delete session confirmation */}
+      <DeleteConfirmationDialog
+        open={!!deleteConfirmId}
+        onOpenChange={(open) => {
+          if (!open) setDeleteConfirmId(null);
+        }}
+        title={t('common:session.delete' as never)}
+        description={t('common:session.deleteConfirm' as never)}
+        confirmLabel={t('common:session.delete' as never)}
+        cancelLabel={t('common:actions.cancel' as never)}
+        onConfirm={() => {
+          deleteSessionMut.mutate(deleteConfirmId!, {
+            onSettled: () => setDeleteConfirmId(null),
+          });
+        }}
+        isPending={deleteSessionMut.isPending}
+      />
     </>
   );
 }

--- a/app/routes/coach/layout.tsx
+++ b/app/routes/coach/layout.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet, useParams } from 'react-router';
+import { AppLoader } from '~/components/ui/app-loader';
 import { Users, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
@@ -20,7 +21,7 @@ export default function CoachLayout() {
   );
   const updateSelfPlan = useUpdateSelfPlanPermission();
 
-  if (isLoading) return null; // GlobalLoader in root.tsx covers this
+  if (isLoading) return <AppLoader />;
   if (!user) return <Navigate to="/login" replace />;
 
   if (user.role !== 'coach') return <Navigate to={`/${locale}/athlete`} replace />;

--- a/app/routes/coach/layout.tsx
+++ b/app/routes/coach/layout.tsx
@@ -1,5 +1,4 @@
 import { Navigate, Outlet, useParams } from 'react-router';
-import { AppLoader } from '~/components/ui/app-loader';
 import { Users, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
@@ -21,8 +20,7 @@ export default function CoachLayout() {
   );
   const updateSelfPlan = useUpdateSelfPlanPermission();
 
-  if (isLoading) return <AppLoader />;
-
+  if (isLoading) return null; // GlobalLoader in root.tsx covers this
   if (!user) return <Navigate to="/login" replace />;
 
   if (user.role !== 'coach') return <Navigate to={`/${locale}/athlete`} replace />;

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -74,87 +74,85 @@ export default function CoachWeekView() {
   return (
     <>
       {showSkeleton && <AppLoader />}
-      <div key={weekId} className="animate-in space-y-6 duration-200 fade-in">
-        {!showSkeleton && weekPlan && (
-          <>
-            {/* Header with navigation */}
-            <StaggerIn>
-              <div className="flex items-center gap-2">
-                <h1 className="shrink-0 text-base font-bold whitespace-nowrap sm:text-xl">
-                  {t('title')}
-                </h1>
-                <WeekNavigation
-                  weekId={weekId}
-                  basePath="coach"
-                  selectedDay={selectedDay}
-                  isLoading={weekFetching}
-                />
-              </div>
-            </StaggerIn>
+      {!showSkeleton && weekPlan && (
+        <div key={weekId} className="animate-in space-y-6 duration-200 fade-in">
+          {/* Header with navigation */}
+          <StaggerIn>
+            <div className="flex items-center gap-2">
+              <h1 className="shrink-0 text-base font-bold whitespace-nowrap sm:text-xl">
+                {t('title')}
+              </h1>
+              <WeekNavigation
+                weekId={weekId}
+                basePath="coach"
+                selectedDay={selectedDay}
+                isLoading={weekFetching}
+              />
+            </div>
+          </StaggerIn>
 
-            {/* Week Summary */}
-            <StaggerIn delay={60}>
-              <div
-                className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
-              >
-                <WeekSummary weekPlan={weekPlan} stats={stats} onUpdate={handleWeekUpdate} />
-              </div>
-            </StaggerIn>
+          {/* Week Summary */}
+          <StaggerIn delay={60}>
+            <div
+              className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
+            >
+              <WeekSummary weekPlan={weekPlan} stats={stats} onUpdate={handleWeekUpdate} />
+            </div>
+          </StaggerIn>
 
-            {/* Multi-Week View (current week + 4 history rows) */}
-            <StaggerIn delay={120}>
-              <div
-                className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
-              >
-                <MultiWeekView
-                  currentWeekId={weekId}
-                  currentWeekPlan={showStaleContent ? null : weekPlan}
-                  currentSessions={showStaleContent ? [] : sessions}
-                  currentSessionsByDay={showStaleContent ? ({} as SessionsByDay) : sessionsByDay}
-                  onAddSession={handleAddSession}
-                  onEditSession={handleEditSession}
-                  onDeleteSession={handleDeleteSession}
-                  onUpdateCoachPostFeedback={handleUpdateCoachPostFeedback}
-                  onToggleComplete={isViewingSelf ? handleToggleComplete : undefined}
-                  onUpdateNotes={isViewingSelf ? handleUpdateNotes : undefined}
-                  onUpdatePerformance={isViewingSelf ? handleUpdatePerformance : undefined}
-                  userRole={user?.role}
-                  showAthleteControls={isViewingSelf}
-                />
-              </div>
-            </StaggerIn>
+          {/* Multi-Week View (current week + 4 history rows) */}
+          <StaggerIn delay={120}>
+            <div
+              className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
+            >
+              <MultiWeekView
+                currentWeekId={weekId}
+                currentWeekPlan={showStaleContent ? null : weekPlan}
+                currentSessions={showStaleContent ? [] : sessions}
+                currentSessionsByDay={showStaleContent ? ({} as SessionsByDay) : sessionsByDay}
+                onAddSession={handleAddSession}
+                onEditSession={handleEditSession}
+                onDeleteSession={handleDeleteSession}
+                onUpdateCoachPostFeedback={handleUpdateCoachPostFeedback}
+                onToggleComplete={isViewingSelf ? handleToggleComplete : undefined}
+                onUpdateNotes={isViewingSelf ? handleUpdateNotes : undefined}
+                onUpdatePerformance={isViewingSelf ? handleUpdatePerformance : undefined}
+                userRole={user?.role}
+                showAthleteControls={isViewingSelf}
+              />
+            </div>
+          </StaggerIn>
 
-            {/* Session Form Sheet */}
-            <SessionForm
-              open={formOpen}
-              onClose={() => setFormOpen(false)}
-              weekPlanId={weekPlan.id}
-              day={formDay}
-              session={editingSession}
-              onSubmit={handleFormSubmit}
-              isCoach={true}
-            />
-          </>
-        )}
+          {/* Session Form Sheet */}
+          <SessionForm
+            open={formOpen}
+            onClose={() => setFormOpen(false)}
+            weekPlanId={weekPlan.id}
+            day={formDay}
+            session={editingSession}
+            onSubmit={handleFormSubmit}
+            isCoach={true}
+          />
+        </div>
+      )}
 
-        {/* Delete session confirmation */}
-        <DeleteConfirmationDialog
-          open={!!deleteConfirmId}
-          onOpenChange={(open) => {
-            if (!open) setDeleteConfirmId(null);
-          }}
-          title={t('session.delete')}
-          description={t('session.deleteConfirm')}
-          confirmLabel={t('session.delete')}
-          cancelLabel={t('common:actions.cancel' as never)}
-          onConfirm={() => {
-            deleteSessionMut.mutate(deleteConfirmId!, {
-              onSettled: () => setDeleteConfirmId(null),
-            });
-          }}
-          isPending={deleteSessionMut.isPending}
-        />
-      </div>
+      {/* Delete session confirmation */}
+      <DeleteConfirmationDialog
+        open={!!deleteConfirmId}
+        onOpenChange={(open) => {
+          if (!open) setDeleteConfirmId(null);
+        }}
+        title={t('session.delete')}
+        description={t('session.deleteConfirm')}
+        confirmLabel={t('session.delete')}
+        cancelLabel={t('common:actions.cancel' as never)}
+        onConfirm={() => {
+          deleteSessionMut.mutate(deleteConfirmId!, {
+            onSettled: () => setDeleteConfirmId(null),
+          });
+        }}
+        isPending={deleteSessionMut.isPending}
+      />
     </>
   );
 }

--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -31,9 +31,8 @@ export default function LandingPage() {
     }
   }, [user, isLoading, navigate, locale]);
 
-  if (isLoading || user) {
-    return <AppLoader />;
-  }
+  if (isLoading) return null; // GlobalLoader in root.tsx covers this
+  if (user) return <AppLoader />;
 
   return (
     <div className="min-h-screen bg-background">

--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -31,8 +31,7 @@ export default function LandingPage() {
     }
   }, [user, isLoading, navigate, locale]);
 
-  if (isLoading) return null; // GlobalLoader in root.tsx covers this
-  if (user) return <AppLoader />;
+  if (isLoading || user) return <AppLoader />;
 
   return (
     <div className="min-h-screen bg-background">

--- a/app/routes/root-redirect.tsx
+++ b/app/routes/root-redirect.tsx
@@ -1,12 +1,13 @@
 import { Navigate } from 'react-router';
 import { useAuth } from '~/lib/context/AuthContext';
+import { AppLoader } from '~/components/ui/app-loader';
 import { getCurrentWeekId } from '~/lib/utils/date';
 
 export default function RootRedirect() {
   const { user, isLoading } = useAuth();
   const locale = localStorage.getItem('locale') ?? 'pl';
 
-  if (isLoading) return null; // GlobalLoader in root.tsx covers this
+  if (isLoading) return <AppLoader />;
   if (!user) return <Navigate to={`/${locale}`} replace />;
   return <Navigate to={`/${locale}/${user.role}/week/${getCurrentWeekId()}`} replace />;
 }

--- a/app/routes/root-redirect.tsx
+++ b/app/routes/root-redirect.tsx
@@ -1,6 +1,12 @@
 import { Navigate } from 'react-router';
+import { useAuth } from '~/lib/context/AuthContext';
+import { getCurrentWeekId } from '~/lib/utils/date';
 
 export default function RootRedirect() {
+  const { user, isLoading } = useAuth();
   const locale = localStorage.getItem('locale') ?? 'pl';
-  return <Navigate to={`/${locale}`} replace />;
+
+  if (isLoading) return null; // GlobalLoader in root.tsx covers this
+  if (!user) return <Navigate to={`/${locale}`} replace />;
+  return <Navigate to={`/${locale}/${user.role}/week/${getCurrentWeekId()}`} replace />;
 }


### PR DESCRIPTION
## Summary

- Syncs the AppLoader breathing animation across remounts via a module-level ANIMATION_START timestamp — no animation jump when the loader re-mounts on route navigation
- Smart-redirects authenticated users from / directly to /locale/role/week/weekId, skipping the landing page redirect chain

## What was tried and reverted

A GlobalLoader component in root.tsx was introduced to centralise loading state, but caused two regressions:
- Double-pop on /: HydrateFallback renders its own AppLoader before React mounts; GlobalLoader then renders a second one, creating two separate animation cycles
- Black flash: layouts returning null while loading left a blank frame between GlobalLoader hiding and content appearing

Each route now manages its own loading state with AppLoader directly (same as before), with the animation sync solving the original remount issue.

## Test plan

- [ ] Cold load as unauthenticated user — loader appears, redirects to landing
- [ ] Cold load as authenticated coach — loader appears once (no double-pop), redirects directly to current week view
- [ ] Cold load as authenticated athlete — same as above
- [ ] Navigate between weeks — no loader flash or animation restart

Generated with Claude Code