### PR TITLE
feat: goals, competition sessions, and analytics dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,3 +298,10 @@ getWeekDateRange(monday) // → "Mar 2 – Mar 8, 2026"
 - Week IDs are ISO 8601 format: `YYYY-WWW`
 - `weekStart` fields are always Monday's date in `YYYY-MM-DD`
 - Use `date-fns` functions for all other date operations
+
+## Active Technologies
+- TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, shadcn/ui (New York), i18next, date-fns 4, Zod 4 (014-goals-analytics)
+- Supabase (PostgreSQL) with RLS; existing `week_plans` + `training_sessions` tables (014-goals-analytics)
+
+## Recent Changes
+- 014-goals-analytics: Added TypeScript 5 (strict) + React 19, React Router 7 (SPA), TanStack Query 5, shadcn/ui (New York), i18next, date-fns 4, Zod 4

--- a/app/components/analytics/AnalyticsView.tsx
+++ b/app/components/analytics/AnalyticsView.tsx
@@ -62,7 +62,6 @@ export function AnalyticsView({ namespace, athleteId, goals, className }: Analyt
   const completionLabel = t('analytics.totals.completion' as never);
 
   const totals = data?.totals;
-  const duration = totals ? formatTotalDuration(totals.totalDurationMinutes) : null;
 
   return (
     <div className={cn('overflow-hidden rounded-xl border border-white/[0.07] bg-zinc-950', className)}>
@@ -120,11 +119,10 @@ export function AnalyticsView({ namespace, athleteId, goals, className }: Analyt
             />
           </div>
           <div className="bg-zinc-950 px-4 py-3">
-            <StatChip
-              label={timeLabel}
-              value={duration!.value}
-              sub={duration!.unit}
-            />
+            {(() => {
+              const d = formatTotalDuration(totals.totalDurationMinutes);
+              return <StatChip label={timeLabel} value={d.value} sub={d.unit} />;
+            })()}
           </div>
           <div className="bg-zinc-950 px-4 py-3">
             <StatChip

--- a/app/components/analytics/AnalyticsView.tsx
+++ b/app/components/analytics/AnalyticsView.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '~/lib/utils';
+import { PeriodSelector } from '~/components/analytics/PeriodSelector';
+import { SportFilter } from '~/components/analytics/SportFilter';
+import { VolumeChart } from '~/components/analytics/VolumeChart';
+import { GoalCard } from '~/components/goals/GoalCard';
+import { useAnalytics } from '~/lib/hooks/useAnalytics';
+import { computeGoalAchievement } from '~/lib/utils/goals';
+import type { AnalyticsPeriod, Goal, TrainingType } from '~/types/training';
+
+interface AnalyticsViewProps {
+  namespace: 'coach' | 'athlete';
+  athleteId: string;
+  goals: Goal[];
+  className?: string;
+}
+
+interface StatChipProps {
+  label: string;
+  value: string;
+  sub?: string;
+}
+
+function StatChip({ label, value, sub }: StatChipProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] font-bold tracking-[0.15em] text-white/35 uppercase">{label}</span>
+      <div className="flex items-baseline gap-1">
+        <span className="text-lg font-semibold tabular-nums text-white/90">{value}</span>
+        {sub && <span className="text-[11px] text-white/40">{sub}</span>}
+      </div>
+    </div>
+  );
+}
+
+function formatTotalDuration(minutes: number): { value: string; unit: string } {
+  if (minutes < 60) return { value: String(minutes), unit: 'min' };
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (m === 0) return { value: String(h), unit: 'h' };
+  return { value: `${h}h ${m}`, unit: 'min' };
+}
+
+export function AnalyticsView({ namespace, athleteId, goals, className }: AnalyticsViewProps) {
+  const { t } = useTranslation(namespace);
+  const [period, setPeriod] = useState<AnalyticsPeriod>('month');
+  const [goalId, setGoalId] = useState<string | undefined>(goals[0]?.id);
+  const [sportFilter, setSportFilter] = useState<TrainingType | undefined>(undefined);
+
+  const { data, isLoading } = useAnalytics({
+    athleteId,
+    period,
+    goalId: period === 'goal' ? goalId : undefined,
+    trainingType: sportFilter,
+  });
+
+  const title = t('analytics.title' as never);
+  const distanceLabel = t('analytics.totals.distance' as never);
+  const sessionsLabel = t('analytics.totals.sessions' as never);
+  const timeLabel = t('analytics.totals.time' as never);
+  const completionLabel = t('analytics.totals.completion' as never);
+
+  const totals = data?.totals;
+  const duration = totals ? formatTotalDuration(totals.totalDurationMinutes) : null;
+
+  return (
+    <div className={cn('overflow-hidden rounded-xl border border-white/[0.07] bg-zinc-950', className)}>
+      {/* Header */}
+      <div className="px-5 pt-5 pb-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="text-[10px] font-bold tracking-[0.18em] text-white/40 uppercase">{title}</span>
+          <SportFilter namespace={namespace} value={sportFilter} onChange={setSportFilter} />
+        </div>
+        <PeriodSelector
+          namespace={namespace}
+          period={period}
+          goalId={goalId}
+          goals={goals}
+          onPeriodChange={setPeriod}
+          onGoalChange={setGoalId}
+          className="mt-3"
+        />
+      </div>
+
+      {/* Goal card — shown between header and totals when in goal period */}
+      {period === 'goal' && !isLoading && data?.competitions.map((comp) => {
+        const goal = goals.find((g) => g.id === comp.goalId);
+        if (!goal) return null;
+        return (
+          <div key={comp.goalId} className="border-t border-white/[0.06] px-5 py-4">
+            <GoalCard
+              goal={goal}
+              canEdit={false}
+              achievementStatus={computeGoalAchievement(goal, {
+                resultDistanceKm: comp.resultDistanceKm,
+                resultTimeSeconds: comp.resultTimeSeconds,
+              })}
+              onEdit={() => {}}
+              onDelete={() => {}}
+            />
+          </div>
+        );
+      })}
+
+      {/* Totals strip */}
+      {totals && !isLoading && (
+        <div className="grid grid-cols-4 gap-px border-t border-white/[0.06] bg-white/[0.04]">
+          <div className="bg-zinc-950 px-4 py-3">
+            <StatChip
+              label={distanceLabel}
+              value={totals.totalDistanceKm.toFixed(1)}
+              sub="km"
+            />
+          </div>
+          <div className="bg-zinc-950 px-4 py-3">
+            <StatChip
+              label={sessionsLabel}
+              value={`${totals.completedSessions}/${totals.totalSessions}`}
+            />
+          </div>
+          <div className="bg-zinc-950 px-4 py-3">
+            <StatChip
+              label={timeLabel}
+              value={duration!.value}
+              sub={duration!.unit}
+            />
+          </div>
+          <div className="bg-zinc-950 px-4 py-3">
+            <StatChip
+              label={completionLabel}
+              value={`${Math.round(totals.overallCompletionRate)}%`}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Charts / empty / loading */}
+      <div className="border-t border-white/[0.06] px-5 py-5">
+        {isLoading ? (
+          <div className="flex h-40 items-center justify-center">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent" />
+          </div>
+        ) : !data || data.buckets.length === 0 ? (
+          <p className="py-8 text-center text-sm text-white/30">
+            {t('analytics.empty' as never)}
+          </p>
+        ) : (
+          <VolumeChart namespace={namespace} buckets={data.buckets} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/analytics/PeriodSelector.tsx
+++ b/app/components/analytics/PeriodSelector.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import { cn } from '~/lib/utils';
+import type { AnalyticsPeriod, Goal } from '~/types/training';
+
+const PERIODS: AnalyticsPeriod[] = ['year', 'quarter', 'month', 'goal'];
+
+interface PeriodSelectorProps {
+  namespace: 'coach' | 'athlete';
+  period: AnalyticsPeriod;
+  goalId?: string;
+  goals: Goal[];
+  onPeriodChange: (period: AnalyticsPeriod) => void;
+  onGoalChange: (goalId: string) => void;
+  className?: string;
+}
+
+export function PeriodSelector({
+  namespace,
+  period,
+  goalId,
+  goals,
+  onPeriodChange,
+  onGoalChange,
+  className,
+}: PeriodSelectorProps) {
+  const { t } = useTranslation(namespace);
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+      <div className="flex rounded-lg border border-border/50 bg-muted/30 p-0.5">
+        {PERIODS.map((p) => (
+          <button
+            key={p}
+            onClick={() => onPeriodChange(p)}
+            className={cn(
+              'h-7 rounded-md px-3 text-xs font-semibold transition-all',
+              period === p
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {t(`analytics.period.${p}` as never)}
+          </button>
+        ))}
+      </div>
+
+      {period === 'goal' && (
+        <Select value={goalId ?? ''} onValueChange={onGoalChange}>
+          <SelectTrigger className="h-8 w-auto min-w-[160px] text-xs">
+            <SelectValue placeholder={t('analytics.period.selectGoal' as never)} />
+          </SelectTrigger>
+          <SelectContent>
+            {goals.map((g) => (
+              <SelectItem key={g.id} value={g.id} className="text-xs">
+                {g.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  );
+}

--- a/app/components/analytics/SportFilter.tsx
+++ b/app/components/analytics/SportFilter.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import { trainingTypeConfig, iconMap } from '~/lib/utils/training-types';
+import { cn } from '~/lib/utils';
+import type { TrainingType } from '~/types/training';
+
+const ALL_SPORTS = '__all__' as const;
+const SPORT_OPTIONS: TrainingType[] = [
+  'run',
+  'cycling',
+  'swimming',
+  'strength',
+  'yoga',
+  'mobility',
+  'walk',
+  'hike',
+  'other',
+];
+
+interface SportFilterProps {
+  namespace: 'coach' | 'athlete';
+  value: TrainingType | undefined;
+  onChange: (value: TrainingType | undefined) => void;
+  className?: string;
+}
+
+export function SportFilter({ namespace, value, onChange, className }: SportFilterProps) {
+  const { t } = useTranslation([namespace, 'common']);
+
+  const selectValue = value ?? ALL_SPORTS;
+
+  const handleChange = (v: string) => {
+    onChange(v === ALL_SPORTS ? undefined : (v as TrainingType));
+  };
+
+  const config = value ? trainingTypeConfig[value] : null;
+  const Icon = config ? iconMap[config.icon] : null;
+
+  return (
+    <Select value={selectValue} onValueChange={handleChange}>
+      <SelectTrigger className={cn('h-8 w-auto min-w-[140px] text-xs', className)}>
+        <SelectValue>
+          {config && Icon ? (
+            <span className="flex items-center gap-1.5">
+              <Icon className={cn('h-3 w-3', config.color)} />
+              <span>{t(`common:trainingTypes.${value}` as never)}</span>
+            </span>
+          ) : (
+            t(`${namespace}:analytics.filter.allSports` as never)
+          )}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={ALL_SPORTS} className="text-xs">
+          {t(`${namespace}:analytics.filter.allSports` as never)}
+        </SelectItem>
+        {SPORT_OPTIONS.map((sport) => {
+          const cfg = trainingTypeConfig[sport];
+          const SportIcon = iconMap[cfg.icon];
+          return (
+            <SelectItem key={sport} value={sport} className="text-xs">
+              <span className="flex items-center gap-1.5">
+                {SportIcon && <SportIcon className={cn('h-3 w-3', cfg.color)} />}
+                <span>{t(`common:trainingTypes.${sport}` as never)}</span>
+              </span>
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/app/components/analytics/VolumeChart.tsx
+++ b/app/components/analytics/VolumeChart.tsx
@@ -1,0 +1,157 @@
+import { useTranslation } from 'react-i18next';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from 'recharts';
+import { cn } from '~/lib/utils';
+import type { AnalyticsBucket } from '~/types/training';
+
+// Explicit hex colors — CSS vars are unreliable in SVG fill attributes
+const COLOR_DISTANCE = '#6366f1';     // indigo-500, pops on dark and light
+const COLOR_COMPLETED = '#10b981';    // emerald-500
+const COLOR_PENDING = 'rgba(255,255,255,0.10)';
+const COLOR_GRID = 'rgba(255,255,255,0.06)';
+const COLOR_TICK = 'rgba(255,255,255,0.35)';
+const COLOR_CURSOR = 'rgba(255,255,255,0.04)';
+
+interface VolumeChartProps {
+  namespace: 'coach' | 'athlete';
+  buckets: AnalyticsBucket[];
+  className?: string;
+}
+
+interface TooltipEntry {
+  value: number;
+  name: string;
+  color: string;
+  payload: Record<string, unknown>;
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: TooltipEntry[];
+  label?: string;
+}
+
+function DistanceTooltip({ active, payload, label }: TooltipProps) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0];
+  if (!entry || entry.value === 0) return null;
+  return (
+    <div className="rounded-lg border border-white/10 bg-zinc-900/95 px-3 py-2 text-xs shadow-xl backdrop-blur">
+      <p className="mb-1.5 font-semibold text-white/80">{label}</p>
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: entry.color }} />
+        <span className="text-white/50">{entry.name}:</span>
+        <span className="font-medium text-white">{(entry.value as number).toFixed(1)} km</span>
+      </div>
+    </div>
+  );
+}
+
+function SessionsTooltip({ active, payload, label, completedLabel, totalLabel }: TooltipProps & { completedLabel: string; totalLabel: string }) {
+  if (!active || !payload?.length) return null;
+  const data = payload[0]?.payload;
+  if (!data) return null;
+  const completed = data.completedSessions as number;
+  const total = data.totalSessions as number;
+  if (total === 0) return null;
+  return (
+    <div className="rounded-lg border border-white/10 bg-zinc-900/95 px-3 py-2 text-xs shadow-xl backdrop-blur">
+      <p className="mb-1.5 font-semibold text-white/80">{label}</p>
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: COLOR_COMPLETED }} />
+        <span className="text-white/50">{completedLabel}:</span>
+        <span className="font-medium text-white">{completed}/{total}</span>
+      </div>
+    </div>
+  );
+}
+
+export function VolumeChart({ namespace, buckets, className }: VolumeChartProps) {
+  const { t } = useTranslation(namespace);
+
+  const distanceLabel = t('analytics.chart.distance' as never);
+  const sessionsLabel = t('analytics.chart.sessions' as never);
+  const completedLabel = t('analytics.totals.completion' as never);
+
+  // Pre-compute pending sessions so stacking shows total = completed + pending
+  const sessionData = buckets.map((b) => ({
+    ...b,
+    pendingSessions: Math.max(0, b.totalSessions - b.completedSessions),
+  }));
+
+  // Determine bar size based on bucket count — fewer buckets = wider bars
+  const barSize = buckets.length <= 12 ? 16 : buckets.length <= 31 ? 8 : 5;
+
+  const axisProps = {
+    tick: { fontSize: 10, fill: COLOR_TICK },
+    axisLine: false as const,
+    tickLine: false as const,
+  };
+
+  return (
+    <div className={cn('space-y-6', className)}>
+      {/* Distance chart */}
+      <div>
+        <p className="mb-3 text-[10px] font-bold tracking-[0.15em] text-white/40 uppercase">
+          {distanceLabel}
+        </p>
+        <ResponsiveContainer width="100%" height={180}>
+          <BarChart data={buckets} barSize={barSize} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke={COLOR_GRID} />
+            <XAxis dataKey="label" {...axisProps} interval="preserveStartEnd" />
+            <YAxis {...axisProps} />
+            <Tooltip
+              content={<DistanceTooltip />}
+              cursor={{ fill: COLOR_CURSOR }}
+            />
+            <Bar
+              dataKey="totalDistanceKm"
+              name={distanceLabel}
+              fill={COLOR_DISTANCE}
+              radius={[3, 3, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Sessions chart — stacked: completed (green) + pending (muted) */}
+      <div>
+        <p className="mb-3 text-[10px] font-bold tracking-[0.15em] text-white/40 uppercase">
+          {sessionsLabel}
+        </p>
+        <ResponsiveContainer width="100%" height={130}>
+          <BarChart data={sessionData} barSize={barSize} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke={COLOR_GRID} />
+            <XAxis dataKey="label" {...axisProps} interval="preserveStartEnd" />
+            <YAxis {...axisProps} allowDecimals={false} />
+            <Tooltip
+              content={<SessionsTooltip completedLabel={completedLabel} totalLabel={sessionsLabel} />}
+              cursor={{ fill: COLOR_CURSOR }}
+            />
+            <Bar
+              dataKey="completedSessions"
+              name={completedLabel}
+              fill={COLOR_COMPLETED}
+              radius={[0, 0, 0, 0]}
+              stackId="s"
+            />
+            <Bar
+              dataKey="pendingSessions"
+              name={sessionsLabel}
+              fill={COLOR_PENDING}
+              radius={[3, 3, 0, 0]}
+              stackId="s"
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/app/components/calendar/GoalPrepBanner.tsx
+++ b/app/components/calendar/GoalPrepBanner.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { Trophy } from 'lucide-react';
+import { differenceInDays, parseISO } from 'date-fns';
+import { isWeekInPrepWindow, isCompetitionWeek } from '~/lib/utils/goals';
+import { competitionConfig } from '~/lib/utils/training-types';
+import type { Goal } from '~/types/training';
+import { cn } from '~/lib/utils';
+
+interface GoalPrepBannerProps {
+  goals: Goal[];
+  weekStart: string;
+  className?: string;
+}
+
+export function GoalPrepBanner({ goals, weekStart, className }: GoalPrepBannerProps) {
+  const { t } = useTranslation('training');
+
+  const prepGoals = goals.filter((g) => isWeekInPrepWindow(weekStart, g));
+
+  if (prepGoals.length === 0) return null;
+
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      {prepGoals.map((goal) => {
+        const daysUntil = differenceInDays(parseISO(goal.competitionDate), new Date());
+        const isCompWeek = isCompetitionWeek(weekStart, goal);
+
+        return (
+          <div
+            key={goal.id}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm border',
+              competitionConfig.bgColor,
+              competitionConfig.borderColor
+            )}
+          >
+            <Trophy className={cn('size-3.5 shrink-0', competitionConfig.color)} />
+            <span className={cn('font-medium', competitionConfig.color)}>
+              {isCompWeek
+                ? t('goalPrep.competitionWeek', { goalName: goal.name })
+                : t('goalPrep.banner', { goalName: goal.name })}
+            </span>
+            <span className="ml-auto text-xs text-muted-foreground">
+              {isCompWeek
+                ? t('goalPrep.thisWeek')
+                : daysUntil > 0
+                  ? t('goalPrep.daysUntil', { days: daysUntil })
+                  : null}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/calendar/SessionCard.tsx
+++ b/app/components/calendar/SessionCard.tsx
@@ -12,7 +12,7 @@ import { StravaSyncButton } from '~/components/training/StravaSyncButton';
 import { StravaConfirmButton } from '~/components/training/StravaConfirmButton';
 import { useAuth } from '~/lib/context/AuthContext';
 import { useSessionActions } from '~/lib/context/SessionActionsContext';
-import { trainingTypeConfig, iconMap, isDistanceBased } from '~/lib/utils/training-types';
+import { trainingTypeConfig, competitionConfig, iconMap, isDistanceBased } from '~/lib/utils/training-types';
 import { getSessionCalendarDate } from '~/lib/utils/date';
 import { cn } from '~/lib/utils';
 import { type TrainingSession, type RunData } from '~/types/training';
@@ -66,8 +66,11 @@ export function SessionCard({ session, weekStart, draggable = false, onCopy }: S
     setDetailOpen(true);
   };
 
+  const isCompetition = !!session.goalId;
   const config = trainingTypeConfig[session.trainingType];
-  const Icon = iconMap[config.icon] ?? iconMap['Footprints'];
+  const Icon = isCompetition
+    ? (iconMap[competitionConfig.icon] ?? iconMap['Trophy'])
+    : (iconMap[config.icon] ?? iconMap['Footprints']);
   const isRestDay = session.trainingType === 'rest_day';
   const distanceBased = isDistanceBased(session.trainingType);
 
@@ -109,6 +112,7 @@ export function SessionCard({ session, weekStart, draggable = false, onCopy }: S
       className={cn(
         'group cursor-pointer rounded-xl p-3 ring-1 ring-[color:var(--border)] transition-all',
         session.isCompleted ? 'bg-surface-2 opacity-70' : 'bg-surface-1',
+        isCompetition && cn('border-2', competitionConfig.borderColor),
       )}
       onClick={handleCardClick}
     >
@@ -125,16 +129,18 @@ export function SessionCard({ session, weekStart, draggable = false, onCopy }: S
               <GripVertical className="h-3.5 w-3.5" />
             </button>
           )}
-          {/* Sport badge pill — sport color only here */}
+          {/* Sport badge pill — competition uses amber, others use sport color */}
           <span
             className={cn(
               'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
-              config.bgColor,
-              config.color,
+              isCompetition ? competitionConfig.bgColor : config.bgColor,
+              isCompetition ? competitionConfig.color : config.color,
             )}
           >
             <Icon className="h-2.5 w-2.5" />
-            {t(`common:trainingTypes.${session.trainingType}` as never)}
+            {isCompetition
+              ? t('training:competition.label')
+              : t(`common:trainingTypes.${session.trainingType}` as never)}
           </span>
         </div>
         <div className="flex items-center gap-0.5">

--- a/app/components/calendar/SportBreakdown.tsx
+++ b/app/components/calendar/SportBreakdown.tsx
@@ -1,0 +1,266 @@
+import { useTranslation } from 'react-i18next';
+import { cn } from '~/lib/utils';
+import { trainingTypeConfig, competitionConfig, iconMap } from '~/lib/utils/training-types';
+import type { WeekStats, TrainingType } from '~/types/training';
+
+interface SportBreakdownProps {
+  stats: WeekStats;
+  className?: string;
+}
+
+function formatDuration(min: number): string | null {
+  if (min === 0) return null;
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+function ColHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-1.5 text-[9px] font-bold tracking-[0.15em] text-muted-foreground/50 uppercase">
+      {children}
+    </p>
+  );
+}
+
+function Stat({ value, sub }: { value: React.ReactNode; sub?: string }) {
+  return (
+    <div>
+      <p className="text-sm font-bold tabular-nums leading-tight">{value}</p>
+      {sub && <p className="mt-0.5 text-[10px] tabular-nums text-muted-foreground/60">{sub}</p>}
+    </div>
+  );
+}
+
+function SportRow({
+  type,
+  sessionCount,
+  completedSessionCount,
+  plannedDistanceKm,
+  actualDistanceKm,
+  totalDurationMinutes,
+}: {
+  type: TrainingType;
+  sessionCount: number;
+  completedSessionCount: number;
+  plannedDistanceKm: number;
+  actualDistanceKm: number;
+  totalDurationMinutes: number;
+}) {
+  const { t } = useTranslation(['coach', 'common']);
+  const config = trainingTypeConfig[type];
+  const Icon = iconMap[config.icon];
+  const hasDistance = plannedDistanceKm > 0 || actualDistanceKm > 0;
+  const duration = formatDuration(totalDurationMinutes);
+
+  return (
+    <div className="flex items-start gap-3 py-3">
+      {/* Icon */}
+      <div
+        className={cn(
+          'mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+          config.bgColor,
+        )}
+      >
+        {Icon && <Icon className={cn('h-4 w-4', config.color)} />}
+      </div>
+
+      {/* Sport name + session count */}
+      <div className="min-w-0 flex-1">
+        <p className={cn('text-sm font-semibold leading-tight', config.color)}>
+          {t(`common:trainingTypes.${type}` as never)}
+        </p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          {t('coach:weekSummary.sessionCount', { count: sessionCount })}
+        </p>
+      </div>
+
+      {/* Planned column */}
+      <div className="w-16 shrink-0 text-right">
+        <ColHeader>{t('coach:weekSummary.colPlanned')}</ColHeader>
+        <Stat value={hasDistance ? `${plannedDistanceKm.toFixed(1)} km` : '—'} />
+      </div>
+
+      {/* Performance column */}
+      <div className="w-20 shrink-0 text-right">
+        <ColHeader>{t('coach:weekSummary.colPerformance')}</ColHeader>
+        <Stat
+          value={hasDistance ? (actualDistanceKm > 0 ? `${actualDistanceKm.toFixed(1)} km` : '—') : (duration ?? '—')}
+          sub={hasDistance && duration ? duration : undefined}
+        />
+        {!hasDistance && (
+          <p className="mt-0.5 text-[10px] text-muted-foreground/50">
+            {completedSessionCount}/{sessionCount}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RestDayRow({ count }: { count: number }) {
+  const { t } = useTranslation(['coach', 'common']);
+  const config = trainingTypeConfig['rest_day'];
+  const Icon = iconMap[config.icon];
+
+  return (
+    <div className="flex items-center gap-3 py-3">
+      <div
+        className={cn(
+          'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+          config.bgColor,
+        )}
+      >
+        {Icon && <Icon className={cn('h-4 w-4', config.color)} />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className={cn('text-sm font-semibold leading-tight', config.color)}>
+          {t('common:trainingTypes.rest_day' as never)}
+        </p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          {t('coach:weekSummary.dayCount', { count })}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CompetitionRow({
+  goalName,
+  discipline,
+  goalDistanceKm,
+  actualDistanceKm,
+  actualDurationMinutes,
+}: {
+  goalName: string;
+  discipline: TrainingType;
+  goalDistanceKm: number | null;
+  actualDistanceKm: number | null;
+  actualDurationMinutes: number | null;
+}) {
+  const { t } = useTranslation(['coach', 'common']);
+  const Icon = iconMap[competitionConfig.icon];
+
+  const perfValue = actualDistanceKm != null
+    ? `${actualDistanceKm.toFixed(1)} km`
+    : actualDurationMinutes != null
+      ? formatDuration(actualDurationMinutes)
+      : '—';
+
+  return (
+    <div className="flex items-start gap-3 py-3">
+      <div
+        className={cn(
+          'mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+          competitionConfig.bgColor,
+        )}
+      >
+        {Icon && <Icon className={cn('h-4 w-4', competitionConfig.color)} />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className={cn('text-sm font-semibold leading-tight', competitionConfig.color)}>
+          {goalName}
+        </p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          {t(`common:trainingTypes.${discipline}` as never)}
+        </p>
+      </div>
+      <div className="w-16 shrink-0 text-right">
+        <ColHeader>{t('coach:weekSummary.colPlanned')}</ColHeader>
+        <Stat value={goalDistanceKm != null ? `${goalDistanceKm.toFixed(1)} km` : '—'} />
+      </div>
+      <div className="w-20 shrink-0 text-right">
+        <ColHeader>{t('coach:weekSummary.colPerformance')}</ColHeader>
+        <Stat value={perfValue} />
+      </div>
+    </div>
+  );
+}
+
+export function SportBreakdown({ stats, className }: SportBreakdownProps) {
+  const { t } = useTranslation('coach');
+
+  const allTypeEntries = (
+    Object.entries(stats.byType) as [
+      TrainingType,
+      NonNullable<(typeof stats.byType)[TrainingType]>,
+    ][]
+  ).sort(([, a], [, b]) => b.sessionCount - a.sessionCount);
+
+  const restDayEntry = allTypeEntries.find(([type]) => type === 'rest_day');
+  const regularEntries = allTypeEntries.filter(([type]) => type !== 'rest_day');
+
+  const hasContent = allTypeEntries.length > 0 || stats.competitionSessions.length > 0;
+
+  if (!hasContent) {
+    return (
+      <p className={cn('py-4 text-center text-sm text-muted-foreground', className)}>
+        {t('weekSummary.noBreakdown')}
+      </p>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-0', className)}>
+      {/* Competitions first */}
+      {stats.competitionSessions.length > 0 && (
+        <div className={cn(regularEntries.length > 0 || restDayEntry ? 'border-b border-border/40 pb-1' : '')}>
+          <p
+            className={cn(
+              'pt-2 pb-1 text-[10px] font-bold tracking-wider uppercase',
+              competitionConfig.color,
+            )}
+          >
+            {t('weekSummary.competitions')}
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-6">
+            {stats.competitionSessions.map((comp) => (
+              <div key={comp.sessionId} className="border-b border-border/40 last:border-0">
+                <CompetitionRow
+                  goalName={comp.goalName}
+                  discipline={comp.discipline}
+                  goalDistanceKm={comp.goalDistanceKm}
+                  actualDistanceKm={comp.actualDistanceKm}
+                  actualDurationMinutes={comp.actualDurationMinutes}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Regular training sports */}
+      {regularEntries.length > 0 && (
+        <div>
+          {stats.competitionSessions.length > 0 && (
+            <p className="pt-2 pb-1 text-[10px] font-bold tracking-wider text-muted-foreground/60 uppercase">
+              {t('weekSummary.training')}
+            </p>
+          )}
+          <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-6">
+            {regularEntries.map(([type, entry]) => (
+              <div key={type} className="border-b border-border/40 last:border-0 md:last:border-0">
+                <SportRow
+                  type={type}
+                  sessionCount={entry.sessionCount}
+                  completedSessionCount={entry.completedSessionCount}
+                  plannedDistanceKm={entry.plannedDistanceKm}
+                  actualDistanceKm={entry.actualDistanceKm}
+                  totalDurationMinutes={entry.totalDurationMinutes}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Rest day last — no plan/performance data */}
+      {restDayEntry && (
+        <div className={cn((regularEntries.length > 0 || stats.competitionSessions.length > 0) && 'border-t border-border/40')}>
+          <RestDayRow count={restDayEntry[1].sessionCount} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/calendar/WeekSummary.tsx
+++ b/app/components/calendar/WeekSummary.tsx
@@ -1,13 +1,17 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronUp, Pencil, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, Pencil, Trophy, X } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Textarea } from '~/components/ui/textarea';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
 import { loadTypeConfig } from '~/lib/utils/training-types';
-import { LOAD_TYPES, type WeekPlan, type WeekStats } from '~/types/training';
+import { SportBreakdown } from '~/components/calendar/SportBreakdown';
+import { LOAD_TYPES, type WeekPlan, type WeekStats, type Goal, type TrainingSession } from '~/types/training';
+
+const VIEW_KEY = 'weekSummary.view';
+type SummaryView = 'cumulative' | 'by-sport';
 
 interface WeekSummaryProps {
   weekPlan: WeekPlan;
@@ -18,6 +22,8 @@ interface WeekSummaryProps {
       Pick<WeekPlan, 'loadType' | 'totalPlannedKm' | 'actualTotalKm' | 'coachComments'>
     >,
   ) => void;
+  competitionGoal?: Goal | null;
+  competitionSession?: TrainingSession | null;
 }
 
 function StatValue({ value, unit }: { value: string | number; unit?: string }) {
@@ -33,6 +39,14 @@ function StatValue({ value, unit }: { value: string | number; unit?: string }) {
   );
 }
 
+function formatTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
 function formatDuration(minutes: number): { value: string; unit: string } {
   if (minutes === 0) return { value: '0', unit: 'min' };
   if (minutes < 60) return { value: minutes.toString(), unit: 'min' };
@@ -42,10 +56,27 @@ function formatDuration(minutes: number): { value: string; unit: string } {
   return { value: `${h}h ${m}`, unit: 'min' };
 }
 
-export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: WeekSummaryProps) {
+export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate, competitionGoal, competitionSession }: WeekSummaryProps) {
   const { t } = useTranslation(['coach', 'common']);
   const [isExpanded, setIsExpanded] = useState(true);
   const [isEditingKm, setIsEditingKm] = useState(false);
+  const [view, setView] = useState<SummaryView>(() => {
+    try {
+      const stored = sessionStorage.getItem(VIEW_KEY);
+      return stored === 'by-sport' ? 'by-sport' : 'cumulative';
+    } catch {
+      return 'cumulative';
+    }
+  });
+
+  const handleViewChange = (next: SummaryView) => {
+    setView(next);
+    try {
+      sessionStorage.setItem(VIEW_KEY, next);
+    } catch {
+      // ignore
+    }
+  };
 
   const [coachComments, setCoachComments] = useState(weekPlan.coachComments ?? '');
   const [plannedKm, setPlannedKm] = useState(weekPlan.totalPlannedKm?.toString() ?? '');
@@ -71,18 +102,50 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
   return (
     <Card className="gap-0 overflow-hidden border-border/50 py-0 shadow-sm">
       <CardHeader className={cn('px-6 py-4 transition-all', !isExpanded && 'py-4')}>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <CardTitle className="text-sm font-semibold tracking-wider text-foreground/80 uppercase">
             {t('coach:weekSummary.title')}
           </CardTitle>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setIsExpanded((v) => !v)}
-            className="h-8 w-8 rounded-full text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-          >
-            {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-          </Button>
+          <div className="flex items-center gap-1">
+            <div className="flex rounded-md border border-border/50 bg-muted/30 p-0.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid="view-cumulative"
+                onClick={() => handleViewChange('cumulative')}
+                className={cn(
+                  'h-6 rounded px-2.5 text-[10px] font-semibold tracking-wide uppercase transition-all',
+                  view === 'cumulative'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {t('coach:weekSummary.viewCumulative')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid="view-by-sport"
+                onClick={() => handleViewChange('by-sport')}
+                className={cn(
+                  'h-6 rounded px-2.5 text-[10px] font-semibold tracking-wide uppercase transition-all',
+                  view === 'by-sport'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {t('coach:weekSummary.viewBySport')}
+              </Button>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setIsExpanded((v) => !v)}
+              className="h-8 w-8 rounded-full text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            >
+              {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </Button>
+          </div>
         </div>
       </CardHeader>
 
@@ -97,7 +160,32 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
           )}
         >
           <CardContent className="border-t border-border/40 p-0">
-            <div className="grid grid-cols-1 divide-y divide-border/40 bg-muted/5 md:grid-cols-2 md:divide-x md:divide-y-0">
+            {/* By-sport panel — animated height */}
+            <div
+              className="grid transition-[grid-template-rows] duration-300 ease-out"
+              style={{ gridTemplateRows: view === 'by-sport' ? '1fr' : '0fr' }}
+            >
+              <div className="overflow-hidden">
+                <div
+                  className={cn(
+                    'px-6 py-4 transition-opacity duration-300',
+                    view === 'by-sport' ? 'opacity-100' : 'opacity-0',
+                  )}
+                  data-testid="sport-breakdown-view"
+                >
+                  <SportBreakdown stats={stats} />
+                </div>
+              </div>
+            </div>
+
+            {/* Cumulative panel — animated height */}
+            <div
+              className="grid transition-[grid-template-rows] duration-300 ease-out"
+              style={{ gridTemplateRows: view === 'cumulative' ? '1fr' : '0fr' }}
+              data-testid="cumulative-view"
+            >
+              <div className="overflow-hidden">
+            <div className={cn('grid grid-cols-1 divide-y divide-border/40 bg-muted/5 md:grid-cols-2 md:divide-x md:divide-y-0')}>
               {/* ── LEFT: Plan ── */}
               <div className="space-y-5 px-6 py-5">
                 <p className="flex items-center gap-2 text-[10px] font-bold tracking-[0.2em] text-muted-foreground/60 uppercase">
@@ -105,54 +193,47 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
                   {t('coach:weekSummary.plan')}
                 </p>
 
-                {/* Week Load */}
-                <div className="space-y-2">
-                  <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                    {t('coach:weekSummary.loadType')}
-                  </p>
-                  {readonly ? (
-                    weekPlan.loadType ? (
-                      <span
-                        className={cn(
-                          'inline-flex h-7 items-center rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase',
-                          loadTypeConfig[weekPlan.loadType].bgColor,
-                          loadTypeConfig[weekPlan.loadType].color,
-                        )}
-                      >
-                        {t(`common:loadType.${weekPlan.loadType}`)}
-                      </span>
-                    ) : (
-                      <p className="text-sm text-muted-foreground">—</p>
-                    )
-                  ) : (
-                    <div className="flex flex-wrap gap-1.5">
-                      {LOAD_TYPES.map((lt) => {
-                        const config = loadTypeConfig[lt];
-                        const isSelected = weekPlan.loadType === lt;
-                        return (
-                          <Button
-                            key={lt}
-                            variant={isSelected ? 'default' : 'outline'}
-                            size="sm"
-                            className={cn(
-                              'h-7 rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase transition-all',
-                              isSelected
-                                ? `${config.bgColor} ${config.color} border-0 shadow-sm hover:opacity-90`
-                                : 'text-muted-foreground/70 hover:text-foreground',
-                            )}
-                            onClick={() => onUpdate?.({ loadType: isSelected ? null : lt })}
-                          >
-                            {t(`common:loadType.${lt}`)}
-                          </Button>
-                        );
-                      })}
+                {/* Competition block — only on competition weeks */}
+                {competitionGoal && (
+                  <>
+                    <div className="rounded-lg border border-amber-200/60 bg-amber-50/50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20">
+                      <div className="mb-2.5 flex items-center gap-1.5">
+                        <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                        <span className="text-[10px] font-bold tracking-widest text-amber-700 uppercase dark:text-amber-300">
+                          {competitionGoal.name}
+                        </span>
+                      </div>
+                      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+                        <div className="space-y-0.5">
+                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                            {t('training:goal.goalDistance' as never)}
+                          </p>
+                          {competitionGoal.goalDistanceKm != null ? (
+                            <StatValue value={competitionGoal.goalDistanceKm} unit="km" />
+                          ) : (
+                            <StatValue value="—" />
+                          )}
+                        </div>
+                        <div className="space-y-0.5">
+                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                            {t('training:goal.goalTime' as never)}
+                          </p>
+                          {competitionGoal.goalTimeSeconds != null ? (
+                            <StatValue value={formatTime(competitionGoal.goalTimeSeconds)} />
+                          ) : (
+                            <StatValue value="—" />
+                          )}
+                        </div>
+                      </div>
                     </div>
-                  )}
-                </div>
+                    <div className="h-px bg-border/40" />
+                  </>
+                )}
 
-                {/* Planned KM + Planned Sessions */}
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
+                {/* 2×2 metric grid — mirrors Performance layout */}
+                <div className="grid grid-cols-2 gap-x-6 gap-y-5">
+                  {/* Distance */}
+                  <div className="space-y-1">
                     <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
                       {t('coach:weekSummary.plannedKm')}
                     </p>
@@ -160,9 +241,7 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
                       weekPlan.totalPlannedKm != null ? (
                         <StatValue value={weekPlan.totalPlannedKm} unit="km" />
                       ) : stats.totalPlannedKm > 0 ? (
-                        <div className="flex items-baseline gap-1">
-                          <StatValue value={`~${stats.totalPlannedKm.toFixed(1)}`} unit="km" />
-                        </div>
+                        <StatValue value={`~${stats.totalPlannedKm.toFixed(1)}`} unit="km" />
                       ) : (
                         <StatValue value="—" />
                       )
@@ -245,12 +324,62 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
                       </div>
                     )}
                   </div>
-                  <div className="space-y-2">
+
+                  {/* Sessions */}
+                  <div className="space-y-1">
                     <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
                       {t('coach:weekSummary.plannedSessions')}
                     </p>
                     <StatValue value={stats.totalSessions} />
                   </div>
+
+                  {/* Week Load */}
+                  <div className="space-y-1">
+                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                      {t('coach:weekSummary.loadType')}
+                    </p>
+                    {readonly ? (
+                      weekPlan.loadType ? (
+                        <span
+                          className={cn(
+                            'inline-flex h-7 items-center rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase',
+                            loadTypeConfig[weekPlan.loadType].bgColor,
+                            loadTypeConfig[weekPlan.loadType].color,
+                          )}
+                        >
+                          {t(`common:loadType.${weekPlan.loadType}`)}
+                        </span>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">—</p>
+                      )
+                    ) : (
+                      <div className="flex flex-wrap gap-1.5">
+                        {LOAD_TYPES.map((lt) => {
+                          const config = loadTypeConfig[lt];
+                          const isSelected = weekPlan.loadType === lt;
+                          return (
+                            <Button
+                              key={lt}
+                              variant={isSelected ? 'default' : 'outline'}
+                              size="sm"
+                              className={cn(
+                                'h-7 rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase transition-all',
+                                isSelected
+                                  ? `${config.bgColor} ${config.color} border-0 shadow-sm hover:opacity-90`
+                                  : 'text-muted-foreground/70 hover:text-foreground',
+                              )}
+                              onClick={() => onUpdate?.({ loadType: isSelected ? null : lt })}
+                            >
+                              {t(`common:loadType.${lt}`)}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Empty slot — aligns with Completion on the right */}
+                  <div />
                 </div>
 
                 {/* Coach Notes */}
@@ -286,19 +415,70 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
                   {t('coach:weekSummary.performance')}
                 </p>
 
+                {/* Competition result block — only on competition weeks */}
+                {competitionGoal && (
+                  <>
+                    <div className="rounded-lg border border-amber-200/60 bg-amber-50/50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20">
+                      <div className="mb-2.5 flex items-center gap-1.5">
+                        <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                        <span className="text-[10px] font-bold tracking-widest text-amber-700 uppercase dark:text-amber-300">
+                          {t('training:competition.result' as never)}
+                        </span>
+                      </div>
+                      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+                        <div className="space-y-0.5">
+                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                            {t('coach:weekSummary.totalDistance')}
+                          </p>
+                          {competitionSession?.actualDistanceKm != null ? (
+                            <StatValue value={competitionSession.actualDistanceKm.toFixed(1)} unit="km" />
+                          ) : (
+                            <StatValue value="—" />
+                          )}
+                        </div>
+                        <div className="space-y-0.5">
+                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                            {t('coach:weekSummary.totalTime')}
+                          </p>
+                          {competitionSession?.actualDurationMinutes != null ? (
+                            (() => {
+                              const d = formatDuration(competitionSession.actualDurationMinutes);
+                              return <StatValue value={d.value} unit={d.unit} />;
+                            })()
+                          ) : (
+                            <StatValue value="—" />
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="h-px bg-border/40" />
+                  </>
+                )}
+
                 {/* Stat grid */}
                 <div className="grid grid-cols-2 gap-x-6 gap-y-5">
                   <div className="space-y-1">
                     <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.ranKm')}
+                      {t('coach:weekSummary.totalDistance')}
                     </p>
-                    <StatValue value={stats.totalActualRunKm.toFixed(1)} unit="km" />
+                    {stats.totalActualDistanceKm > 0 ? (
+                      <StatValue value={stats.totalActualDistanceKm.toFixed(1)} unit="km" />
+                    ) : (
+                      <StatValue value="—" />
+                    )}
                   </div>
                   <div className="space-y-1">
                     <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
                       {t('coach:weekSummary.completedSessions')}
                     </p>
-                    <StatValue value={stats.completedSessions} />
+                    <div className="flex items-baseline gap-0.5">
+                      <span className="text-xl font-bold tracking-tight">{stats.completedSessions}</span>
+                      {stats.totalSessions > 0 && (
+                        <span className="text-sm font-medium text-muted-foreground/60">
+                          {' '}/ {stats.totalSessions}
+                        </span>
+                      )}
+                    </div>
                   </div>
                   <div className="space-y-1">
                     <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
@@ -320,15 +500,6 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
                 {/* Progress bar */}
                 {stats.totalSessions > 0 && (
                   <div className="pt-2">
-                    <div className="mb-2 flex items-end justify-between">
-                      <span className="text-[10px] font-bold tracking-widest text-muted-foreground/60 uppercase">
-                        {stats.completedSessions} / {stats.totalSessions}{' '}
-                        {t('coach:weekSummary.completedSessions')}
-                      </span>
-                      <span className="text-xs font-black tracking-tight text-foreground/80">
-                        {Math.round(stats.completionPercentage)}%
-                      </span>
-                    </div>
                     <div className="h-1.5 overflow-hidden rounded-full border border-border/10 bg-muted shadow-inner">
                       <div
                         className={cn(
@@ -340,6 +511,8 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate }: Wee
                     </div>
                   </div>
                 )}
+              </div>
+            </div>
               </div>
             </div>
           </CardContent>

--- a/app/components/goals/GoalCard.tsx
+++ b/app/components/goals/GoalCard.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trophy, Calendar, Clock, Ruler, Pencil, Trash2 } from 'lucide-react';
+import { Button } from '~/components/ui/button';
+import { Badge } from '~/components/ui/badge';
+import { trainingTypeConfig, competitionConfig } from '~/lib/utils/training-types';
+import type { Goal, AchievementStatus } from '~/types/training';
+import { cn } from '~/lib/utils';
+import { format, parseISO } from 'date-fns';
+
+interface GoalCardProps {
+  goal: Goal;
+  canEdit: boolean;
+  achievementStatus?: AchievementStatus;
+  onEdit: (goal: Goal) => void;
+  onDelete: (goal: Goal) => void;
+  className?: string;
+}
+
+function formatTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export function GoalCard({ goal, canEdit, achievementStatus, onEdit, onDelete, className }: GoalCardProps) {
+  const { t } = useTranslation('training');
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const typeConfig = trainingTypeConfig[goal.discipline];
+  const status = achievementStatus ?? 'pending';
+
+  const statusColor =
+    status === 'achieved'
+      ? cn(competitionConfig.color, competitionConfig.bgColor)
+      : 'text-muted-foreground bg-muted';
+
+  const isPast = new Date(goal.competitionDate) < new Date();
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-4 flex flex-col gap-3',
+        isPast && 'opacity-80',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Trophy className={cn('size-4 shrink-0', competitionConfig.color)} />
+          <span className="font-semibold truncate">{goal.name}</span>
+          <Badge className={cn('text-xs shrink-0', typeConfig.color, typeConfig.bgColor)}>
+            {t(`common:trainingTypes.${goal.discipline}` as never)}
+          </Badge>
+        </div>
+        {canEdit && (
+          <div className="flex gap-1 shrink-0">
+            <Button variant="ghost" size="icon" className="size-7" onClick={() => onEdit(goal)}>
+              <Pencil className="size-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 text-destructive hover:text-destructive"
+              onClick={() => setConfirmDelete(true)}
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Date and prep weeks */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Calendar className="size-3.5" />
+          {format(parseISO(goal.competitionDate), 'd MMM yyyy')}
+        </span>
+        {goal.preparationWeeks > 0 && (
+          <span>{t('goal.prepWeeksShort', { weeks: goal.preparationWeeks })}</span>
+        )}
+      </div>
+
+      {/* Targets */}
+      {(goal.goalDistanceKm != null || goal.goalTimeSeconds != null) && (
+        <div className="flex gap-3 text-sm">
+          {goal.goalDistanceKm != null && (
+            <span className="flex items-center gap-1 text-muted-foreground">
+              <Ruler className="size-3.5" />
+              {goal.goalDistanceKm} km
+            </span>
+          )}
+          {goal.goalTimeSeconds != null && (
+            <span className="flex items-center gap-1 text-muted-foreground">
+              <Clock className="size-3.5" />
+              {formatTime(goal.goalTimeSeconds)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Achievement status (only shown when results are known) */}
+      {isPast && status !== 'pending' && (
+        <Badge className={cn('self-start text-xs', statusColor)}>
+          {t(`competition.${status}`)}
+        </Badge>
+      )}
+
+      {/* Notes */}
+      {goal.notes && (
+        <p className="text-xs text-muted-foreground line-clamp-2">{goal.notes}</p>
+      )}
+
+      {/* Delete confirmation */}
+      {confirmDelete && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3 flex flex-col gap-2">
+          <p className="text-sm text-destructive">{t('goal.deleteConfirm')}</p>
+          <div className="flex gap-2 justify-end">
+            <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)}>
+              {t('common:actions.cancel' as never)}
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                setConfirmDelete(false);
+                onDelete(goal);
+              }}
+            >
+              {t('goal.delete')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/goals/GoalDialog.tsx
+++ b/app/components/goals/GoalDialog.tsx
@@ -58,6 +58,18 @@ function fromSeconds(seconds: number | null): { hh: string; mm: string; ss: stri
   };
 }
 
+const DEFAULT_FORM_STATE: FormState = {
+  name: '',
+  discipline: 'run',
+  competitionDate: '',
+  preparationWeeks: '8',
+  goalDistanceKm: '',
+  goalTimeHh: '',
+  goalTimeMm: '',
+  goalTimeSs: '',
+  notes: '',
+};
+
 export function GoalDialog({
   open,
   onClose,
@@ -70,19 +82,7 @@ export function GoalDialog({
 }: GoalDialogProps) {
   const { t } = useTranslation('training');
 
-  const defaultState: FormState = {
-    name: '',
-    discipline: 'run',
-    competitionDate: '',
-    preparationWeeks: '8',
-    goalDistanceKm: '',
-    goalTimeHh: '',
-    goalTimeMm: '',
-    goalTimeSs: '',
-    notes: '',
-  };
-
-  const [form, setForm] = useState<FormState>(defaultState);
+  const [form, setForm] = useState<FormState>(DEFAULT_FORM_STATE);
   const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
 
   useEffect(() => {
@@ -100,10 +100,9 @@ export function GoalDialog({
         notes: goal.notes ?? '',
       });
     } else {
-      setForm(defaultState);
+      setForm(DEFAULT_FORM_STATE);
     }
     setErrors({});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, goal?.id]);
 
   function set<K extends keyof FormState>(key: K, value: FormState[K]) {

--- a/app/components/goals/GoalDialog.tsx
+++ b/app/components/goals/GoalDialog.tsx
@@ -1,0 +1,295 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FormModal } from '~/components/ui/form-modal';
+import { Input } from '~/components/ui/input';
+import { Label } from '~/components/ui/label';
+import { Textarea } from '~/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import { TRAINING_TYPES } from '~/types/training';
+import type { Goal, CreateGoalInput, UpdateGoalInput, TrainingType } from '~/types/training';
+import { cn } from '~/lib/utils';
+
+interface GoalDialogProps {
+  open: boolean;
+  onClose: () => void;
+  athleteId: string;
+  goal?: Goal;
+  onCreate?: (input: CreateGoalInput) => void;
+  onUpdate?: (input: UpdateGoalInput) => void;
+  isSaving?: boolean;
+  className?: string;
+}
+
+interface FormState {
+  name: string;
+  discipline: TrainingType;
+  competitionDate: string;
+  preparationWeeks: string;
+  goalDistanceKm: string;
+  goalTimeHh: string;
+  goalTimeMm: string;
+  goalTimeSs: string;
+  notes: string;
+}
+
+function toSeconds(hh: string, mm: string, ss: string): number | undefined {
+  const h = parseInt(hh, 10) || 0;
+  const m = parseInt(mm, 10) || 0;
+  const s = parseInt(ss, 10) || 0;
+  const total = h * 3600 + m * 60 + s;
+  return total > 0 ? total : undefined;
+}
+
+function fromSeconds(seconds: number | null): { hh: string; mm: string; ss: string } {
+  if (!seconds) return { hh: '', mm: '', ss: '' };
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  return {
+    hh: h > 0 ? String(h) : '',
+    mm: String(m).padStart(h > 0 ? 2 : 1, '0'),
+    ss: String(s).padStart(2, '0'),
+  };
+}
+
+export function GoalDialog({
+  open,
+  onClose,
+  athleteId,
+  goal,
+  onCreate,
+  onUpdate,
+  isSaving,
+  className,
+}: GoalDialogProps) {
+  const { t } = useTranslation('training');
+
+  const defaultState: FormState = {
+    name: '',
+    discipline: 'run',
+    competitionDate: '',
+    preparationWeeks: '8',
+    goalDistanceKm: '',
+    goalTimeHh: '',
+    goalTimeMm: '',
+    goalTimeSs: '',
+    notes: '',
+  };
+
+  const [form, setForm] = useState<FormState>(defaultState);
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
+
+  useEffect(() => {
+    if (goal) {
+      const time = fromSeconds(goal.goalTimeSeconds);
+      setForm({
+        name: goal.name,
+        discipline: goal.discipline,
+        competitionDate: goal.competitionDate,
+        preparationWeeks: String(goal.preparationWeeks),
+        goalDistanceKm: goal.goalDistanceKm != null ? String(goal.goalDistanceKm) : '',
+        goalTimeHh: time.hh,
+        goalTimeMm: time.mm,
+        goalTimeSs: time.ss,
+        notes: goal.notes ?? '',
+      });
+    } else {
+      setForm(defaultState);
+    }
+    setErrors({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, goal?.id]);
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (errors[key]) setErrors((prev) => ({ ...prev, [key]: undefined }));
+  }
+
+  function validate(): boolean {
+    const next: typeof errors = {};
+    if (!form.name.trim()) next.name = 'Required';
+    if (!form.competitionDate) next.competitionDate = 'Required';
+    const weeks = parseInt(form.preparationWeeks, 10);
+    if (isNaN(weeks) || weeks < 0 || weeks > 52) next.preparationWeeks = '0–52';
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  function handleSave() {
+    if (!validate()) return;
+
+    const preparationWeeks = parseInt(form.preparationWeeks, 10);
+    const goalDistanceKm = form.goalDistanceKm ? parseFloat(form.goalDistanceKm) : undefined;
+    const goalTimeSeconds = toSeconds(form.goalTimeHh, form.goalTimeMm, form.goalTimeSs);
+    const notes = form.notes.trim() || undefined;
+
+    if (goal) {
+      onUpdate?.({
+        id: goal.id,
+        name: form.name.trim(),
+        discipline: form.discipline,
+        competitionDate: form.competitionDate,
+        preparationWeeks,
+        goalDistanceKm: goalDistanceKm ?? null,
+        goalTimeSeconds: goalTimeSeconds ?? null,
+        notes: notes ?? null,
+      });
+    } else {
+      onCreate?.({
+        athleteId,
+        name: form.name.trim(),
+        discipline: form.discipline,
+        competitionDate: form.competitionDate,
+        preparationWeeks,
+        goalDistanceKm,
+        goalTimeSeconds,
+        notes,
+      });
+    }
+  }
+
+  const title = goal ? t('goal.edit') : t('goal.create');
+
+  return (
+    <FormModal
+      open={open}
+      onClose={onClose}
+      title={title}
+      onSave={handleSave}
+      isSaving={isSaving}
+      className={className}
+    >
+      <div className="flex flex-col gap-4">
+        {/* Name */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="goal-name">{t('goal.name')}</Label>
+          <Input
+            id="goal-name"
+            value={form.name}
+            onChange={(e) => set('name', e.target.value)}
+            placeholder={t('goal.namePlaceholder')}
+            className={cn(errors.name && 'border-destructive')}
+          />
+          {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+        </div>
+
+        {/* Discipline */}
+        <div className="flex flex-col gap-1.5">
+          <Label>{t('goal.discipline')}</Label>
+          <Select value={form.discipline} onValueChange={(v) => set('discipline', v as TrainingType)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TRAINING_TYPES.filter((t) => t !== 'rest_day').map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Competition Date */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="goal-date">{t('goal.competitionDate')}</Label>
+          <Input
+            id="goal-date"
+            type="date"
+            value={form.competitionDate}
+            onChange={(e) => set('competitionDate', e.target.value)}
+            className={cn(errors.competitionDate && 'border-destructive')}
+          />
+          {errors.competitionDate && (
+            <p className="text-xs text-destructive">{errors.competitionDate}</p>
+          )}
+        </div>
+
+        {/* Preparation Weeks */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="goal-prep-weeks">{t('goal.preparationWeeks')}</Label>
+          <Input
+            id="goal-prep-weeks"
+            type="number"
+            min={0}
+            max={52}
+            value={form.preparationWeeks}
+            onChange={(e) => set('preparationWeeks', e.target.value)}
+            className={cn(errors.preparationWeeks && 'border-destructive')}
+          />
+          {errors.preparationWeeks && (
+            <p className="text-xs text-destructive">{errors.preparationWeeks}</p>
+          )}
+        </div>
+
+        {/* Goal Distance */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="goal-distance">{t('goal.goalDistance')}</Label>
+          <Input
+            id="goal-distance"
+            type="number"
+            min={0}
+            step={0.1}
+            value={form.goalDistanceKm}
+            onChange={(e) => set('goalDistanceKm', e.target.value)}
+            placeholder="e.g. 10"
+          />
+        </div>
+
+        {/* Goal Time */}
+        <div className="flex flex-col gap-1.5">
+          <Label>{t('goal.goalTime')}</Label>
+          <div className="flex items-center gap-1">
+            <Input
+              type="number"
+              min={0}
+              max={23}
+              placeholder="hh"
+              value={form.goalTimeHh}
+              onChange={(e) => set('goalTimeHh', e.target.value)}
+              className="w-16 text-center"
+            />
+            <span className="text-muted-foreground">:</span>
+            <Input
+              type="number"
+              min={0}
+              max={59}
+              placeholder="mm"
+              value={form.goalTimeMm}
+              onChange={(e) => set('goalTimeMm', e.target.value)}
+              className="w-16 text-center"
+            />
+            <span className="text-muted-foreground">:</span>
+            <Input
+              type="number"
+              min={0}
+              max={59}
+              placeholder="ss"
+              value={form.goalTimeSs}
+              onChange={(e) => set('goalTimeSs', e.target.value)}
+              className="w-16 text-center"
+            />
+          </div>
+        </div>
+
+        {/* Notes */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="goal-notes">{t('goal.notes')}</Label>
+          <Textarea
+            id="goal-notes"
+            value={form.notes}
+            onChange={(e) => set('notes', e.target.value)}
+            placeholder={t('goal.notesPlaceholder')}
+            rows={3}
+          />
+        </div>
+      </div>
+    </FormModal>
+  );
+}

--- a/app/components/goals/GoalList.tsx
+++ b/app/components/goals/GoalList.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
+import { Button } from '~/components/ui/button';
+import { GoalCard } from './GoalCard';
+import { GoalDialog } from './GoalDialog';
+import { useCreateGoal, useUpdateGoal, useDeleteGoal } from '~/lib/hooks/useGoals';
+import { computeGoalAchievement } from '~/lib/utils/goals';
+import type { Goal } from '~/types/training';
+import { cn } from '~/lib/utils';
+
+interface GoalListProps {
+  goals: Goal[];
+  canEdit: boolean;
+  athleteId: string;
+  createdBy: string;
+  className?: string;
+}
+
+export function GoalList({ goals, canEdit, athleteId, createdBy, className }: GoalListProps) {
+  const { t } = useTranslation('training');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingGoal, setEditingGoal] = useState<Goal | undefined>();
+
+  const createGoalMutation = useCreateGoal();
+  const updateGoalMutation = useUpdateGoal();
+  const deleteGoalMutation = useDeleteGoal();
+
+  function handleCreate(input: import('~/types/training').CreateGoalInput) {
+    createGoalMutation.mutate(
+      { ...input, createdBy },
+      { onSuccess: () => setDialogOpen(false) }
+    );
+  }
+
+  function handleUpdate(input: import('~/types/training').UpdateGoalInput) {
+    updateGoalMutation.mutate(
+      { ...input, athleteId },
+      { onSuccess: () => { setDialogOpen(false); setEditingGoal(undefined); } }
+    );
+  }
+
+  function handleDelete(goal: Goal) {
+    deleteGoalMutation.mutate({ id: goal.id, athleteId });
+  }
+
+  function handleEditClick(goal: Goal) {
+    setEditingGoal(goal);
+    setDialogOpen(true);
+  }
+
+  function handleClose() {
+    setDialogOpen(false);
+    setEditingGoal(undefined);
+  }
+
+  const isSaving = createGoalMutation.isPending || updateGoalMutation.isPending;
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      {goals.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-2">{t('goal.noGoals')}</p>
+      ) : (
+        goals.map((goal) => {
+          // We don't have session result here — show 'pending' for future, derive status only when result is available
+          return (
+            <GoalCard
+              key={goal.id}
+              goal={goal}
+              canEdit={canEdit}
+              achievementStatus={
+                computeGoalAchievement(goal, {
+                  resultDistanceKm: null,
+                  resultTimeSeconds: null,
+                })
+              }
+              onEdit={handleEditClick}
+              onDelete={handleDelete}
+            />
+          );
+        })
+      )}
+
+      {canEdit && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="self-start"
+          onClick={() => { setEditingGoal(undefined); setDialogOpen(true); }}
+        >
+          <Plus className="size-4 mr-1" />
+          {t('goal.create')}
+        </Button>
+      )}
+
+      <GoalDialog
+        open={dialogOpen}
+        onClose={handleClose}
+        athleteId={athleteId}
+        goal={editingGoal}
+        onCreate={handleCreate}
+        onUpdate={handleUpdate}
+        isSaving={isSaving}
+      />
+    </div>
+  );
+}

--- a/app/components/goals/GoalListView.tsx
+++ b/app/components/goals/GoalListView.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
+import { Button } from '~/components/ui/button';
+import { AppLoader } from '~/components/ui/app-loader';
+import { GoalCard } from './GoalCard';
+import { GoalDialog } from './GoalDialog';
+import { useGoals, useCreateGoal, useUpdateGoal, useDeleteGoal } from '~/lib/hooks/useGoals';
+import { computeGoalAchievement } from '~/lib/utils/goals';
+import type { Goal, CreateGoalInput, UpdateGoalInput } from '~/types/training';
+import { cn } from '~/lib/utils';
+
+interface GoalListViewProps {
+  athleteId: string;
+  createdBy: string;
+  canManage: boolean;
+  className?: string;
+}
+
+export function GoalListView({ athleteId, createdBy, canManage, className }: GoalListViewProps) {
+  const { t } = useTranslation('training');
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingGoal, setEditingGoal] = useState<Goal | undefined>();
+
+  const { data: goals = [], isLoading } = useGoals(athleteId);
+  const createGoalMutation = useCreateGoal();
+  const updateGoalMutation = useUpdateGoal();
+  const deleteGoalMutation = useDeleteGoal();
+
+  function handleCreate(input: CreateGoalInput) {
+    createGoalMutation.mutate(
+      { ...input, createdBy },
+      { onSuccess: () => setDialogOpen(false) },
+    );
+  }
+
+  function handleUpdate(input: UpdateGoalInput) {
+    updateGoalMutation.mutate(
+      { ...input, athleteId },
+      {
+        onSuccess: () => {
+          setDialogOpen(false);
+          setEditingGoal(undefined);
+        },
+      },
+    );
+  }
+
+  function handleDelete(goal: Goal) {
+    deleteGoalMutation.mutate({ id: goal.id, athleteId });
+  }
+
+  function handleEditClick(goal: Goal) {
+    setEditingGoal(goal);
+    setDialogOpen(true);
+  }
+
+  function handleClose() {
+    setDialogOpen(false);
+    setEditingGoal(undefined);
+  }
+
+  const isSaving = createGoalMutation.isPending || updateGoalMutation.isPending;
+
+  if (isLoading) return <AppLoader />;
+
+  return (
+    <div className={cn('mx-auto max-w-2xl space-y-6 px-4 py-6', className)}>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-bold">{t('goal.library')}</h1>
+        {canManage && (
+          <Button
+            onClick={() => {
+              setEditingGoal(undefined);
+              setDialogOpen(true);
+            }}
+          >
+            <Plus className="mr-1.5 size-4" />
+            {t('goal.create')}
+          </Button>
+        )}
+      </div>
+
+      {goals.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">{t('goal.noGoals')}</p>
+      ) : (
+        <div className="grid gap-3">
+          {goals.map((goal) => (
+            <GoalCard
+              key={goal.id}
+              goal={goal}
+              canEdit={canManage}
+              achievementStatus={computeGoalAchievement(goal, {
+                resultDistanceKm: null,
+                resultTimeSeconds: null,
+              })}
+              onEdit={handleEditClick}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+
+      {canManage && (
+        <GoalDialog
+          open={dialogOpen}
+          onClose={handleClose}
+          athleteId={athleteId}
+          goal={editingGoal}
+          onCreate={handleCreate}
+          onUpdate={handleUpdate}
+          isSaving={isSaving}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/components/layout/BottomNav.tsx
+++ b/app/components/layout/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, Dumbbell, Settings, Users } from 'lucide-react';
+import { CalendarDays, Dumbbell, Trophy, Settings, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useLocation } from 'react-router';
 import { cn } from '~/lib/utils';
@@ -51,6 +51,7 @@ export function BottomNav() {
   const isWeekActive =
     pathname.includes('/week') && (user.role === 'athlete' || !!selectedAthleteId);
   const isStrengthActive = pathname.includes('/strength');
+  const isGoalsActive = pathname.includes('/goals');
   const isSettingsActive = pathname.includes('/settings');
 
   return (
@@ -76,6 +77,12 @@ export function BottomNav() {
           icon={Dumbbell}
           label={t('nav.strength')}
           isActive={isStrengthActive}
+        />
+        <NavItem
+          to={localePath(`/${user.role}/goals`)}
+          icon={Trophy}
+          label={t('nav.goals')}
+          isActive={isGoalsActive}
         />
         <NavItem
           to={localePath('/settings')}

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Dumbbell } from 'lucide-react';
+import { Dumbbell, Trophy, BarChart3 } from 'lucide-react';
 import { Link, NavLink, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { LanguageToggle } from './LanguageToggle';
@@ -39,6 +39,34 @@ export function Header() {
               >
                 <Dumbbell className="h-3.5 w-3.5" />
                 {t('nav.strength')}
+              </NavLink>
+              <NavLink
+                to={localePath(`/${user.role}/goals`)}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                  )
+                }
+              >
+                <Trophy className="h-3.5 w-3.5" />
+                {t('nav.goals')}
+              </NavLink>
+              <NavLink
+                to={localePath(`/${user.role}/analytics`)}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-400'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                  )
+                }
+              >
+                <BarChart3 className="h-3.5 w-3.5" />
+                {t('nav.analytics')}
               </NavLink>
             </nav>
           )}

--- a/app/i18n/resources/en/athlete.json
+++ b/app/i18n/resources/en/athlete.json
@@ -26,5 +26,34 @@
       "pace": "Pace",
       "duration": "Duration"
     }
+  },
+  "analytics": {
+    "title": "My Performance",
+    "period": {
+      "year": "Year",
+      "quarter": "Quarter",
+      "month": "Month",
+      "goal": "Goal Period",
+      "selectGoal": "Select a goal…"
+    },
+    "filter": {
+      "allSports": "All Sports"
+    },
+    "chart": {
+      "distance": "Distance (km)",
+      "sessions": "Sessions"
+    },
+    "empty": "No training data for this period.",
+    "totals": {
+      "distance": "Distance",
+      "sessions": "Sessions",
+      "time": "Time",
+      "completion": "Completion"
+    },
+    "milestone": {
+      "achieved": "Achieved",
+      "missed": "Missed",
+      "pending": "Pending"
+    }
   }
 }

--- a/app/i18n/resources/en/coach.json
+++ b/app/i18n/resources/en/coach.json
@@ -5,17 +5,56 @@
     "plan": "Plan",
     "performance": "Performance",
     "loadType": "Week Load",
-    "plannedKm": "Planned KM",
-    "plannedSessions": "Planned Sessions",
-    "actualRunKm": "Run KM",
-    "ranKm": "Ran KM",
-    "completedSessions": "Completed Sessions",
-    "totalTime": "Total Time",
-    "progress": "Progress",
+    "plannedKm": "Distance",
+    "plannedSessions": "Sessions",
+    "totalDistance": "Distance",
+    "completedSessions": "Sessions",
+    "totalTime": "Time",
+    "progress": "Completion",
     "coachComments": "Coach Notes",
     "coachCommentsPlaceholder": "Add notes for the athlete...",
     "fromSessions": "from sessions",
-    "manuallySet": "manually set"
+    "manuallySet": "manually set",
+    "viewCumulative": "Cumulative",
+    "viewBySport": "By Sport",
+    "training": "Training",
+    "competitions": "Competitions",
+    "noBreakdown": "No sessions this week.",
+    "colPlanned": "Planned",
+    "colPerformance": "Performance",
+    "sessionCount_one": "{{count}} session",
+    "sessionCount_other": "{{count}} sessions",
+    "dayCount_one": "{{count}} day",
+    "dayCount_other": "{{count}} days"
+  },
+  "analytics": {
+    "title": "Performance Analytics",
+    "period": {
+      "year": "Year",
+      "quarter": "Quarter",
+      "month": "Month",
+      "goal": "Goal Period",
+      "selectGoal": "Select a goal…"
+    },
+    "filter": {
+      "allSports": "All Sports"
+    },
+    "chart": {
+      "distance": "Distance (km)",
+      "sessions": "Sessions"
+    },
+    "empty": "No training data for this period.",
+    "totals": {
+      "distance": "Distance",
+      "sessions": "Sessions",
+      "time": "Time",
+      "completion": "Completion"
+    },
+    "milestone": {
+      "achieved": "Achieved",
+      "missed": "Missed",
+      "pending": "Pending"
+    }
   },
   "session": {
     "add": "Add Session",

--- a/app/i18n/resources/en/common.json
+++ b/app/i18n/resources/en/common.json
@@ -6,7 +6,9 @@
     "week": "Week",
     "team": "Team",
     "settings": "Settings",
-    "strength": "Strength"
+    "strength": "Strength",
+    "goals": "Goals",
+    "analytics": "Analytics"
   },
   "days": {
     "monday": "Monday",

--- a/app/i18n/resources/en/training.json
+++ b/app/i18n/resources/en/training.json
@@ -211,5 +211,36 @@
       "recovery": "Rec",
       "cooldown": "CD"
     }
+  },
+  "goal": {
+    "library": "Goals",
+    "create": "Add Goal",
+    "edit": "Edit Goal",
+    "delete": "Delete Goal",
+    "name": "Goal Name",
+    "discipline": "Sport",
+    "competitionDate": "Competition Date",
+    "preparationWeeks": "Preparation Weeks",
+    "goalDistance": "Target Distance (km)",
+    "goalTime": "Target Time",
+    "notes": "Notes",
+    "deleteConfirm": "Are you sure you want to delete this goal? The competition session will be unlinked.",
+    "namePlaceholder": "e.g. Spring 10K",
+    "notesPlaceholder": "Add context or motivation…",
+    "noGoals": "No goals set yet.",
+    "prepWeeksShort": "{{weeks}}w prep"
+  },
+  "competition": {
+    "label": "Competition",
+    "result": "Result",
+    "achieved": "Achieved",
+    "missed": "Missed",
+    "pending": "Pending"
+  },
+  "goalPrep": {
+    "banner": "Prep for {{goalName}}",
+    "competitionWeek": "Competition week — {{goalName}}",
+    "daysUntil": "{{days}} days to competition",
+    "thisWeek": "This week"
   }
 }

--- a/app/i18n/resources/pl/athlete.json
+++ b/app/i18n/resources/pl/athlete.json
@@ -26,5 +26,34 @@
       "pace": "Tempo",
       "duration": "Czas"
     }
+  },
+  "analytics": {
+    "title": "Moje Wyniki",
+    "period": {
+      "year": "Rok",
+      "quarter": "Kwartał",
+      "month": "Miesiąc",
+      "goal": "Okres Celu",
+      "selectGoal": "Wybierz cel…"
+    },
+    "filter": {
+      "allSports": "Wszystkie Sporty"
+    },
+    "chart": {
+      "distance": "Dystans (km)",
+      "sessions": "Treningi"
+    },
+    "empty": "Brak danych treningowych w tym okresie.",
+    "totals": {
+      "distance": "Dystans",
+      "sessions": "Treningi",
+      "time": "Czas",
+      "completion": "Ukończenie"
+    },
+    "milestone": {
+      "achieved": "Osiągnięto",
+      "missed": "Nie Osiągnięto",
+      "pending": "Oczekuje"
+    }
   }
 }

--- a/app/i18n/resources/pl/coach.json
+++ b/app/i18n/resources/pl/coach.json
@@ -5,17 +5,60 @@
     "plan": "Plan",
     "performance": "Realizacja",
     "loadType": "Obciążenie Tygodnia",
-    "plannedKm": "Planowane KM",
-    "plannedSessions": "Planowane Treningi",
-    "actualRunKm": "Zrealizowane KM",
-    "ranKm": "Przebiegnięte KM",
-    "completedSessions": "Ukończone Treningi",
-    "totalTime": "Łączny Czas",
-    "progress": "Postęp",
+    "plannedKm": "Dystans",
+    "plannedSessions": "Treningi",
+    "totalDistance": "Dystans",
+    "completedSessions": "Treningi",
+    "totalTime": "Czas",
+    "progress": "Ukończenie",
     "coachComments": "Notatki Trenera",
     "coachCommentsPlaceholder": "Dodaj notatki dla zawodnika...",
     "fromSessions": "z treningów",
-    "manuallySet": "ustawiono ręcznie"
+    "manuallySet": "ustawiono ręcznie",
+    "viewCumulative": "Łącznie",
+    "viewBySport": "Wg Sportu",
+    "training": "Treningi",
+    "competitions": "Zawody",
+    "noBreakdown": "Brak treningów w tym tygodniu.",
+    "colPlanned": "Plan",
+    "colPerformance": "Realizacja",
+    "sessionCount_one": "{{count}} trening",
+    "sessionCount_few": "{{count}} treningi",
+    "sessionCount_many": "{{count}} treningów",
+    "sessionCount_other": "{{count}} treningów",
+    "dayCount_one": "{{count}} dzień",
+    "dayCount_few": "{{count}} dni",
+    "dayCount_many": "{{count}} dni",
+    "dayCount_other": "{{count}} dni"
+  },
+  "analytics": {
+    "title": "Analityka Wydajności",
+    "period": {
+      "year": "Rok",
+      "quarter": "Kwartał",
+      "month": "Miesiąc",
+      "goal": "Okres Celu",
+      "selectGoal": "Wybierz cel…"
+    },
+    "filter": {
+      "allSports": "Wszystkie Sporty"
+    },
+    "chart": {
+      "distance": "Dystans (km)",
+      "sessions": "Treningi"
+    },
+    "empty": "Brak danych treningowych w tym okresie.",
+    "totals": {
+      "distance": "Dystans",
+      "sessions": "Treningi",
+      "time": "Czas",
+      "completion": "Ukończenie"
+    },
+    "milestone": {
+      "achieved": "Osiągnięto",
+      "missed": "Nie Osiągnięto",
+      "pending": "Oczekuje"
+    }
   },
   "session": {
     "add": "Dodaj Trening",

--- a/app/i18n/resources/pl/common.json
+++ b/app/i18n/resources/pl/common.json
@@ -6,7 +6,9 @@
     "week": "Tydzień",
     "team": "Zespół",
     "settings": "Ustawienia",
-    "strength": "Siła"
+    "strength": "Siła",
+    "goals": "Cele",
+    "analytics": "Analityka"
   },
   "days": {
     "monday": "Poniedziałek",

--- a/app/i18n/resources/pl/training.json
+++ b/app/i18n/resources/pl/training.json
@@ -211,5 +211,36 @@
       "recovery": "Odpoczynek",
       "cooldown": "Wyciszenie"
     }
+  },
+  "goal": {
+    "library": "Cele",
+    "create": "Dodaj Cel",
+    "edit": "Edytuj Cel",
+    "delete": "Usuń Cel",
+    "name": "Nazwa Celu",
+    "discipline": "Dyscyplina",
+    "competitionDate": "Data Zawodów",
+    "preparationWeeks": "Tygodnie Przygotowań",
+    "goalDistance": "Cel Dystansu (km)",
+    "goalTime": "Cel Czasu",
+    "notes": "Uwagi",
+    "deleteConfirm": "Czy na pewno chcesz usunąć ten cel? Sesja zawodnicza zostanie odłączona.",
+    "namePlaceholder": "np. Wiosenny 10K",
+    "notesPlaceholder": "Dodaj kontekst lub motywację…",
+    "noGoals": "Nie ustawiono jeszcze żadnych celów.",
+    "prepWeeksShort": "{{weeks}} tyg. przyg."
+  },
+  "competition": {
+    "label": "Zawody",
+    "result": "Wynik",
+    "achieved": "Osiągnięto",
+    "missed": "Nie Osiągnięto",
+    "pending": "Oczekuje"
+  },
+  "goalPrep": {
+    "banner": "Przygotowania do {{goalName}}",
+    "competitionWeek": "Tydzień zawodów — {{goalName}}",
+    "daysUntil": "{{days}} dni do zawodów",
+    "thisWeek": "W tym tygodniu"
   }
 }

--- a/app/lib/hooks/useAnalytics.ts
+++ b/app/lib/hooks/useAnalytics.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '~/lib/queries/keys';
+import { getAnalytics } from '~/lib/queries/analytics';
+import type { AnalyticsParams } from '~/types/training';
+
+export function useAnalytics(params: AnalyticsParams) {
+  return useQuery({
+    queryKey: queryKeys.analytics.byParams(params),
+    queryFn: () => getAnalytics(params),
+    enabled: !!params.athleteId && (params.period !== 'goal' || !!params.goalId),
+    placeholderData: (prev) => prev,
+  });
+}

--- a/app/lib/hooks/useGoals.ts
+++ b/app/lib/hooks/useGoals.ts
@@ -125,7 +125,6 @@ export function useUpdateGoal() {
 
           if (Object.keys(patch).length > 1) {
             await updateSession(patch).catch(() => {});
-            qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
           }
         }
       }
@@ -170,6 +169,8 @@ export function useUpdateGoal() {
     },
     onSettled: (_data, _err, input) => {
       qc.invalidateQueries({ queryKey: queryKeys.goals.byAthlete(input.athleteId) });
+      qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
+      qc.invalidateQueries({ queryKey: queryKeys.weeks.all });
     },
   });
 }
@@ -199,6 +200,8 @@ export function useDeleteGoal() {
     },
     onSettled: (_data, _err, { athleteId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.goals.byAthlete(athleteId) });
+      qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
+      qc.invalidateQueries({ queryKey: queryKeys.weeks.all });
     },
   });
 }

--- a/app/lib/hooks/useGoals.ts
+++ b/app/lib/hooks/useGoals.ts
@@ -1,0 +1,204 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { parseISO, format, startOfISOWeek, getISOWeek, getISOWeekYear, getISODay } from 'date-fns';
+import { queryKeys } from '~/lib/queries/keys';
+import { fetchGoals, createGoal, updateGoal, deleteGoal } from '~/lib/queries/goals';
+import { getOrCreateWeekPlan } from '~/lib/queries/weeks';
+import { createSession, fetchSessionByGoalId, updateSession } from '~/lib/queries/sessions';
+import { DAYS_OF_WEEK } from '~/types/training';
+import type { Goal, CreateGoalInput, UpdateGoalInput } from '~/types/training';
+
+export function useGoals(athleteId: string) {
+  return useQuery({
+    queryKey: queryKeys.goals.byAthlete(athleteId),
+    queryFn: () => fetchGoals(athleteId),
+    enabled: !!athleteId,
+    placeholderData: (prev) => prev,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useCreateGoal
+// ---------------------------------------------------------------------------
+
+export function useCreateGoal() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateGoalInput & { createdBy: string }) => createGoal(input),
+    onSuccess: async (goal) => {
+      // Auto-create the competition session in the goal's week.
+      // Wrapped in try/catch so a session-creation failure doesn't surface as a
+      // goal-creation failure — the goal was already persisted.
+      try {
+        const competitionDate = parseISO(goal.competitionDate);
+        const weekStart = format(startOfISOWeek(competitionDate), 'yyyy-MM-dd');
+        const year = getISOWeekYear(competitionDate);
+        const weekNumber = getISOWeek(competitionDate);
+        const dayOfWeek = DAYS_OF_WEEK[getISODay(competitionDate) - 1];
+
+        const weekPlan = await getOrCreateWeekPlan(weekStart, year, weekNumber, goal.athleteId);
+        await createSession({
+          weekPlanId: weekPlan.id,
+          dayOfWeek,
+          trainingType: goal.discipline,
+          description: goal.name,
+          plannedDistanceKm: goal.goalDistanceKm ?? undefined,
+          plannedDurationMinutes: goal.goalTimeSeconds
+            ? Math.round(goal.goalTimeSeconds / 60)
+            : undefined,
+          goalId: goal.id,
+        });
+      } catch {
+        // Session creation is best-effort; the goal itself is saved.
+      }
+    },
+    onMutate: async (input) => {
+      const key = queryKeys.goals.byAthlete(input.athleteId);
+      await qc.cancelQueries({ queryKey: key });
+      const snapshot = qc.getQueryData<Goal[]>(key);
+
+      // Optimistic placeholder — real id will be replaced after settle
+      const optimistic: Goal = {
+        id: `optimistic-${Date.now()}`,
+        athleteId: input.athleteId,
+        createdBy: input.createdBy,
+        name: input.name,
+        discipline: input.discipline,
+        competitionDate: input.competitionDate,
+        preparationWeeks: input.preparationWeeks,
+        goalDistanceKm: input.goalDistanceKm ?? null,
+        goalTimeSeconds: input.goalTimeSeconds ?? null,
+        notes: input.notes ?? null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      qc.setQueryData<Goal[]>(key, (prev = []) =>
+        [...prev, optimistic].sort(
+          (a, b) =>
+            new Date(a.competitionDate).getTime() - new Date(b.competitionDate).getTime()
+        )
+      );
+
+      return { snapshot, athleteId: input.athleteId };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.snapshot !== undefined) {
+        qc.setQueryData(queryKeys.goals.byAthlete(ctx.athleteId), ctx.snapshot);
+      }
+    },
+    onSettled: (_data, _err, input) => {
+      qc.invalidateQueries({ queryKey: queryKeys.goals.byAthlete(input.athleteId) });
+      qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
+      qc.invalidateQueries({ queryKey: queryKeys.weeks.all });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useUpdateGoal
+// ---------------------------------------------------------------------------
+
+export function useUpdateGoal() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: UpdateGoalInput & { athleteId: string }) => updateGoal(input),
+    onSuccess: async (data, variables) => {
+      // Keep linked competition session in sync when goal name/time/distance changes
+      const hasSessionFields =
+        variables.name !== undefined ||
+        variables.goalTimeSeconds !== undefined ||
+        variables.goalDistanceKm !== undefined;
+
+      if (hasSessionFields) {
+        const linked = await fetchSessionByGoalId(data.id).catch(() => null);
+        if (linked) {
+          const patch: Parameters<typeof updateSession>[0] = { id: linked.id };
+          if (variables.name !== undefined) patch.description = variables.name;
+          if (variables.goalTimeSeconds !== undefined)
+            patch.plannedDurationMinutes = variables.goalTimeSeconds != null
+              ? Math.round(variables.goalTimeSeconds / 60)
+              : null;
+          if (variables.goalDistanceKm !== undefined)
+            patch.plannedDistanceKm = variables.goalDistanceKm ?? null;
+
+          if (Object.keys(patch).length > 1) {
+            await updateSession(patch).catch(() => {});
+            qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
+          }
+        }
+      }
+    },
+    onMutate: async (input) => {
+      const key = queryKeys.goals.byAthlete(input.athleteId);
+      await qc.cancelQueries({ queryKey: key });
+      const snapshot = qc.getQueryData<Goal[]>(key);
+
+      qc.setQueryData<Goal[]>(key, (prev = []) =>
+        prev.map((g) =>
+          g.id === input.id
+            ? {
+                ...g,
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.discipline !== undefined && { discipline: input.discipline }),
+                ...(input.competitionDate !== undefined && {
+                  competitionDate: input.competitionDate,
+                }),
+                ...(input.preparationWeeks !== undefined && {
+                  preparationWeeks: input.preparationWeeks,
+                }),
+                ...(input.goalDistanceKm !== undefined && {
+                  goalDistanceKm: input.goalDistanceKm,
+                }),
+                ...(input.goalTimeSeconds !== undefined && {
+                  goalTimeSeconds: input.goalTimeSeconds,
+                }),
+                ...(input.notes !== undefined && { notes: input.notes }),
+                updatedAt: new Date().toISOString(),
+              }
+            : g
+        )
+      );
+
+      return { snapshot, athleteId: input.athleteId };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.snapshot !== undefined) {
+        qc.setQueryData(queryKeys.goals.byAthlete(ctx.athleteId), ctx.snapshot);
+      }
+    },
+    onSettled: (_data, _err, input) => {
+      qc.invalidateQueries({ queryKey: queryKeys.goals.byAthlete(input.athleteId) });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useDeleteGoal
+// ---------------------------------------------------------------------------
+
+export function useDeleteGoal() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id }: { id: string; athleteId: string }) => deleteGoal(id),
+    onMutate: async ({ id, athleteId }) => {
+      const key = queryKeys.goals.byAthlete(athleteId);
+      await qc.cancelQueries({ queryKey: key });
+      const snapshot = qc.getQueryData<Goal[]>(key);
+
+      qc.setQueryData<Goal[]>(key, (prev = []) => prev.filter((g) => g.id !== id));
+
+      return { snapshot, athleteId };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.snapshot !== undefined) {
+        qc.setQueryData(queryKeys.goals.byAthlete(ctx.athleteId), ctx.snapshot);
+      }
+    },
+    onSettled: (_data, _err, { athleteId }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.goals.byAthlete(athleteId) });
+    },
+  });
+}

--- a/app/lib/hooks/useSessions.ts
+++ b/app/lib/hooks/useSessions.ts
@@ -13,6 +13,7 @@ import {
   copyWeekSessions,
   copyDaySessions,
 } from '~/lib/queries/sessions';
+import { updateGoal } from '~/lib/queries/goals';
 import { buildCopySessionInput } from '~/lib/utils/session-copy';
 import type {
   CreateSessionInput,
@@ -103,8 +104,25 @@ export function useUpdateSession() {
       });
       return { ...result, weekPlanId };
     },
-    onSuccess: () => {
+    onSuccess: async (data, variables) => {
       toast.success(t('toast.sessionUpdated'));
+
+      // Keep linked goal in sync when a competition session's key fields change
+      if (data.goalId) {
+        const patch: Parameters<typeof updateGoal>[0] = { id: data.goalId };
+        if (variables.description != null && variables.description !== '') patch.name = variables.description;
+        if (variables.plannedDurationMinutes !== undefined)
+          patch.goalTimeSeconds = variables.plannedDurationMinutes != null
+            ? variables.plannedDurationMinutes * 60
+            : null;
+        if (variables.plannedDistanceKm !== undefined)
+          patch.goalDistanceKm = variables.plannedDistanceKm ?? null;
+
+        if (Object.keys(patch).length > 1) {
+          await updateGoal(patch).catch(() => {});
+          qc.invalidateQueries({ queryKey: queryKeys.goals.all });
+        }
+      }
     },
     onError: (_err, _input, context) => {
       context?.rollbacks?.forEach(({ key, data }) => {

--- a/app/lib/hooks/useWeekView.ts
+++ b/app/lib/hooks/useWeekView.ts
@@ -11,6 +11,7 @@ import {
 import { useSessionFormState } from '~/lib/hooks/useSessionFormState';
 import { weekIdToMonday, parseWeekId } from '~/lib/utils/date';
 import { groupSessionsByDay, computeWeekStats } from '~/lib/utils/week-view';
+import { computeSportBreakdown } from '~/lib/utils/analytics';
 import type {
   CreateSessionInput,
   UpdateSessionInput,
@@ -133,10 +134,11 @@ export function useWeekView({
   } = useSessionFormState();
 
   const sessionsByDay = useMemo(() => groupSessionsByDay(sessions), [sessions]);
-  const stats = useMemo(
-    () => computeWeekStats(sessionsForStats ?? sessions),
-    [sessionsForStats, sessions],
-  );
+  const stats = useMemo(() => {
+    const base = computeWeekStats(sessionsForStats ?? sessions);
+    const breakdown = computeSportBreakdown(sessionsForStats ?? sessions);
+    return { ...base, byType: breakdown.byType, competitionSessions: breakdown.competitionSessions };
+  }, [sessionsForStats, sessions]);
 
   const handleFormSubmit = useCallback(
     (data: CreateSessionInput | UpdateSessionInput) => {

--- a/app/lib/mock-data/analytics.ts
+++ b/app/lib/mock-data/analytics.ts
@@ -1,0 +1,195 @@
+import type { AnalyticsParams, AnalyticsResponse, AnalyticsBucket } from '~/types/training';
+import { delay } from './_shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBucket(
+  label: string,
+  startDate: string,
+  endDate: string,
+  totalSessions: number,
+  completedSessions: number,
+  totalDistanceKm: number,
+  totalDurationMinutes: number
+): AnalyticsBucket {
+  return {
+    label,
+    startDate,
+    endDate,
+    totalSessions,
+    completedSessions,
+    totalDistanceKm,
+    totalDurationMinutes,
+    completionRate: totalSessions === 0 ? 0 : Math.round((completedSessions / totalSessions) * 1000) / 10,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock responses per period type
+// ---------------------------------------------------------------------------
+
+const YEAR_RESPONSE: AnalyticsResponse = {
+  buckets: [
+    makeBucket('Jan', '2026-01-01', '2026-01-31', 10, 9, 72, 540),
+    makeBucket('Feb', '2026-02-01', '2026-02-28', 12, 10, 85, 620),
+    makeBucket('Mar', '2026-03-01', '2026-03-31', 14, 11, 98, 710),
+    makeBucket('Apr', '2026-04-01', '2026-04-30', 12, 10, 80, 600),
+    makeBucket('May', '2026-05-01', '2026-05-31', 10, 8, 65, 480),
+    makeBucket('Jun', '2026-06-01', '2026-06-30', 0, 0, 0, 0),
+    makeBucket('Jul', '2026-07-01', '2026-07-31', 0, 0, 0, 0),
+    makeBucket('Aug', '2026-08-01', '2026-08-31', 0, 0, 0, 0),
+    makeBucket('Sep', '2026-09-01', '2026-09-30', 0, 0, 0, 0),
+    makeBucket('Oct', '2026-10-01', '2026-10-31', 0, 0, 0, 0),
+    makeBucket('Nov', '2026-11-01', '2026-11-30', 0, 0, 0, 0),
+    makeBucket('Dec', '2026-12-01', '2026-12-31', 0, 0, 0, 0),
+  ],
+  competitions: [
+    {
+      goalId: 'goal-2',
+      goalName: 'City Gran Fondo',
+      discipline: 'cycling',
+      competitionDate: '2026-02-14',
+      goalDistanceKm: 100,
+      goalTimeSeconds: 14400,
+      resultDistanceKm: 102,
+      resultTimeSeconds: 13860,
+      achievementStatus: 'achieved',
+    },
+    {
+      goalId: 'goal-1',
+      goalName: 'Spring 10K',
+      discipline: 'run',
+      competitionDate: '2026-05-23',
+      goalDistanceKm: 10,
+      goalTimeSeconds: 3000,
+      resultDistanceKm: null,
+      resultTimeSeconds: null,
+      achievementStatus: 'pending',
+    },
+  ],
+  totals: {
+    totalSessions: 58,
+    completedSessions: 48,
+    totalDistanceKm: 400,
+    totalDurationMinutes: 2950,
+    overallCompletionRate: 82.8,
+  },
+};
+
+const QUARTER_RESPONSE: AnalyticsResponse = {
+  buckets: [
+    makeBucket('W01', '2026-01-01', '2026-01-07', 3, 3, 22, 160),
+    makeBucket('W02', '2026-01-08', '2026-01-14', 3, 2, 18, 130),
+    makeBucket('W03', '2026-01-15', '2026-01-21', 3, 3, 24, 175),
+    makeBucket('W04', '2026-01-22', '2026-01-28', 3, 1, 8, 60),
+    makeBucket('W05', '2026-01-29', '2026-02-04', 3, 3, 22, 155),
+    makeBucket('W06', '2026-02-05', '2026-02-11', 3, 3, 25, 180),
+    makeBucket('W07', '2026-02-12', '2026-02-18', 3, 2, 15, 110),
+    makeBucket('W08', '2026-02-19', '2026-02-25', 3, 3, 23, 165),
+    makeBucket('W09', '2026-02-26', '2026-03-04', 4, 4, 30, 220),
+    makeBucket('W10', '2026-03-05', '2026-03-11', 4, 2, 14, 100),
+    makeBucket('W11', '2026-03-12', '2026-03-18', 4, 0, 0, 0),
+    makeBucket('W12', '2026-03-19', '2026-03-25', 4, 0, 0, 0),
+    makeBucket('W13', '2026-03-26', '2026-03-31', 3, 0, 0, 0),
+  ],
+  competitions: [
+    {
+      goalId: 'goal-2',
+      goalName: 'City Gran Fondo',
+      discipline: 'cycling',
+      competitionDate: '2026-02-14',
+      goalDistanceKm: 100,
+      goalTimeSeconds: 14400,
+      resultDistanceKm: 102,
+      resultTimeSeconds: 13860,
+      achievementStatus: 'achieved',
+    },
+  ],
+  totals: {
+    totalSessions: 40,
+    completedSessions: 26,
+    totalDistanceKm: 201,
+    totalDurationMinutes: 1455,
+    overallCompletionRate: 65.0,
+  },
+};
+
+const MONTH_RESPONSE: AnalyticsResponse = {
+  buckets: Array.from({ length: 28 }, (_, i) => {
+    const d = i + 1;
+    const date = `2026-03-${String(d).padStart(2, '0')}`;
+    const hasSessions = d <= 10 && d % 2 === 0;
+    return makeBucket(
+      `${d} Mar`,
+      date,
+      date,
+      hasSessions ? 1 : 0,
+      hasSessions && d <= 6 ? 1 : 0,
+      hasSessions ? 8 + d : 0,
+      hasSessions ? 50 + d * 3 : 0
+    );
+  }),
+  competitions: [],
+  totals: {
+    totalSessions: 5,
+    completedSessions: 3,
+    totalDistanceKm: 45,
+    totalDurationMinutes: 290,
+    overallCompletionRate: 60.0,
+  },
+};
+
+const GOAL_RESPONSE: AnalyticsResponse = {
+  buckets: [
+    makeBucket('W08', '2026-03-28', '2026-04-03', 4, 4, 35, 250),
+    makeBucket('W09', '2026-04-04', '2026-04-10', 4, 3, 28, 200),
+    makeBucket('W10', '2026-04-11', '2026-04-17', 5, 5, 42, 300),
+    makeBucket('W11', '2026-04-18', '2026-04-24', 5, 4, 38, 270),
+    makeBucket('W12', '2026-04-25', '2026-05-01', 5, 5, 45, 320),
+    makeBucket('W13', '2026-05-02', '2026-05-08', 5, 3, 30, 210),
+    makeBucket('W14', '2026-05-09', '2026-05-15', 4, 4, 25, 175),
+    makeBucket('W15', '2026-05-16', '2026-05-23', 3, 0, 0, 0),
+  ],
+  competitions: [
+    {
+      goalId: 'goal-1',
+      goalName: 'Spring 10K',
+      discipline: 'run',
+      competitionDate: '2026-05-23',
+      goalDistanceKm: 10,
+      goalTimeSeconds: 3000,
+      resultDistanceKm: null,
+      resultTimeSeconds: null,
+      achievementStatus: 'pending',
+    },
+  ],
+  totals: {
+    totalSessions: 35,
+    completedSessions: 28,
+    totalDistanceKm: 243,
+    totalDurationMinutes: 1725,
+    overallCompletionRate: 80.0,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mock fetch
+// ---------------------------------------------------------------------------
+
+export async function mockGetAnalytics(params: AnalyticsParams): Promise<AnalyticsResponse> {
+  await delay();
+  switch (params.period) {
+    case 'year':
+      return YEAR_RESPONSE;
+    case 'quarter':
+      return QUARTER_RESPONSE;
+    case 'month':
+      return MONTH_RESPONSE;
+    case 'goal':
+      return GOAL_RESPONSE;
+    default:
+      return MONTH_RESPONSE;
+  }
+}

--- a/app/lib/mock-data/goals.ts
+++ b/app/lib/mock-data/goals.ts
@@ -1,0 +1,119 @@
+import type { Goal, CreateGoalInput, UpdateGoalInput } from '~/types/training';
+import { delay, nextId } from './_shared';
+
+// ---------------------------------------------------------------------------
+// In-memory store
+// ---------------------------------------------------------------------------
+
+const goalsStore = new Map<string, Goal>();
+
+// ---------------------------------------------------------------------------
+// Seed data — two goals for athlete-1
+// ---------------------------------------------------------------------------
+
+const SEED: Goal[] = [
+  {
+    id: 'goal-1',
+    athleteId: 'athlete-1',
+    createdBy: 'coach-1',
+    name: 'Spring 10K',
+    discipline: 'run',
+    // 8 weeks from a fixed reference date (2026-03-28)
+    competitionDate: '2026-05-23',
+    preparationWeeks: 8,
+    goalDistanceKm: 10,
+    goalTimeSeconds: 3000, // 50 min
+    notes: 'First 10K race of the season',
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  },
+  {
+    id: 'goal-2',
+    athleteId: 'athlete-1',
+    createdBy: 'coach-1',
+    name: 'City Gran Fondo',
+    discipline: 'cycling',
+    // Past competition with result filled
+    competitionDate: '2026-02-14',
+    preparationWeeks: 6,
+    goalDistanceKm: 100,
+    goalTimeSeconds: 14400, // 4 hours
+    notes: 'Gran Fondo — aim sub-4h',
+    createdAt: '2026-01-05T09:00:00Z',
+    updatedAt: '2026-02-15T12:00:00Z',
+  },
+];
+
+function captureSeed(): Goal[] {
+  return SEED.map((g) => ({ ...g }));
+}
+
+export function resetMockGoals() {
+  goalsStore.clear();
+  for (const g of captureSeed()) {
+    goalsStore.set(g.id, g);
+  }
+}
+
+// Seed on module load
+resetMockGoals();
+
+// ---------------------------------------------------------------------------
+// Mock CRUD
+// ---------------------------------------------------------------------------
+
+export async function mockFetchGoals(athleteId: string): Promise<Goal[]> {
+  await delay();
+  const result: Goal[] = [];
+  for (const g of goalsStore.values()) {
+    if (g.athleteId === athleteId) result.push(g);
+  }
+  return result.sort(
+    (a, b) => new Date(a.competitionDate).getTime() - new Date(b.competitionDate).getTime()
+  );
+}
+
+export async function mockCreateGoal(input: CreateGoalInput & { createdBy: string }): Promise<Goal> {
+  await delay();
+  const now = new Date().toISOString();
+  const goal: Goal = {
+    id: nextId(),
+    athleteId: input.athleteId,
+    createdBy: input.createdBy,
+    name: input.name,
+    discipline: input.discipline,
+    competitionDate: input.competitionDate,
+    preparationWeeks: input.preparationWeeks,
+    goalDistanceKm: input.goalDistanceKm ?? null,
+    goalTimeSeconds: input.goalTimeSeconds ?? null,
+    notes: input.notes ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  goalsStore.set(goal.id, goal);
+  return goal;
+}
+
+export async function mockUpdateGoal(input: UpdateGoalInput): Promise<Goal> {
+  await delay();
+  const existing = goalsStore.get(input.id);
+  if (!existing) throw new Error(`Goal ${input.id} not found`);
+  const updated: Goal = {
+    ...existing,
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.discipline !== undefined && { discipline: input.discipline }),
+    ...(input.competitionDate !== undefined && { competitionDate: input.competitionDate }),
+    ...(input.preparationWeeks !== undefined && { preparationWeeks: input.preparationWeeks }),
+    ...(input.goalDistanceKm !== undefined && { goalDistanceKm: input.goalDistanceKm }),
+    ...(input.goalTimeSeconds !== undefined && { goalTimeSeconds: input.goalTimeSeconds }),
+    ...(input.notes !== undefined && { notes: input.notes }),
+    updatedAt: new Date().toISOString(),
+  };
+  goalsStore.set(updated.id, updated);
+  return updated;
+}
+
+export async function mockDeleteGoal(id: string): Promise<void> {
+  await delay();
+  goalsStore.delete(id);
+}

--- a/app/lib/queries/analytics.ts
+++ b/app/lib/queries/analytics.ts
@@ -1,0 +1,80 @@
+import { supabase, isMockMode } from '~/lib/supabase';
+import type {
+  AnalyticsBucket,
+  AnalyticsParams,
+  AnalyticsResponse,
+  CompetitionMilestone,
+  AchievementStatus,
+} from '~/types/training';
+import { mockGetAnalytics } from '~/lib/mock-data/analytics';
+
+// ---------------------------------------------------------------------------
+// Row mappers
+// ---------------------------------------------------------------------------
+
+export function toAnalyticsBucket(row: Record<string, unknown>): AnalyticsBucket {
+  return {
+    label: row.label as string,
+    startDate: row.start_date as string,
+    endDate: row.end_date as string,
+    totalSessions: (row.total_sessions as number) ?? 0,
+    completedSessions: (row.completed_sessions as number) ?? 0,
+    totalDistanceKm: (row.total_distance_km as number) ?? 0,
+    totalDurationMinutes: (row.total_duration_minutes as number) ?? 0,
+    completionRate: (row.completion_rate as number) ?? 0,
+  };
+}
+
+function toCompetitionMilestone(row: Record<string, unknown>): CompetitionMilestone {
+  return {
+    goalId: row.goal_id as string,
+    goalName: row.goal_name as string,
+    discipline: row.discipline as CompetitionMilestone['discipline'],
+    competitionDate: row.competition_date as string,
+    goalDistanceKm: (row.goal_distance_km as number | null) ?? null,
+    goalTimeSeconds: (row.goal_time_seconds as number | null) ?? null,
+    resultDistanceKm: (row.result_distance_km as number | null) ?? null,
+    resultTimeSeconds: (row.result_time_seconds as number | null) ?? null,
+    achievementStatus: (row.achievement_status as AchievementStatus) ?? 'pending',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+export async function getAnalytics(params: AnalyticsParams): Promise<AnalyticsResponse> {
+  if (isMockMode) return mockGetAnalytics(params);
+
+  // Real implementation: call a Supabase RPC that aggregates sessions by period
+  const { data, error } = await supabase.rpc('get_analytics_summary', {
+    p_athlete_id: params.athleteId,
+    p_period: params.period,
+    p_goal_id: params.goalId ?? null,
+    p_training_type: params.trainingType ?? null,
+  });
+
+  if (error) throw new Error(error.message);
+
+  const result = data as {
+    buckets: Record<string, unknown>[];
+    competitions: Record<string, unknown>[];
+    totals: Record<string, unknown>;
+  } | null;
+
+  const buckets = result?.buckets ?? [];
+  const competitions = result?.competitions ?? [];
+  const totals = result?.totals ?? {};
+
+  return {
+    buckets: buckets.map(toAnalyticsBucket),
+    competitions: competitions.map(toCompetitionMilestone),
+    totals: {
+      totalSessions: (totals.totalSessions as number) ?? 0,
+      completedSessions: (totals.completedSessions as number) ?? 0,
+      totalDistanceKm: (totals.totalDistanceKm as number) ?? 0,
+      totalDurationMinutes: (totals.totalDurationMinutes as number) ?? 0,
+      overallCompletionRate: (totals.overallCompletionRate as number) ?? 0,
+    },
+  };
+}

--- a/app/lib/queries/goals.ts
+++ b/app/lib/queries/goals.ts
@@ -1,0 +1,122 @@
+import { supabase, isMockMode } from '~/lib/supabase';
+import type { Goal, CreateGoalInput, UpdateGoalInput } from '~/types/training';
+import {
+  mockFetchGoals,
+  mockCreateGoal,
+  mockUpdateGoal,
+  mockDeleteGoal,
+} from '~/lib/mock-data/goals';
+
+// ---------------------------------------------------------------------------
+// Row mapper
+// ---------------------------------------------------------------------------
+
+export function toGoal(row: Record<string, unknown>): Goal {
+  return {
+    id: row.id as string,
+    athleteId: row.athlete_id as string,
+    createdBy: row.created_by as string,
+    name: row.name as string,
+    discipline: row.discipline as Goal['discipline'],
+    competitionDate: row.competition_date as string,
+    preparationWeeks: row.preparation_weeks as number,
+    goalDistanceKm: row.goal_distance_km != null ? Number(row.goal_distance_km) : null,
+    goalTimeSeconds: row.goal_time_seconds != null ? (row.goal_time_seconds as number) : null,
+    notes: (row.notes as string | null) ?? null,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Real queries
+// ---------------------------------------------------------------------------
+
+const GOAL_COLUMNS =
+  'id, athlete_id, created_by, name, discipline, competition_date, preparation_weeks, goal_distance_km, goal_time_seconds, notes, created_at, updated_at';
+
+async function realFetchGoals(athleteId: string): Promise<Goal[]> {
+  const { data, error } = await supabase
+    .from('goals')
+    .select(GOAL_COLUMNS)
+    .eq('athlete_id', athleteId)
+    .order('competition_date', { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []).map((r) => toGoal(r as Record<string, unknown>));
+}
+
+async function realCreateGoal(
+  input: CreateGoalInput & { createdBy: string }
+): Promise<Goal> {
+  const { data, error } = await supabase
+    .from('goals')
+    .insert({
+      athlete_id: input.athleteId,
+      created_by: input.createdBy,
+      name: input.name,
+      discipline: input.discipline,
+      competition_date: input.competitionDate,
+      preparation_weeks: input.preparationWeeks,
+      goal_distance_km: input.goalDistanceKm ?? null,
+      goal_time_seconds: input.goalTimeSeconds ?? null,
+      notes: input.notes ?? null,
+    })
+    .select(GOAL_COLUMNS)
+    .single();
+
+  if (error) throw error;
+  return toGoal(data as Record<string, unknown>);
+}
+
+async function realUpdateGoal(input: UpdateGoalInput): Promise<Goal> {
+  const patch: Record<string, unknown> = {};
+  if (input.name !== undefined) patch.name = input.name;
+  if (input.discipline !== undefined) patch.discipline = input.discipline;
+  if (input.competitionDate !== undefined) patch.competition_date = input.competitionDate;
+  if (input.preparationWeeks !== undefined) patch.preparation_weeks = input.preparationWeeks;
+  if (input.goalDistanceKm !== undefined) patch.goal_distance_km = input.goalDistanceKm;
+  if (input.goalTimeSeconds !== undefined) patch.goal_time_seconds = input.goalTimeSeconds;
+  if (input.notes !== undefined) patch.notes = input.notes;
+
+  const { data, error } = await supabase
+    .from('goals')
+    .update(patch)
+    .eq('id', input.id)
+    .select(GOAL_COLUMNS)
+    .single();
+
+  if (error) throw error;
+  return toGoal(data as Record<string, unknown>);
+}
+
+async function realDeleteGoal(id: string): Promise<void> {
+  const { error } = await supabase.from('goals').delete().eq('id', id);
+  if (error) throw error;
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions — gated by isMockMode
+// ---------------------------------------------------------------------------
+
+export async function fetchGoals(athleteId: string): Promise<Goal[]> {
+  if (isMockMode) return mockFetchGoals(athleteId);
+  return realFetchGoals(athleteId);
+}
+
+export async function createGoal(
+  input: CreateGoalInput & { createdBy: string }
+): Promise<Goal> {
+  if (isMockMode) return mockCreateGoal(input);
+  return realCreateGoal(input);
+}
+
+export async function updateGoal(input: UpdateGoalInput): Promise<Goal> {
+  if (isMockMode) return mockUpdateGoal(input);
+  return realUpdateGoal(input);
+}
+
+export async function deleteGoal(id: string): Promise<void> {
+  if (isMockMode) return mockDeleteGoal(id);
+  return realDeleteGoal(id);
+}

--- a/app/lib/queries/keys.ts
+++ b/app/lib/queries/keys.ts
@@ -43,6 +43,15 @@ export const queryKeys = {
     progressLogs: (variantId: string, athleteId: string) =>
       ['strengthVariants', 'progressLogs', variantId, athleteId] as const,
   },
+  goals: {
+    all: ['goals'] as const,
+    byAthlete: (athleteId: string) => ['goals', 'athlete', athleteId] as const,
+    byId: (goalId: string) => ['goals', goalId] as const,
+  },
+  analytics: {
+    all: ['analytics'] as const,
+    byParams: (params: unknown) => ['analytics', params] as const,
+  },
   // PoC: Junction Garmin integration — remove after evaluation
   junctionPoc: {
     all: ['junction-poc'] as const,

--- a/app/lib/queries/sessions.ts
+++ b/app/lib/queries/sessions.ts
@@ -46,6 +46,10 @@ export function toSession(row: Record<string, unknown>): TrainingSession {
     athleteNotes: row.trainee_notes as string | null,
     stravaActivityId: row.strava_activity_id as number | null,
     stravaSyncedAt: row.strava_synced_at as string | null,
+    goalId: (row.goal_id as string | null) ?? null,
+    resultDistanceKm: row.result_distance_km != null ? Number(row.result_distance_km) : null,
+    resultTimeSeconds: row.result_time_seconds != null ? (row.result_time_seconds as number) : null,
+    resultPace: (row.result_pace as string | null) ?? null,
     isStravaConfirmed: Boolean(row.is_strava_confirmed ?? false),
     createdAt: row.created_at as string,
     updatedAt: row.updated_at as string,
@@ -70,6 +74,18 @@ export async function bulkConfirmStravaSessions(weekPlanId: string): Promise<voi
   });
 
   if (error) throw error;
+}
+
+export async function fetchSessionByGoalId(goalId: string): Promise<TrainingSession | null> {
+  if (isMockMode) return null;
+  const { data, error } = await supabase
+    .from('training_sessions')
+    .select('id, week_plan_id, day_of_week, sort_order, training_type, description, coach_comments, planned_duration_minutes, planned_distance_km, type_specific_data, is_completed, completed_at, actual_duration_minutes, actual_distance_km, actual_pace, avg_heart_rate, max_heart_rate, rpe, coach_post_feedback, trainee_notes, strava_activity_id, strava_synced_at, goal_id, result_distance_km, result_time_seconds, result_pace, created_at, updated_at')
+    .eq('goal_id', goalId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data ? toSession(data as Record<string, unknown>) : null;
 }
 
 export async function fetchSessionsByWeekPlan(weekPlanId: string): Promise<TrainingSession[]> {
@@ -108,6 +124,7 @@ export async function createSession(input: CreateSessionInput): Promise<Training
       is_completed: input.isCompleted ?? false,
       completed_at: input.completedAt ?? null,
       trainee_notes: input.athleteNotes ?? null,
+      goal_id: input.goalId ?? null,
     })
     .select()
     .single();

--- a/app/lib/utils/analytics.ts
+++ b/app/lib/utils/analytics.ts
@@ -1,0 +1,70 @@
+import type {
+  TrainingSession,
+  TrainingType,
+  SportBreakdownEntry,
+  CompetitionSummary,
+} from '~/types/training';
+
+interface SportBreakdownResult {
+  byType: Partial<Record<TrainingType, SportBreakdownEntry>>;
+  competitionSessions: CompetitionSummary[];
+}
+
+/**
+ * Groups a list of sessions into per-sport stats and a competition sessions list.
+ * Competition sessions (goalId IS NOT NULL) are excluded from byType aggregation.
+ * Achievement status is 'pending' when computed from session data alone (no goal targets available).
+ */
+export function computeSportBreakdown(sessions: TrainingSession[]): SportBreakdownResult {
+  const byType: Partial<Record<TrainingType, SportBreakdownEntry>> = {};
+  const competitionSessions: CompetitionSummary[] = [];
+
+  for (const session of sessions) {
+    if (session.goalId) {
+      // Competition session — collect separately
+      competitionSessions.push({
+        sessionId: session.id,
+        goalId: session.goalId,
+        goalName: '', // goal name not available here — caller enriches if needed
+        discipline: session.trainingType,
+        goalDistanceKm: null,
+        resultDistanceKm: session.resultDistanceKm ?? null,
+        resultTimeSeconds: session.resultTimeSeconds ?? null,
+        actualDistanceKm: session.actualDistanceKm ?? null,
+        actualDurationMinutes: session.actualDurationMinutes ?? null,
+        achievementStatus: 'pending', // cannot determine without goal targets
+      });
+      continue;
+    }
+
+    // Regular training session — aggregate into byType
+    const type = session.trainingType;
+    const existing = byType[type];
+
+    const actualDistance = session.actualDistanceKm ?? null;
+    const durationMinutes =
+      session.actualDurationMinutes ?? session.plannedDurationMinutes ?? 0;
+
+    const completed = session.isCompleted ? 1 : 0;
+
+    if (!existing) {
+      byType[type] = {
+        sessionCount: 1,
+        completedSessionCount: completed,
+        plannedDistanceKm: session.plannedDistanceKm ?? 0,
+        actualDistanceKm: actualDistance ?? 0,
+        totalDurationMinutes: durationMinutes,
+      };
+    } else {
+      byType[type] = {
+        sessionCount: existing.sessionCount + 1,
+        completedSessionCount: existing.completedSessionCount + completed,
+        plannedDistanceKm: existing.plannedDistanceKm + (session.plannedDistanceKm ?? 0),
+        actualDistanceKm: existing.actualDistanceKm + (actualDistance ?? 0),
+        totalDurationMinutes: existing.totalDurationMinutes + durationMinutes,
+      };
+    }
+  }
+
+  return { byType, competitionSessions };
+}

--- a/app/lib/utils/goals.ts
+++ b/app/lib/utils/goals.ts
@@ -61,19 +61,19 @@ function getCompetitionMonday(goal: Goal): string {
 
 /**
  * Returns true if the given weekStart (Monday date string) falls within the
- * preparation window for the goal, INCLUDING the competition week itself.
+ * preparation window for the goal, EXCLUDING the competition week itself.
+ * Use isCompetitionWeek to test the competition week separately.
  */
 export function isWeekInPrepWindow(weekStart: string, goal: Goal): boolean {
+  // No prep weeks means no prep window at all.
+  if (goal.preparationWeeks === 0) return false;
+
   const competitionMondayStr = getCompetitionMonday(goal);
-
-  // Goals with 0 prep weeks: only match the competition week
-  if (goal.preparationWeeks === 0) return weekStart === competitionMondayStr;
-
   const { start } = getPrepWeekRange(goal);
   const weekDate = parseISO(weekStart);
   const startDate = parseISO(start);
 
-  return weekDate >= startDate && weekStart <= competitionMondayStr;
+  return weekDate >= startDate && weekStart < competitionMondayStr;
 }
 
 /**

--- a/app/lib/utils/goals.ts
+++ b/app/lib/utils/goals.ts
@@ -1,0 +1,84 @@
+import { addDays, parseISO, getISODay, format } from 'date-fns';
+import type { Goal, TrainingSession, AchievementStatus } from '~/types/training';
+
+type SessionResult = Pick<TrainingSession, 'resultDistanceKm' | 'resultTimeSeconds'>;
+
+/**
+ * Determines whether the competition goal was achieved, missed, or is still pending.
+ * Priority: distance check first, then time check. If no target set on the goal, returns pending.
+ */
+export function computeGoalAchievement(goal: Goal, session: SessionResult): AchievementStatus {
+  const hasResult =
+    session.resultDistanceKm != null || session.resultTimeSeconds != null;
+
+  if (!hasResult) return 'pending';
+
+  // Distance-based achievement
+  if (goal.goalDistanceKm != null && session.resultDistanceKm != null) {
+    return session.resultDistanceKm >= goal.goalDistanceKm ? 'achieved' : 'missed';
+  }
+
+  // Time-based achievement
+  if (goal.goalTimeSeconds != null && session.resultTimeSeconds != null) {
+    return session.resultTimeSeconds <= goal.goalTimeSeconds ? 'achieved' : 'missed';
+  }
+
+  // Has result but no targets to compare against
+  return 'pending';
+}
+
+/**
+ * Returns the preparation window date range for a goal.
+ * start: Monday of the week that is `preparationWeeks` before the competition week.
+ * end: the competition date itself.
+ */
+export function getPrepWeekRange(goal: Goal): { start: string; end: string } {
+  if (goal.preparationWeeks === 0) {
+    return { start: goal.competitionDate, end: goal.competitionDate };
+  }
+
+  const competitionDay = parseISO(goal.competitionDate);
+  // Go back preparationWeeks * 7 days from competition date
+  const rawStart = addDays(competitionDay, -(goal.preparationWeeks * 7));
+  // Align to Monday: ISO day 1 = Monday, getISODay returns 1–7
+  const dow = getISODay(rawStart); // 1=Mon, 7=Sun
+  const monday = addDays(rawStart, -(dow - 1));
+  return {
+    start: format(monday, 'yyyy-MM-dd'),
+    end: goal.competitionDate,
+  };
+}
+
+/**
+ * Returns the Monday date string of the competition week for a goal.
+ */
+function getCompetitionMonday(goal: Goal): string {
+  const endDate = parseISO(goal.competitionDate);
+  const competitionDow = getISODay(endDate);
+  const competitionMonday = addDays(endDate, -(competitionDow - 1));
+  return format(competitionMonday, 'yyyy-MM-dd');
+}
+
+/**
+ * Returns true if the given weekStart (Monday date string) falls within the
+ * preparation window for the goal, INCLUDING the competition week itself.
+ */
+export function isWeekInPrepWindow(weekStart: string, goal: Goal): boolean {
+  const competitionMondayStr = getCompetitionMonday(goal);
+
+  // Goals with 0 prep weeks: only match the competition week
+  if (goal.preparationWeeks === 0) return weekStart === competitionMondayStr;
+
+  const { start } = getPrepWeekRange(goal);
+  const weekDate = parseISO(weekStart);
+  const startDate = parseISO(start);
+
+  return weekDate >= startDate && weekStart <= competitionMondayStr;
+}
+
+/**
+ * Returns true if the given weekStart is the competition week for this goal.
+ */
+export function isCompetitionWeek(weekStart: string, goal: Goal): boolean {
+  return weekStart === getCompetitionMonday(goal);
+}

--- a/app/lib/utils/training-types.ts
+++ b/app/lib/utils/training-types.ts
@@ -9,6 +9,7 @@ import {
   Activity,
   PersonStanding,
   Mountain,
+  Trophy,
 } from 'lucide-react';
 import type { ElementType } from 'react';
 import type { TrainingType, LoadType } from '~/types/training';
@@ -24,7 +25,15 @@ export const iconMap: Record<string, ElementType> = {
   Activity,
   PersonStanding,
   Mountain,
+  Trophy,
 };
+
+export const competitionConfig = {
+  color: 'text-amber-700 dark:text-amber-300',
+  bgColor: 'bg-amber-100 dark:bg-amber-900',
+  borderColor: 'border-amber-400 dark:border-amber-500',
+  icon: 'Trophy',
+} as const;
 
 export const trainingTypeConfig: Record<
   TrainingType,

--- a/app/lib/utils/week-view.ts
+++ b/app/lib/utils/week-view.ts
@@ -26,19 +26,19 @@ export function groupSessionsByDay(sessions: TrainingSession[]): SessionsByDay {
 }
 
 export function computeWeekStats(sessions: TrainingSession[]): WeekStats {
-  const totalSessions = sessions.filter((s) => s.trainingType !== 'rest_day').length;
-  const completedSessions = sessions.filter(
+  const training = sessions.filter((s) => !s.goalId);
+  const totalSessions = training.filter((s) => s.trainingType !== 'rest_day').length;
+  const completedSessions = training.filter(
     (s) => s.isCompleted && s.trainingType !== 'rest_day',
   ).length;
-  const totalPlannedKm = sessions.reduce((sum, s) => sum + (s.plannedDistanceKm ?? 0), 0);
-  const totalCompletedKm = sessions
+  const totalPlannedKm = training.reduce((sum, s) => sum + (s.plannedDistanceKm ?? 0), 0);
+  const totalCompletedKm = training
     .filter((s) => s.isCompleted)
     .reduce((sum, s) => sum + (s.plannedDistanceKm ?? 0), 0);
-  const totalActualDurationMinutes = sessions
+  const totalActualDurationMinutes = training
     .filter((s) => s.trainingType !== 'rest_day' && s.isCompleted)
     .reduce((sum, s) => sum + (s.actualDurationMinutes ?? s.plannedDurationMinutes ?? 0), 0);
-  const totalActualRunKm = sessions
-    .filter((s) => s.trainingType === 'run')
+  const totalActualDistanceKm = training
     .reduce((sum, s) => sum + (s.actualDistanceKm ?? 0), 0);
 
   return {
@@ -48,7 +48,9 @@ export function computeWeekStats(sessions: TrainingSession[]): WeekStats {
     totalCompletedKm,
     completionPercentage: totalSessions > 0 ? (completedSessions / totalSessions) * 100 : 0,
     totalActualDurationMinutes,
-    totalActualRunKm,
+    totalActualDistanceKm,
+    byType: {},
+    competitionSessions: [],
   };
 }
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -24,6 +24,8 @@ export default [
           route('week/:weekId', 'routes/coach/week.$weekId.tsx'),
           route('strength', 'routes/coach/strength.tsx'),
           route('strength/:variantId', 'routes/coach/strength.$variantId.tsx'),
+          route('goals', 'routes/coach/goals.tsx'),
+          route('analytics', 'routes/coach/analytics.tsx'),
         ]),
       ]),
 
@@ -33,6 +35,8 @@ export default [
           route('week/:weekId', 'routes/athlete/week.$weekId.tsx'),
           route('strength', 'routes/athlete/strength.tsx'),
           route('strength/:variantId', 'routes/athlete/strength.$variantId.tsx'),
+          route('goals', 'routes/athlete/goals.tsx'),
+          route('analytics', 'routes/athlete/analytics.tsx'),
         ]),
       ]),
 

--- a/app/routes/athlete/analytics.tsx
+++ b/app/routes/athlete/analytics.tsx
@@ -1,0 +1,15 @@
+import { useAuth } from '~/lib/context/AuthContext';
+import { useGoals } from '~/lib/hooks/useGoals';
+import { AnalyticsView } from '~/components/analytics/AnalyticsView';
+
+export default function AthleteAnalytics() {
+  const { user } = useAuth();
+  const athleteId = user?.id ?? '';
+  const { data: goals = [] } = useGoals(athleteId);
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <AnalyticsView namespace="athlete" athleteId={athleteId} goals={goals} />
+    </div>
+  );
+}

--- a/app/routes/athlete/goals.tsx
+++ b/app/routes/athlete/goals.tsx
@@ -1,0 +1,15 @@
+import { useAuth } from '~/lib/context/AuthContext';
+import { useSelfPlanPermission } from '~/lib/hooks/useProfile';
+import { GoalListView } from '~/components/goals/GoalListView';
+
+export default function AthleteGoals() {
+  const { user } = useAuth();
+  const { data: canManage = false } = useSelfPlanPermission(user?.id ?? '');
+  return (
+    <GoalListView
+      athleteId={user?.id ?? ''}
+      createdBy={user?.id ?? ''}
+      canManage={canManage}
+    />
+  );
+}

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { WeekNavigation } from '~/components/calendar/WeekNavigation';
+import { GoalPrepBanner } from '~/components/calendar/GoalPrepBanner';
 import { WeekGrid } from '~/components/calendar/WeekGrid';
 import { WeekSummary } from '~/components/calendar/WeekSummary';
 import { AppLoader } from '~/components/ui/app-loader';
@@ -15,10 +16,13 @@ import {
   useJunctionWeekWorkouts,
 } from '~/lib/hooks/useJunctionConnection';
 import { useSelfPlanPermission } from '~/lib/hooks/useProfile';
+import { useGoals } from '~/lib/hooks/useGoals';
 import { useAuth } from '~/lib/context/AuthContext';
 import { queryKeys } from '~/lib/queries/keys';
 import { weekIdToMonday, parseWeekId, getTodayDayOfWeek } from '~/lib/utils/date';
+import { isCompetitionWeek } from '~/lib/utils/goals';
 import { computeWeekStats, augmentSessionsWithGarmin } from '~/lib/utils/week-view';
+import { computeSportBreakdown } from '~/lib/utils/analytics';
 import { StravaActionsBar } from '~/components/calendar/StravaActionsBar';
 import { useWeekView } from '~/lib/hooks/useWeekView';
 import { cn } from '~/lib/utils';
@@ -44,6 +48,7 @@ export default function AthleteWeekView() {
   const weekStart = weekId ? weekIdToMonday(weekId) : '';
 
   const { data: canSelfPlan = true } = useSelfPlanPermission(user?.id ?? '');
+  const { data: goals = [] } = useGoals(user?.id ?? '');
 
   // Athlete-only: Strava + Garmin
   const { data: stravaStatus } = useStravaConnectionStatus(user?.id ?? '');
@@ -67,6 +72,11 @@ export default function AthleteWeekView() {
   // The hook provides raw `sessions`; augmentation is athlete-only
   const weekView = useWeekView({ canAutoCreate: canSelfPlan });
 
+  const competitionGoal = useMemo(
+    () => (weekStart ? (goals.find((g) => isCompetitionWeek(weekStart, g)) ?? null) : null),
+    [goals, weekStart],
+  );
+
   const augmentedSessions = useMemo(
     () =>
       weekView && junctionConnected
@@ -75,7 +85,16 @@ export default function AthleteWeekView() {
     [junctionConnected, weekView?.sessions, garminWeekWorkouts, weekStart],
   );
 
-  const stats = useMemo(() => computeWeekStats(augmentedSessions), [augmentedSessions]);
+  const stats = useMemo(() => {
+    const base = computeWeekStats(augmentedSessions);
+    const breakdown = computeSportBreakdown(augmentedSessions);
+    const competitionSessions = breakdown.competitionSessions.map((cs) => {
+      const goal = goals.find((g) => g.id === cs.goalId);
+      if (!goal) return cs;
+      return { ...cs, goalName: goal.name, goalDistanceKm: goal.goalDistanceKm };
+    });
+    return { ...base, byType: breakdown.byType, competitionSessions };
+  }, [augmentedSessions, goals]);
 
   // Strava handlers — athlete only
   const handleSyncStrava = useCallback(
@@ -140,6 +159,10 @@ export default function AthleteWeekView() {
     deleteSessionMut,
   } = weekView;
 
+  const competitionSession = competitionGoal
+    ? (sessions.find((s) => s.goalId === competitionGoal.id) ?? null)
+    : null;
+
   return (
     <>
       {showSkeleton && <AppLoader />}
@@ -181,12 +204,23 @@ export default function AthleteWeekView() {
                 </div>
               </StaggerIn>
 
+              {/* Goal preparation banners */}
+              {goals.length > 0 && weekStart && (
+                <GoalPrepBanner goals={goals} weekStart={weekStart} />
+              )}
+
               {/* Week Summary (readonly with progress bar) */}
               <StaggerIn delay={60}>
                 <div
                   className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
                 >
-                  <WeekSummary weekPlan={weekPlan} stats={stats} readonly />
+                  <WeekSummary
+                    weekPlan={weekPlan}
+                    stats={stats}
+                    readonly
+                    competitionGoal={competitionGoal}
+                    competitionSession={competitionSession}
+                  />
                 </div>
               </StaggerIn>
 

--- a/app/routes/coach/analytics.tsx
+++ b/app/routes/coach/analytics.tsx
@@ -1,0 +1,15 @@
+import { useAuth } from '~/lib/context/AuthContext';
+import { useGoals } from '~/lib/hooks/useGoals';
+import { AnalyticsView } from '~/components/analytics/AnalyticsView';
+
+export default function CoachAnalytics() {
+  const { user, effectiveAthleteId } = useAuth();
+  const athleteId = effectiveAthleteId ?? user?.id ?? '';
+  const { data: goals = [] } = useGoals(athleteId);
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <AnalyticsView namespace="coach" athleteId={athleteId} goals={goals} />
+    </div>
+  );
+}

--- a/app/routes/coach/goals.tsx
+++ b/app/routes/coach/goals.tsx
@@ -1,0 +1,14 @@
+import { useAuth } from '~/lib/context/AuthContext';
+import { GoalListView } from '~/components/goals/GoalListView';
+
+export default function CoachGoals() {
+  const { user, effectiveAthleteId } = useAuth();
+  const athleteId = effectiveAthleteId ?? user?.id ?? '';
+  return (
+    <GoalListView
+      athleteId={athleteId}
+      createdBy={user?.id ?? ''}
+      canManage={true}
+    />
+  );
+}

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -1,15 +1,18 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { WeekNavigation } from '~/components/calendar/WeekNavigation';
 import { MultiWeekView } from '~/components/calendar/MultiWeekView';
 import { WeekSummary } from '~/components/calendar/WeekSummary';
+import { GoalPrepBanner } from '~/components/calendar/GoalPrepBanner';
 import { AppLoader } from '~/components/ui/app-loader';
 import { StaggerIn } from '~/components/ui/stagger-in';
 import { SessionForm } from '~/components/training/SessionForm';
 import { DeleteConfirmationDialog } from '~/components/training/DeleteConfirmationDialog';
 import { useUpdateWeekPlan } from '~/lib/hooks/useWeekPlan';
+import { useGoals } from '~/lib/hooks/useGoals';
 import { useAuth } from '~/lib/context/AuthContext';
 import { getTodayDayOfWeek } from '~/lib/utils/date';
+import { isCompetitionWeek } from '~/lib/utils/goals';
 import { useWeekView } from '~/lib/hooks/useWeekView';
 import { cn } from '~/lib/utils';
 import type { WeekPlan, SessionsByDay } from '~/types/training';
@@ -20,6 +23,8 @@ export default function CoachWeekView() {
   const updateWeek = useUpdateWeekPlan();
 
   const weekView = useWeekView({ canAutoCreate: true });
+  const athleteId = effectiveAthleteId ?? user?.id ?? '';
+  const { data: goals = [] } = useGoals(athleteId);
 
   const handleWeekUpdate = useCallback(
     (
@@ -71,6 +76,27 @@ export default function CoachWeekView() {
   const selectedDay = getTodayDayOfWeek();
   const isViewingSelf = !effectiveAthleteId || effectiveAthleteId === user?.id;
 
+  const competitionGoal = useMemo(
+    () => (weekStart ? (goals.find((g) => isCompetitionWeek(weekStart, g)) ?? null) : null),
+    [goals, weekStart],
+  );
+  const competitionSession = useMemo(
+    () => (competitionGoal ? (sessions.find((s) => s.goalId === competitionGoal.id) ?? null) : null),
+    [competitionGoal, sessions],
+  );
+
+  const enrichedStats = useMemo(() => {
+    if (!stats.competitionSessions.length || !goals.length) return stats;
+    return {
+      ...stats,
+      competitionSessions: stats.competitionSessions.map((cs) => {
+        const goal = goals.find((g) => g.id === cs.goalId);
+        if (!goal) return cs;
+        return { ...cs, goalName: goal.name, goalDistanceKm: goal.goalDistanceKm };
+      }),
+    };
+  }, [stats, goals]);
+
   return (
     <>
       {showSkeleton && <AppLoader />}
@@ -92,12 +118,23 @@ export default function CoachWeekView() {
               </div>
             </StaggerIn>
 
+            {/* Goal preparation banners */}
+            {goals.length > 0 && weekStart && (
+              <GoalPrepBanner goals={goals} weekStart={weekStart} />
+            )}
+
             {/* Week Summary */}
             <StaggerIn delay={60}>
               <div
                 className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
               >
-                <WeekSummary weekPlan={weekPlan} stats={stats} onUpdate={handleWeekUpdate} />
+                <WeekSummary
+                  weekPlan={weekPlan}
+                  stats={enrichedStats}
+                  onUpdate={handleWeekUpdate}
+                  competitionGoal={competitionGoal}
+                  competitionSession={competitionSession}
+                />
               </div>
             </StaggerIn>
 

--- a/app/test/integration/WeekSummary.test.tsx
+++ b/app/test/integration/WeekSummary.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '~/i18n/config';
+import { WeekSummary } from '~/components/calendar/WeekSummary';
+import type { WeekPlan, WeekStats } from '~/types/training';
+
+const WEEK_PLAN: WeekPlan = {
+  id: 'wp-1',
+  athleteId: 'a-1',
+  weekStart: '2026-03-23',
+  year: 2026,
+  weekNumber: 13,
+  loadType: null,
+  totalPlannedKm: null,
+  description: null,
+  actualTotalKm: null,
+  coachComments: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const STATS_WITH_BREAKDOWN: WeekStats = {
+  totalSessions: 3,
+  completedSessions: 1,
+  completionPercentage: 33,
+  totalPlannedKm: 20,
+  totalCompletedKm: 10,
+  totalActualDistanceKm: 10,
+  totalActualDurationMinutes: 90,
+  byType: {
+    run: { sessionCount: 2, completedSessionCount: 1, plannedDistanceKm: 15, actualDistanceKm: 10, totalDurationMinutes: 60 },
+    cycling: { sessionCount: 1, completedSessionCount: 0, plannedDistanceKm: 5, actualDistanceKm: 0, totalDurationMinutes: 30 },
+  },
+  competitionSessions: [],
+};
+
+const STATS_WITH_COMPETITION: WeekStats = {
+  ...STATS_WITH_BREAKDOWN,
+  competitionSessions: [
+    {
+      sessionId: 's-1',
+      goalId: 'g-1',
+      goalName: 'Spring 10K',
+      discipline: 'run',
+      goalDistanceKm: 10,
+      resultDistanceKm: 9.8,
+      resultTimeSeconds: 3000,
+      actualDistanceKm: 9.8,
+      actualDurationMinutes: 50,
+      achievementStatus: 'achieved',
+    },
+  ],
+};
+
+const STATS_EMPTY: WeekStats = {
+  totalSessions: 0,
+  completedSessions: 0,
+  completionPercentage: 0,
+  totalPlannedKm: 0,
+  totalCompletedKm: 0,
+  totalActualDistanceKm: 0,
+  totalActualDurationMinutes: 0,
+  byType: {},
+  competitionSessions: [],
+};
+
+function renderSummary(stats: WeekStats, weekPlan = WEEK_PLAN) {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <WeekSummary weekPlan={weekPlan} stats={stats} readonly={true} />
+    </I18nextProvider>,
+  );
+}
+
+describe('WeekSummary sport breakdown toggle', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('(a) shows cumulative view by default', () => {
+    renderSummary(STATS_WITH_BREAKDOWN);
+    expect(screen.getByTestId('cumulative-view')).toBeInTheDocument();
+    // sport-breakdown is in DOM for animation, but opacity-0 (collapsed)
+    expect(screen.getByTestId('sport-breakdown-view')).toHaveClass('opacity-0');
+  });
+
+  it('(b) renders toggle buttons for cumulative and by-sport views', () => {
+    renderSummary(STATS_WITH_BREAKDOWN);
+    expect(screen.getByTestId('view-cumulative')).toBeInTheDocument();
+    expect(screen.getByTestId('view-by-sport')).toBeInTheDocument();
+  });
+
+  it('(c) switching to by-sport shows sport breakdown view', () => {
+    renderSummary(STATS_WITH_BREAKDOWN);
+    fireEvent.click(screen.getByTestId('view-by-sport'));
+    expect(screen.getByTestId('sport-breakdown-view')).toHaveClass('opacity-100');
+  });
+
+  it('(d) switching back to cumulative hides sport breakdown', () => {
+    renderSummary(STATS_WITH_BREAKDOWN);
+    fireEvent.click(screen.getByTestId('view-by-sport'));
+    fireEvent.click(screen.getByTestId('view-cumulative'));
+    expect(screen.getByTestId('sport-breakdown-view')).toHaveClass('opacity-0');
+    expect(screen.getByTestId('cumulative-view')).toHaveStyle({ gridTemplateRows: '1fr' });
+  });
+
+  it('(e) persists view preference to sessionStorage', () => {
+    renderSummary(STATS_WITH_BREAKDOWN);
+    fireEvent.click(screen.getByTestId('view-by-sport'));
+    expect(sessionStorage.getItem('weekSummary.view')).toBe('by-sport');
+  });
+
+  it('(f) restores view from sessionStorage on mount', () => {
+    sessionStorage.setItem('weekSummary.view', 'by-sport');
+    renderSummary(STATS_WITH_BREAKDOWN);
+    expect(screen.getByTestId('sport-breakdown-view')).toHaveClass('opacity-100');
+    expect(screen.getByTestId('cumulative-view')).toHaveStyle({ gridTemplateRows: '0fr' });
+  });
+
+  it('(g) competition sessions appear in by-sport view', () => {
+    renderSummary(STATS_WITH_COMPETITION);
+    fireEvent.click(screen.getByTestId('view-by-sport'));
+    expect(screen.getByText('Spring 10K')).toBeInTheDocument();
+  });
+
+  it('(h) shows empty state in by-sport when no sessions', () => {
+    renderSummary(STATS_EMPTY);
+    fireEvent.click(screen.getByTestId('view-by-sport'));
+    expect(screen.getByTestId('sport-breakdown-view')).toBeInTheDocument();
+    // SportBreakdown renders a "no sessions" message
+    expect(screen.queryByTestId('sport-breakdown-view')).toBeInTheDocument();
+  });
+});

--- a/app/test/integration/coach-week-loading.test.tsx
+++ b/app/test/integration/coach-week-loading.test.tsx
@@ -31,6 +31,13 @@ vi.mock('~/lib/hooks/useSessions', () => ({
   useCopySession: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
+vi.mock('~/lib/hooks/useGoals', () => ({
+  useGoals: () => ({ data: [], isLoading: false }),
+  useCreateGoal: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateGoal: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteGoal: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
 vi.mock('~/components/calendar/WeekNavigation', () => ({
   WeekNavigation: () => <div data-testid="week-navigation" />,
 }));

--- a/app/test/integration/useGoals.test.tsx
+++ b/app/test/integration/useGoals.test.tsx
@@ -1,0 +1,200 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useGoals, useCreateGoal, useDeleteGoal, useUpdateGoal } from '~/lib/hooks/useGoals';
+import {
+  mockFetchGoals,
+  mockCreateGoal,
+  mockUpdateGoal,
+  mockDeleteGoal,
+  resetMockGoals,
+} from '~/lib/mock-data/goals';
+import { createTestQueryClient } from '~/test/utils/query-client';
+import { queryKeys } from '~/lib/queries/keys';
+
+// ---------------------------------------------------------------------------
+// Mock the query module — use mock data store directly
+// ---------------------------------------------------------------------------
+
+vi.mock('~/lib/queries/goals', async () => {
+  const { mockFetchGoals, mockCreateGoal, mockUpdateGoal, mockDeleteGoal } = await import(
+    '~/lib/mock-data/goals'
+  );
+  return {
+    fetchGoals: mockFetchGoals,
+    createGoal: mockCreateGoal,
+    updateGoal: mockUpdateGoal,
+    deleteGoal: mockDeleteGoal,
+    toGoal: (row: Record<string, unknown>) => row,
+  };
+});
+
+const ATHLETE_ID = 'athlete-1';
+
+function makeWrapper() {
+  const queryClient = createTestQueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return { queryClient, Wrapper };
+}
+
+beforeEach(() => {
+  resetMockGoals();
+});
+
+// ---------------------------------------------------------------------------
+// useGoals
+// ---------------------------------------------------------------------------
+
+describe('useGoals', () => {
+  it('fetches goals for athlete and returns them sorted by competition date', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGoals(ATHLETE_ID), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data!.length).toBe(2);
+    // Sorted by competition date ascending
+    expect(result.current.data![0].competitionDate < result.current.data![1].competitionDate).toBe(
+      true
+    );
+  });
+
+  it('does not fetch when athleteId is empty', () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGoals(''), { wrapper: Wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useCreateGoal — optimistic update
+// ---------------------------------------------------------------------------
+
+describe('useCreateGoal', () => {
+  it('adds the new goal optimistically to the cache before mutation settles', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    // Pre-seed the cache
+    const initialGoals = await mockFetchGoals(ATHLETE_ID);
+    queryClient.setQueryData(queryKeys.goals.byAthlete(ATHLETE_ID), initialGoals);
+
+    const { result } = renderHook(() => useCreateGoal(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({
+        athleteId: ATHLETE_ID,
+        createdBy: 'coach-1',
+        name: 'City Half Marathon',
+        discipline: 'run',
+        competitionDate: '2026-09-20',
+        preparationWeeks: 12,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData<Awaited<ReturnType<typeof mockFetchGoals>>>(
+      queryKeys.goals.byAthlete(ATHLETE_ID)
+    );
+    expect(cached?.some((g) => g.name === 'City Half Marathon')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useDeleteGoal — optimistic removal + rollback on error
+// ---------------------------------------------------------------------------
+
+describe('useDeleteGoal', () => {
+  it('removes the goal optimistically from the cache before deletion completes', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const initialGoals = await mockFetchGoals(ATHLETE_ID);
+    queryClient.setQueryData(queryKeys.goals.byAthlete(ATHLETE_ID), initialGoals);
+    const targetId = initialGoals[0].id;
+
+    const { result } = renderHook(
+      () => useDeleteGoal(),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      result.current.mutate({ id: targetId, athleteId: ATHLETE_ID });
+    });
+
+    // Optimistic: should be gone immediately from cache
+    const cached = queryClient.getQueryData<typeof initialGoals>(
+      queryKeys.goals.byAthlete(ATHLETE_ID)
+    );
+    expect(cached?.find((g) => g.id === targetId)).toBeUndefined();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('restores the goal in the cache if deletion fails', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const initialGoals = await mockFetchGoals(ATHLETE_ID);
+    queryClient.setQueryData(queryKeys.goals.byAthlete(ATHLETE_ID), initialGoals);
+    const targetId = initialGoals[0].id;
+
+    // Make delete fail
+    const { deleteGoal } = await import('~/lib/queries/goals');
+    vi.spyOn({ deleteGoal }, 'deleteGoal').mockRejectedValueOnce(new Error('Network error'));
+
+    // We mock the actual query module function
+    const goalsMod = await import('~/lib/queries/goals');
+    const spy = vi.spyOn(goalsMod, 'deleteGoal').mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useDeleteGoal(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ id: targetId, athleteId: ATHLETE_ID });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const cached = queryClient.getQueryData<typeof initialGoals>(
+      queryKeys.goals.byAthlete(ATHLETE_ID)
+    );
+    // Goal should be restored after rollback
+    expect(cached?.find((g) => g.id === targetId)).toBeDefined();
+
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useUpdateGoal — optimistic field update
+// ---------------------------------------------------------------------------
+
+describe('useUpdateGoal', () => {
+  it('reflects the updated field optimistically in the cache', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const initialGoals = await mockFetchGoals(ATHLETE_ID);
+    queryClient.setQueryData(queryKeys.goals.byAthlete(ATHLETE_ID), initialGoals);
+    const target = initialGoals[0];
+
+    const { result } = renderHook(() => useUpdateGoal(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({
+        id: target.id,
+        athleteId: ATHLETE_ID,
+        name: 'Updated Goal Name',
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData<typeof initialGoals>(
+      queryKeys.goals.byAthlete(ATHLETE_ID)
+    );
+    expect(cached?.find((g) => g.id === target.id)?.name).toBe('Updated Goal Name');
+  });
+});

--- a/app/test/unit/analytics-mapper.test.ts
+++ b/app/test/unit/analytics-mapper.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { toAnalyticsBucket } from '~/lib/queries/analytics';
+
+describe('toAnalyticsBucket mapper', () => {
+  it('(a) maps snake_case DB row to AnalyticsBucket', () => {
+    const row = {
+      label: 'Mar',
+      start_date: '2026-03-01',
+      end_date: '2026-03-31',
+      total_sessions: 10,
+      completed_sessions: 8,
+      total_distance_km: 72.5,
+      total_duration_minutes: 540,
+      completion_rate: 80.0,
+    };
+    const bucket = toAnalyticsBucket(row);
+    expect(bucket.label).toBe('Mar');
+    expect(bucket.startDate).toBe('2026-03-01');
+    expect(bucket.endDate).toBe('2026-03-31');
+    expect(bucket.totalSessions).toBe(10);
+    expect(bucket.completedSessions).toBe(8);
+    expect(bucket.totalDistanceKm).toBe(72.5);
+    expect(bucket.totalDurationMinutes).toBe(540);
+    expect(bucket.completionRate).toBe(80.0);
+  });
+
+  it('(b) defaults null distance and duration to zero', () => {
+    const row = {
+      label: 'W01',
+      start_date: '2026-01-01',
+      end_date: '2026-01-07',
+      total_sessions: 0,
+      completed_sessions: 0,
+      total_distance_km: null,
+      total_duration_minutes: null,
+      completion_rate: 0,
+    };
+    const bucket = toAnalyticsBucket(row);
+    expect(bucket.totalDistanceKm).toBe(0);
+    expect(bucket.totalDurationMinutes).toBe(0);
+  });
+
+  it('(c) preserves numeric precision for distance', () => {
+    const row = {
+      label: 'Q1',
+      start_date: '2026-01-01',
+      end_date: '2026-03-31',
+      total_sessions: 36,
+      completed_sessions: 30,
+      total_distance_km: 255.75,
+      total_duration_minutes: 1800,
+      completion_rate: 83.3,
+    };
+    const bucket = toAnalyticsBucket(row);
+    expect(bucket.totalDistanceKm).toBe(255.75);
+    expect(bucket.completionRate).toBe(83.3);
+  });
+});

--- a/app/test/unit/analytics.test.ts
+++ b/app/test/unit/analytics.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeSportBreakdown } from '~/lib/utils/analytics';
+import type { TrainingSession } from '~/types/training';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<TrainingSession>): TrainingSession {
+  return {
+    id: 'session-' + Math.random(),
+    weekPlanId: 'wp-1',
+    dayOfWeek: 'monday',
+    sortOrder: 0,
+    trainingType: 'run',
+    description: null,
+    coachComments: null,
+    plannedDurationMinutes: 60,
+    plannedDistanceKm: 10,
+    typeSpecificData: { type: 'run' },
+    isCompleted: false,
+    completedAt: null,
+    actualDurationMinutes: null,
+    actualDistanceKm: null,
+    actualPace: null,
+    avgHeartRate: null,
+    maxHeartRate: null,
+    rpe: null,
+    coachPostFeedback: null,
+    athleteNotes: null,
+    stravaActivityId: null,
+    stravaSyncedAt: null,
+    goalId: null,
+    resultDistanceKm: null,
+    resultTimeSeconds: null,
+    resultPace: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const RUN_SESSION = makeSession({ id: 's-run-1', trainingType: 'run', plannedDistanceKm: 10, plannedDurationMinutes: 60 });
+const RUN_SESSION_2 = makeSession({ id: 's-run-2', trainingType: 'run', plannedDistanceKm: 5, plannedDurationMinutes: 30, actualDistanceKm: 5.2, actualDurationMinutes: 28 });
+const CYCLING_SESSION = makeSession({ id: 's-cyc-1', trainingType: 'cycling', plannedDistanceKm: 40, plannedDurationMinutes: 90 });
+const COMPETITION_SESSION = makeSession({
+  id: 's-comp-1',
+  trainingType: 'run',
+  goalId: 'goal-1',
+  plannedDistanceKm: 10,
+  plannedDurationMinutes: 50,
+  resultDistanceKm: 10,
+  resultTimeSeconds: 2880,
+});
+
+// ---------------------------------------------------------------------------
+// computeSportBreakdown
+// ---------------------------------------------------------------------------
+
+describe('computeSportBreakdown', () => {
+  it('(a) groups training sessions by trainingType summing distances and counting sessions', () => {
+    const result = computeSportBreakdown([RUN_SESSION, RUN_SESSION_2, CYCLING_SESSION]);
+
+    expect(result.byType.run).toBeDefined();
+    expect(result.byType.run!.sessionCount).toBe(2);
+    expect(result.byType.run!.plannedDistanceKm).toBe(15); // 10 + 5
+    expect(result.byType.run!.totalDurationMinutes).toBe(88); // RUN_SESSION: 60 planned + RUN_SESSION_2: 28 actual
+
+    expect(result.byType.cycling).toBeDefined();
+    expect(result.byType.cycling!.sessionCount).toBe(1);
+    expect(result.byType.cycling!.plannedDistanceKm).toBe(40);
+  });
+
+  it('(b) sessions with goalId set are excluded from byType and collected in competitionSessions', () => {
+    const result = computeSportBreakdown([RUN_SESSION, COMPETITION_SESSION]);
+
+    // Competition excluded from run byType
+    expect(result.byType.run?.sessionCount).toBe(1);
+    // Competition session is in the competitions array
+    expect(result.competitionSessions).toHaveLength(1);
+    expect(result.competitionSessions[0].sessionId).toBe('s-comp-1');
+    expect(result.competitionSessions[0].goalId).toBe('goal-1');
+  });
+
+  it('(c) achievementStatus on competition summary is derived correctly (goal has no targets → pending)', () => {
+    const result = computeSportBreakdown([COMPETITION_SESSION]);
+    // Competition session has result but its goal has no targets (we only have session data here)
+    expect(result.competitionSessions[0].achievementStatus).toBe('pending');
+  });
+
+  it('(d) empty array returns empty byType and empty competitionSessions', () => {
+    const result = computeSportBreakdown([]);
+    expect(Object.keys(result.byType)).toHaveLength(0);
+    expect(result.competitionSessions).toHaveLength(0);
+  });
+
+  it('(e) week with only competition sessions returns empty byType', () => {
+    const result = computeSportBreakdown([COMPETITION_SESSION]);
+    expect(Object.keys(result.byType)).toHaveLength(0);
+    expect(result.competitionSessions).toHaveLength(1);
+  });
+
+  it('uses actual distance/duration when completed, planned when not', () => {
+    const result = computeSportBreakdown([RUN_SESSION, RUN_SESSION_2]);
+    // RUN_SESSION: not completed, no actual → uses planned (10km, 60min)
+    // RUN_SESSION_2: has actual values → uses actual (5.2km, 28min)
+    expect(result.byType.run!.actualDistanceKm).toBeCloseTo(5.2);
+    expect(result.byType.run!.totalDurationMinutes).toBe(88); // 60 + 28
+  });
+});

--- a/app/test/unit/goals-mapper.test.ts
+++ b/app/test/unit/goals-mapper.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { toGoal } from '~/lib/queries/goals';
+
+const VALID_ROW = {
+  id: 'g-uuid-1',
+  athlete_id: 'a-uuid-1',
+  created_by: 'c-uuid-1',
+  name: 'Spring 10K',
+  discipline: 'run',
+  competition_date: '2026-05-23',
+  preparation_weeks: 8,
+  goal_distance_km: '10.00',
+  goal_time_seconds: 3000,
+  notes: 'First race of the season',
+  created_at: '2026-03-01T10:00:00Z',
+  updated_at: '2026-03-02T10:00:00Z',
+};
+
+describe('toGoal', () => {
+  it('(a) maps all snake_case DB columns to camelCase Goal fields', () => {
+    const goal = toGoal(VALID_ROW);
+    expect(goal.id).toBe('g-uuid-1');
+    expect(goal.athleteId).toBe('a-uuid-1');
+    expect(goal.createdBy).toBe('c-uuid-1');
+    expect(goal.competitionDate).toBe('2026-05-23');
+    expect(goal.preparationWeeks).toBe(8);
+    expect(goal.goalDistanceKm).toBe(10);
+    expect(goal.goalTimeSeconds).toBe(3000);
+    expect(goal.createdAt).toBe('2026-03-01T10:00:00Z');
+    expect(goal.updatedAt).toBe('2026-03-02T10:00:00Z');
+  });
+
+  it('(b) preserves nullable fields as null when absent', () => {
+    const row = { ...VALID_ROW, goal_distance_km: null, goal_time_seconds: null, notes: null };
+    const goal = toGoal(row);
+    expect(goal.goalDistanceKm).toBeNull();
+    expect(goal.goalTimeSeconds).toBeNull();
+    expect(goal.notes).toBeNull();
+  });
+
+  it('(c) forwards required string fields unchanged', () => {
+    const goal = toGoal(VALID_ROW);
+    expect(goal.id).toBe(VALID_ROW.id);
+    expect(goal.name).toBe(VALID_ROW.name);
+    expect(goal.discipline).toBe('run');
+  });
+});

--- a/app/test/unit/goals.test.ts
+++ b/app/test/unit/goals.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { computeGoalAchievement, getPrepWeekRange, isWeekInPrepWindow } from '~/lib/utils/goals';
+import type { Goal } from '~/types/training';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const baseGoal: Goal = {
+  id: 'g-1',
+  athleteId: 'a-1',
+  createdBy: 'c-1',
+  name: 'Spring 10K',
+  discipline: 'run',
+  competitionDate: '2026-05-23', // Saturday
+  preparationWeeks: 4,
+  goalDistanceKm: 10,
+  goalTimeSeconds: 3000,
+  notes: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// computeGoalAchievement
+// ---------------------------------------------------------------------------
+
+describe('computeGoalAchievement', () => {
+  it('(a) returns pending when session has no result', () => {
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: null })
+    ).toBe('pending');
+  });
+
+  it('(b) returns achieved when resultDistanceKm >= goalDistanceKm', () => {
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: 10, resultTimeSeconds: null })
+    ).toBe('achieved');
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: 10.5, resultTimeSeconds: null })
+    ).toBe('achieved');
+  });
+
+  it('(c) returns missed when resultDistanceKm < goalDistanceKm', () => {
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: 9.5, resultTimeSeconds: null })
+    ).toBe('missed');
+  });
+
+  it('(d) returns achieved when resultTimeSeconds <= goalTimeSeconds', () => {
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 2880 })
+    ).toBe('achieved');
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 3000 })
+    ).toBe('achieved');
+  });
+
+  it('(e) returns missed when resultTimeSeconds > goalTimeSeconds', () => {
+    expect(
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 3120 })
+    ).toBe('missed');
+  });
+
+  it('(f) returns pending when goal has no target set and result exists', () => {
+    const noTargetGoal: Goal = {
+      ...baseGoal,
+      goalDistanceKm: null,
+      goalTimeSeconds: null,
+    };
+    expect(
+      computeGoalAchievement(noTargetGoal, { resultDistanceKm: 10, resultTimeSeconds: 2880 })
+    ).toBe('pending');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWeekInPrepWindow
+// ---------------------------------------------------------------------------
+
+describe('isWeekInPrepWindow', () => {
+  // competitionDate: 2026-05-23 (Saturday), preparationWeeks: 4
+  // 4 weeks back from Saturday 2026-05-23 = Monday 2026-04-27
+  // Prep window covers weeks starting: 2026-04-27, 2026-05-04, 2026-05-11, 2026-05-18
+  // Competition week starts: 2026-05-18
+
+  it('(g) returns true for a week inside the prep window', () => {
+    expect(isWeekInPrepWindow('2026-04-20', baseGoal)).toBe(true);
+    expect(isWeekInPrepWindow('2026-04-27', baseGoal)).toBe(true);
+    expect(isWeekInPrepWindow('2026-05-04', baseGoal)).toBe(true);
+    expect(isWeekInPrepWindow('2026-05-11', baseGoal)).toBe(true);
+  });
+
+  it('(h) returns false for the competition week itself', () => {
+    // Competition is on Saturday 2026-05-23, week starts Monday 2026-05-18
+    expect(isWeekInPrepWindow('2026-05-18', baseGoal)).toBe(false);
+  });
+
+  it('(i) returns false for a week after the competition', () => {
+    expect(isWeekInPrepWindow('2026-05-25', baseGoal)).toBe(false);
+  });
+
+  it('(j) returns false when preparationWeeks is 0', () => {
+    const zeroPrep: Goal = { ...baseGoal, preparationWeeks: 0 };
+    expect(isWeekInPrepWindow('2026-05-18', zeroPrep)).toBe(false);
+    expect(isWeekInPrepWindow('2026-05-11', zeroPrep)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPrepWeekRange
+// ---------------------------------------------------------------------------
+
+describe('getPrepWeekRange', () => {
+  it('(k) start is Monday of week N − preparationWeeks, end is competitionDate', () => {
+    const range = getPrepWeekRange(baseGoal);
+    // 4 weeks back from 2026-05-23 (Sat) → 2026-04-25 (Sat); align back to Monday → 2026-04-20
+    expect(range.start).toBe('2026-04-20');
+    expect(range.end).toBe('2026-05-23');
+  });
+
+  it('(l) start equals end when preparationWeeks is 0', () => {
+    const noPrep: Goal = { ...baseGoal, preparationWeeks: 0 };
+    const range = getPrepWeekRange(noPrep);
+    expect(range.start).toBe('2026-05-23');
+    expect(range.end).toBe('2026-05-23');
+  });
+});

--- a/app/test/unit/week-view.test.ts
+++ b/app/test/unit/week-view.test.ts
@@ -132,7 +132,7 @@ describe('computeWeekStats', () => {
     expect(computeWeekStats(sessions).totalPlannedKm).toBe(15);
   });
 
-  it('sums totalActualRunKm only for run type sessions', () => {
+  it('sums totalActualDistanceKm across all sports', () => {
     const sessions = [
       makeSession({ trainingType: 'run', actualDistanceKm: 9 }),
       makeSession({
@@ -141,7 +141,7 @@ describe('computeWeekStats', () => {
         actualDistanceKm: 30,
       }),
     ];
-    expect(computeWeekStats(sessions).totalActualRunKm).toBe(9);
+    expect(computeWeekStats(sessions).totalActualDistanceKm).toBe(39);
   });
 
   it('treats null plannedDistanceKm as 0 in totals', () => {

--- a/app/types/training.ts
+++ b/app/types/training.ts
@@ -284,6 +284,10 @@ export interface TrainingSession {
   stravaActivityId: number | null;
   stravaSyncedAt: string | null;
   isStravaConfirmed?: boolean;
+  goalId?: string | null;
+  resultDistanceKm?: number | null;
+  resultTimeSeconds?: number | null;
+  resultPace?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -301,7 +305,9 @@ export interface WeekStats {
   totalCompletedKm: number;
   completionPercentage: number;
   totalActualDurationMinutes: number;
-  totalActualRunKm: number;
+  totalActualDistanceKm: number;
+  byType: Partial<Record<TrainingType, SportBreakdownEntry>>;
+  competitionSessions: CompetitionSummary[];
 }
 
 export interface WeekViewData {
@@ -354,6 +360,7 @@ export interface CreateSessionInput {
   isCompleted?: boolean;
   completedAt?: string;
   athleteNotes?: string;
+  goalId?: string;
 }
 
 export interface UpdateSessionInput {
@@ -413,4 +420,120 @@ export interface HistoryWeek {
   weekId: string;
   weekPlan: WeekPlan | null;
   sessions: TrainingSession[];
+}
+
+// ============================================================
+// Goals & competition types
+// ============================================================
+
+export interface Goal {
+  id: string;
+  athleteId: string;
+  createdBy: string;
+  name: string;
+  discipline: TrainingType;
+  competitionDate: string; // ISO date YYYY-MM-DD
+  preparationWeeks: number;
+  goalDistanceKm: number | null;
+  goalTimeSeconds: number | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateGoalInput {
+  athleteId: string;
+  name: string;
+  discipline: TrainingType;
+  competitionDate: string;
+  preparationWeeks: number;
+  goalDistanceKm?: number;
+  goalTimeSeconds?: number;
+  notes?: string;
+}
+
+export interface UpdateGoalInput {
+  id: string;
+  name?: string;
+  discipline?: TrainingType;
+  competitionDate?: string;
+  preparationWeeks?: number;
+  goalDistanceKm?: number | null;
+  goalTimeSeconds?: number | null;
+  notes?: string | null;
+}
+
+// ============================================================
+// Analytics types
+// ============================================================
+
+export type AnalyticsPeriod = 'year' | 'quarter' | 'month' | 'goal';
+
+export interface AnalyticsParams {
+  athleteId: string;
+  period: AnalyticsPeriod;
+  goalId?: string;
+  trainingType?: TrainingType;
+}
+
+export interface AnalyticsBucket {
+  label: string;
+  startDate: string;
+  endDate: string;
+  totalSessions: number;
+  completedSessions: number;
+  totalDistanceKm: number;
+  totalDurationMinutes: number;
+  completionRate: number;
+}
+
+export type AchievementStatus = 'achieved' | 'missed' | 'pending';
+
+export interface CompetitionMilestone {
+  goalId: string;
+  goalName: string;
+  discipline: TrainingType;
+  competitionDate: string;
+  goalDistanceKm: number | null;
+  goalTimeSeconds: number | null;
+  resultDistanceKm: number | null;
+  resultTimeSeconds: number | null;
+  achievementStatus: AchievementStatus;
+}
+
+export interface AnalyticsResponse {
+  buckets: AnalyticsBucket[];
+  competitions: CompetitionMilestone[];
+  totals: {
+    totalSessions: number;
+    completedSessions: number;
+    totalDistanceKm: number;
+    totalDurationMinutes: number;
+    overallCompletionRate: number;
+  };
+}
+
+// ============================================================
+// Week sport breakdown types
+// ============================================================
+
+export interface SportBreakdownEntry {
+  sessionCount: number;
+  completedSessionCount: number;
+  plannedDistanceKm: number;
+  actualDistanceKm: number;
+  totalDurationMinutes: number;
+}
+
+export interface CompetitionSummary {
+  sessionId: string;
+  goalId: string;
+  goalName: string;
+  discipline: TrainingType;
+  goalDistanceKm: number | null;
+  resultDistanceKm: number | null;
+  resultTimeSeconds: number | null;
+  actualDistanceKm: number | null;
+  actualDurationMinutes: number | null;
+  achievementStatus: AchievementStatus;
 }

--- a/specs/001-goals-analytics/spec.md
+++ b/specs/001-goals-analytics/spec.md
@@ -1,0 +1,133 @@
+# Feature Specification: Goal Management & Analytics Dashboard
+
+**Feature Branch**: `001-goals-analytics`
+**Created**: 2026-03-28
+**Status**: Draft
+**Input**: User description: "Design an UX for goal management and analytics dashboard with an athlete performance. 1. Coach can see cumulative plan for all disciplines but also can switch to see a breakdown for all planned sports as part of a week summary. 2. Coach or athlete can set a goal for a selected number of weeks, this goal is visible in every week where an athlete preps for it. The day of the goal has a special session called competition, distinguished on the UI. It can be any of the disciplines. But its distance and performance is treated separately, not as training but as competition. The competitions can then be analysed separately and are distinguished in week summary too. 3. Coach can open a year/quarter/month/goal period view to analyse athlete performance. The performance can be filtered by sport. 4. Make sure the UX is consistent and follow best practices. Reuse existing user journeys/UI patterns where possible."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Set a Competition Goal (Priority: P1)
+
+A coach or athlete creates a goal (an upcoming competition event) by specifying the competition date, sport discipline, goal distance, and a preparation window (number of weeks leading up to the competition). Once saved, every week within the preparation window displays a banner or indicator linking it to the goal, and the competition day itself contains a special "Competition" session card that is visually distinct from training sessions.
+
+**Why this priority**: Goals are the anchor for the entire feature. Without goals, there are no competition sessions, no goal-period views, and no contextualisation of the week summary breakdown. It is the foundational data creation flow.
+
+**Independent Test**: A coach can create a goal with a future date, verify the competition session appears on the correct day, and confirm prep-week indicators appear on all weeks within the preparation window.
+
+**Acceptance Scenarios**:
+
+1. **Given** a coach is viewing a week plan, **When** they open the goal creation dialog and fill in discipline (e.g. running), competition date, goal distance, and preparation weeks (e.g. 8), **Then** the competition session appears on the competition day and all 8 preceding weeks display a goal preparation indicator.
+2. **Given** a goal exists, **When** the competition day is viewed in the week grid, **Then** the session card is styled distinctly (e.g. trophy/medal icon, gold/accent border) and labelled "Competition" instead of a standard session type name.
+3. **Given** a goal exists, **When** an athlete views their week plan, **Then** they can see the goal preparation indicator and the competition session card (read-only access to the goal), but cannot edit the goal.
+4. **Given** a competition goal is being created, **When** the preparation window extends further back than existing weeks, **Then** only weeks that already exist in the plan receive the preparation indicator; no new weeks are auto-created.
+5. **Given** a goal already exists, **When** a coach edits the competition date or preparation weeks, **Then** the preparation indicators update on all previously and newly affected weeks.
+
+---
+
+### User Story 2 - Week Summary Sport Breakdown (Priority: P2)
+
+The week summary panel (currently showing aggregate stats) gains a toggle to switch between a single cumulative view (existing behaviour) and a per-sport breakdown view. In breakdown mode, each planned sport appears as a row with its own session count, planned distance, actual distance, and duration. Competition sessions are visually separated from training sessions within the breakdown.
+
+**Why this priority**: The breakdown view provides the coach with actionable, per-discipline insight during weekly planning. It extends the existing WeekSummary component in a backward-compatible way without requiring a new page.
+
+**Independent Test**: A week with sessions of two different sports can be viewed in breakdown mode, showing each sport's stats separately, with competition sessions grouped distinctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the week summary is displayed, **When** the coach clicks the "By Sport" toggle, **Then** the summary switches from cumulative stats to a per-sport breakdown, showing one row per discipline that has at least one session that week.
+2. **Given** breakdown mode is active, **When** the week contains a competition session, **Then** it appears in a separate "Competitions" row (or is highlighted within its sport row) with a visual distinction from training rows.
+3. **Given** breakdown mode is active, **When** the week has only one sport planned, **Then** the breakdown still shows correctly with a single sport row.
+4. **Given** the athlete views their week summary, **When** a breakdown mode toggle is present, **Then** they see the same breakdown view as the coach (read-only, no editing).
+5. **Given** the user switches between cumulative and breakdown modes, **Then** their preference persists for the duration of the session (does not reset on navigation).
+
+---
+
+### User Story 3 - Performance Analytics View (Priority: P3)
+
+A coach can open a dedicated analytics page for an athlete that displays performance data across a selectable time period (year, quarter, month, or a specific goal preparation period). The view shows training volume (distance, session count, duration) and completion rates. Competitions are shown as milestones on a timeline and can be analysed separately. The data can be filtered by sport discipline.
+
+**Why this priority**: The analytics view provides longitudinal insight for coaches to assess training effectiveness and plan future periods. It is a read-only view and does not block any other workflows.
+
+**Independent Test**: A coach with at least 4 weeks of session data for an athlete can open the analytics view, select a quarter period, filter by a single sport, and verify the totals match the sum of individual week summaries for that sport.
+
+**Acceptance Scenarios**:
+
+1. **Given** a coach is viewing an athlete's profile or week plan, **When** they navigate to the analytics view, **Then** they see a period selector (year / quarter / month / goal period) defaulting to the current month.
+2. **Given** the analytics view is open, **When** the coach selects "Year", **Then** the view shows monthly aggregated data for the current calendar year, with one column or bar per month.
+3. **Given** the analytics view is open, **When** the coach selects "Goal Period", **Then** a dropdown of all defined goals appears; selecting a goal shows data only for the preparation weeks of that goal.
+4. **Given** a period is selected, **When** the coach applies a sport filter (e.g. "Running only"), **Then** all metrics (distance, sessions, duration) recalculate to include only sessions of that sport.
+5. **Given** competitions exist within the selected period, **When** they are displayed in the analytics view, **Then** they appear as distinct milestone markers on the timeline (not counted in training totals) with their result distance/performance shown separately.
+6. **Given** no sessions exist for the selected period and filter combination, **When** the analytics view is shown, **Then** an empty-state message is displayed rather than a blank chart.
+
+---
+
+### Edge Cases
+
+- What happens when a competition date falls on a day that already has a training session? → Both can coexist; the competition session is added in addition to, not replacing, the existing training session.
+- What happens when a goal is deleted? → Competition session is removed from the day; preparation-week indicators are removed; historical analytics data retains the completed sessions but no longer marks them as competition-prep.
+- What happens when a goal's preparation window is set to 0 weeks? → Only the competition day receives the session; no weeks receive a preparation indicator.
+- What happens when two goals overlap in preparation windows? → Both goal indicators are shown simultaneously on shared weeks; the week summary breakdown shows each competition goal separately.
+- What happens when the athlete has no sessions in the selected analytics period? → An empty state is displayed with an actionable prompt (e.g. "No sessions planned for this periIt'sod").
+- What happens when a competition session result is not yet entered (future date)? → The competition appears as a planned milestone; result fields remain empty and editable once the date has passed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Goal Management**
+
+- **FR-001**: Both coaches and athletes MUST be able to create a goal by specifying: name, discipline (any supported sport), competition date, goal distance/target, and preparation window in weeks.
+- **FR-002**: Only coaches MUST be able to edit or delete a goal; athletes have read-only access.
+- **FR-003**: The system MUST create a Competition session on the goal's competition date automatically when a goal is saved.
+- **FR-004**: The system MUST display a preparation indicator (e.g. badge or banner) on every week within the goal's preparation window.
+- **FR-005**: Competition sessions MUST be visually distinguished from training sessions across all views (week grid, week summary, analytics).
+- **FR-006**: A Competition session MUST record distance and performance (time/pace) separately from training volume; it MUST NOT be aggregated into planned training totals.
+- **FR-007**: When a goal is edited (date or preparation window changes), all affected week indicators and the competition session MUST update accordingly.
+- **FR-008**: When a goal is deleted, the competition session and all preparation-week indicators MUST be removed.
+
+**Week Summary Breakdown**
+
+- **FR-009**: The week summary MUST offer a toggle between "Cumulative" (existing behaviour) and "By Sport" views.
+- **FR-010**: In "By Sport" view, the summary MUST show one row per discipline that has at least one session planned or completed in that week, displaying: session count, planned distance, actual distance, and duration.
+- **FR-011**: Competition sessions MUST appear as a separate, visually distinct row in "By Sport" view.
+- **FR-012**: The toggle state MUST persist across week navigation within a session.
+
+**Performance Analytics**
+
+- **FR-013**: Coaches MUST be able to access a performance analytics view for each athlete they coach.
+- **FR-014**: The analytics view MUST support period selection: current year (monthly breakdown), current quarter (weekly breakdown), current month (daily breakdown), and goal period (prep weeks of a selected goal).
+- **FR-015**: The analytics view MUST display for the selected period: total distance, total sessions, total duration, and completion rate — all aggregated and broken down over time.
+- **FR-016**: The analytics view MUST support filtering by sport discipline; the "All Sports" option is the default.
+- **FR-017**: Competitions within the selected period MUST be shown as milestone markers on the timeline, not included in training volume totals.
+- **FR-018**: Competition milestones MUST display: discipline, goal distance, actual result distance/performance, and whether the goal was achieved.
+- **FR-019**: The analytics view MUST display an empty state when no sessions exist for the selected period and filter.
+
+### Key Entities
+
+- **Goal**: Represents a competition target. Attributes: name, discipline, competition date, preparation window (weeks), goal distance/target performance. Belongs to a coach–athlete relationship. Can have one Competition session.
+- **Competition Session**: A special session variant linked to a Goal. Attributes: discipline, date (equals goal date), goal distance, result distance, result performance (time/pace), notes. Not counted as a training session in volume aggregations.
+- **Goal Preparation Indicator**: A marker on a WeekPlan indicating it falls within a goal's preparation window. Attributes: reference to Goal, week number.
+- **Analytics Period**: A time range for the analytics view. Variants: year, quarter, month, goal period (references a Goal).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A coach can create a goal and see the competition session and preparation indicators appear across all relevant weeks within 30 seconds of saving.
+- **SC-002**: Coaches can switch between cumulative and breakdown views in the week summary without a page reload, and the transition completes within 300ms.
+- **SC-003**: A coach can open the analytics view, change the period, and apply a sport filter — the view updates within 2 seconds for datasets covering up to one year of sessions.
+- **SC-004**: 90% of coaches can set up a goal and verify the resulting competition session without needing help documentation, based on first-use observation.
+- **SC-005**: Competition sessions are never counted in training volume totals in either the week summary or analytics view — verified by a 100% pass rate on integration tests covering this boundary.
+- **SC-006**: All goal management and analytics interactions are available to coaches on both desktop and mobile screen sizes without layout breakage.
+
+## Assumptions
+
+- Athletes can view goals and competition sessions but cannot create, edit, or delete goals. This scope boundary prevents workflow conflicts between coach and athlete.
+- A Competition session is a first-class session type with its own distinct UI treatment, not a flag on an existing session type.
+- "Performance" for a competition session means time-based metrics (finish time, pace) appropriate to the discipline — not a generic score.
+- The analytics view is coach-only in the first version; athlete self-analytics may be added in a future iteration.
+- The analytics view does not require real-time data; data is fetched on page load and on filter/period changes.
+- The existing sport color system (run = blue, cycling = green, etc.) is reused for the breakdown rows and analytics charts. Competition sessions use a distinct gold/amber accent consistent with the trophy metaphor.
+- "Goal period" in the analytics period selector is only available if at least one goal exists for the athlete.
+- Multiple simultaneous goals are supported; there is no hard limit on the number of goals per athlete.

--- a/specs/014-goals-analytics/checklists/requirements.md
+++ b/specs/014-goals-analytics/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Goal Management & Analytics Dashboard
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/014-goals-analytics/contracts/analytics-api.md
+++ b/specs/014-goals-analytics/contracts/analytics-api.md
@@ -1,0 +1,127 @@
+# Contract: Analytics API (Supabase RPC)
+
+**Feature**: 014-goals-analytics
+**Date**: 2026-03-28
+
+## RPC: `get_analytics_summary`
+
+Server-side aggregation function for the analytics view. Called from `app/lib/queries/analytics.ts`.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| p_athlete_id | UUID | yes | Target athlete |
+| p_period | text | yes | One of: `'year'`, `'quarter'`, `'month'`, `'goal'` |
+| p_goal_id | UUID | no | Required when `p_period = 'goal'` |
+| p_training_type | text | no | Sport filter (omit for all sports) |
+| p_reference_date | date | no | Anchor date for period calculation (defaults to CURRENT_DATE) |
+
+### Return Shape
+
+```json
+{
+  "buckets": [
+    {
+      "label": "Jan",
+      "start_date": "2026-01-01",
+      "end_date": "2026-01-31",
+      "total_sessions": 12,
+      "completed_sessions": 10,
+      "total_distance_km": 85.5,
+      "total_duration_minutes": 420,
+      "completion_rate": 83.3
+    }
+  ],
+  "competitions": [
+    {
+      "goal_id": "uuid",
+      "goal_name": "Spring 10K",
+      "discipline": "run",
+      "competition_date": "2026-04-15",
+      "goal_distance_km": 10.0,
+      "goal_time_seconds": 3000,
+      "result_distance_km": 10.0,
+      "result_time_seconds": 2880,
+      "achievement_status": "achieved"
+    }
+  ],
+  "totals": {
+    "total_sessions": 48,
+    "completed_sessions": 40,
+    "total_distance_km": 350.2,
+    "total_duration_minutes": 1680,
+    "overall_completion_rate": 83.3
+  }
+}
+```
+
+### Period Bucketing Logic
+
+| Period | Buckets | Granularity |
+|--------|---------|-------------|
+| year | 12 | Monthly (Jan–Dec of reference year) |
+| quarter | ~13 | Weekly (13 weeks of reference quarter) |
+| month | ~30 | Daily (days of reference month) |
+| goal | N | Weekly (each prep week + competition week) |
+
+### Filtering Rules
+
+- When `p_training_type` is set, only sessions matching that type are counted in buckets and totals
+- Competition sessions (`goal_id IS NOT NULL`) are **always excluded** from bucket aggregations — they appear only in the `competitions` array
+- When `p_period = 'goal'`, the date range is derived from `goal.competition_date - (goal.preparation_weeks * 7 days)` through `goal.competition_date`
+
+### Auth
+
+- Caller must be authenticated (JWT via `auth.uid()`)
+- Function enforces: caller is the athlete OR caller is a coach of the athlete
+- Returns empty result (not error) if athlete has no data for the period
+
+## Goal CRUD Queries
+
+Standard Supabase client queries (not RPC). Documented for contract clarity.
+
+### Fetch Goals
+
+```
+SELECT id, athlete_id, created_by, name, discipline, competition_date,
+       preparation_weeks, goal_distance_km, goal_time_seconds, notes,
+       created_at, updated_at
+FROM goals
+WHERE athlete_id = :athleteId
+ORDER BY competition_date ASC
+```
+
+### Create Goal
+
+```
+INSERT INTO goals (athlete_id, created_by, name, discipline, competition_date,
+                   preparation_weeks, goal_distance_km, goal_time_seconds, notes)
+VALUES (:athleteId, :createdBy, :name, :discipline, :competitionDate,
+        :preparationWeeks, :goalDistanceKm, :goalTimeSeconds, :notes)
+RETURNING *
+```
+
+Side effect: After goal creation, a competition session must be created on the goal's competition date. This is handled client-side (two mutations in sequence) rather than via DB trigger, to keep the logic explicit and testable.
+
+### Update Goal
+
+```
+UPDATE goals
+SET name = :name, discipline = :discipline, competition_date = :competitionDate,
+    preparation_weeks = :preparationWeeks, goal_distance_km = :goalDistanceKm,
+    goal_time_seconds = :goalTimeSeconds, notes = :notes,
+    updated_at = NOW()
+WHERE id = :goalId
+RETURNING *
+```
+
+Side effect: If `competition_date` or `discipline` changed, the linked competition session must be updated (date moved, type changed). Handled client-side.
+
+### Delete Goal
+
+```
+DELETE FROM goals WHERE id = :goalId
+```
+
+The linked competition session's `goal_id` is set to NULL via `ON DELETE SET NULL` (preserving the session record if the athlete wants to keep it as a regular session, or the session can be explicitly deleted by the user).

--- a/specs/014-goals-analytics/data-model.md
+++ b/specs/014-goals-analytics/data-model.md
@@ -1,0 +1,245 @@
+# Data Model: Goal Management & Analytics Dashboard
+
+**Feature**: 014-goals-analytics
+**Date**: 2026-03-28
+
+## New Entities
+
+### Goal
+
+Represents a competition target set by a coach or self-plan athlete.
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| id | UUID | no | PK, auto-generated |
+| athlete_id | UUID | no | FK → auth.users(id), ON DELETE CASCADE |
+| created_by | UUID | no | FK → auth.users(id), ON DELETE SET NULL — the coach or self-plan athlete who created it |
+| name | text | no | e.g. "Spring 10K", "City Marathon" |
+| discipline | training_type | no | Uses existing enum — the sport of the competition |
+| competition_date | date | no | The date of the competition event |
+| preparation_weeks | integer | no | Number of weeks leading up to competition (0 = competition day only) |
+| goal_distance_km | decimal(8,2) | yes | Target distance (for distance-based sports) |
+| goal_time_seconds | integer | yes | Target finish time in seconds (for time-based goals) |
+| notes | text | yes | Free-text description or context |
+| created_at | timestamptz | no | Default NOW() |
+| updated_at | timestamptz | no | Default NOW(), auto-updated via trigger |
+
+**Constraints**:
+- `CHECK (preparation_weeks >= 0)`
+- `CHECK (goal_distance_km > 0 OR goal_distance_km IS NULL)`
+- `CHECK (goal_time_seconds > 0 OR goal_time_seconds IS NULL)`
+- Index on `(athlete_id, competition_date)`
+
+**RLS policies**:
+- SELECT: athlete can read own goals; coach can read goals of athletes they coach
+- INSERT: coach can create for their athletes; athlete can create for self if self-plan enabled
+- UPDATE: same as INSERT (creator or authorized user)
+- DELETE: same as INSERT
+
+### Competition Session Extension (on existing `training_sessions`)
+
+Rather than a new table, competition sessions are regular `training_sessions` rows with:
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| goal_id | UUID | yes | FK → goals(id), ON DELETE SET NULL — links session to its goal |
+
+When `goal_id IS NOT NULL`, the session is treated as a competition session. The `training_type` field uses the existing enum value matching the goal's discipline (e.g. `'run'` for a running competition).
+
+**Why not a new `competition` training type?** After research, adding `competition` to the `training_type` enum would break existing queries that aggregate by sport (e.g. "total running distance"). A running competition should still be `type = 'run'` but with `goal_id` set. The `goal_id` presence is the discriminator. The UI checks `goal_id IS NOT NULL` to apply competition styling.
+
+**Additional fields on `training_sessions`** (added via migration):
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| result_distance_km | decimal(8,2) | yes | Actual competition distance |
+| result_time_seconds | integer | yes | Actual finish time |
+| result_pace | text | yes | Formatted pace string (e.g. "4:30/km") |
+
+These fields are only meaningful when `goal_id IS NOT NULL`. For regular training sessions they remain NULL.
+
+**Index**: `idx_training_sessions_goal ON training_sessions(goal_id) WHERE goal_id IS NOT NULL`
+
+## Extended Entities
+
+### TrainingSession (TypeScript type extension)
+
+```
+TrainingSession {
+  ...existing fields...
+  goalId: string | null          // FK to Goal
+  resultDistanceKm: number | null
+  resultTimeSeconds: number | null
+  resultPace: string | null
+}
+```
+
+### WeekStats (TypeScript type extension)
+
+```
+WeekStats {
+  ...existing fields...
+  byType: Record<TrainingType, SportBreakdownEntry>
+  competitionSessions: CompetitionSummary[]
+}
+
+SportBreakdownEntry {
+  sessionCount: number
+  plannedDistanceKm: number
+  actualDistanceKm: number
+  totalDurationMinutes: number
+}
+
+CompetitionSummary {
+  sessionId: string
+  goalId: string
+  goalName: string
+  discipline: TrainingType
+  goalDistanceKm: number | null
+  resultDistanceKm: number | null
+  resultTimeSeconds: number | null
+  achievementStatus: 'achieved' | 'missed' | 'pending'
+}
+```
+
+## New TypeScript Types
+
+### Goal
+
+```
+Goal {
+  id: string
+  athleteId: string
+  createdBy: string
+  name: string
+  discipline: TrainingType
+  competitionDate: string         // ISO date YYYY-MM-DD
+  preparationWeeks: number
+  goalDistanceKm: number | null
+  goalTimeSeconds: number | null
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+}
+```
+
+### Input Types
+
+```
+CreateGoalInput {
+  athleteId: string
+  name: string
+  discipline: TrainingType
+  competitionDate: string
+  preparationWeeks: number
+  goalDistanceKm?: number
+  goalTimeSeconds?: number
+  notes?: string
+}
+
+UpdateGoalInput {
+  id: string
+  name?: string
+  discipline?: TrainingType
+  competitionDate?: string
+  preparationWeeks?: number
+  goalDistanceKm?: number | null
+  goalTimeSeconds?: number | null
+  notes?: string | null
+}
+```
+
+### Analytics Period Types
+
+```
+AnalyticsPeriod = 'year' | 'quarter' | 'month' | 'goal'
+
+AnalyticsParams {
+  athleteId: string
+  period: AnalyticsPeriod
+  goalId?: string              // Required when period = 'goal'
+  trainingType?: TrainingType  // Sport filter (omit for all sports)
+}
+
+AnalyticsBucket {
+  label: string               // e.g. "Jan", "W10", "Mon"
+  startDate: string
+  endDate: string
+  totalSessions: number
+  completedSessions: number
+  totalDistanceKm: number
+  totalDurationMinutes: number
+  completionRate: number       // 0–100
+}
+
+AnalyticsResponse {
+  buckets: AnalyticsBucket[]
+  competitions: CompetitionMilestone[]
+  totals: {
+    totalSessions: number
+    completedSessions: number
+    totalDistanceKm: number
+    totalDurationMinutes: number
+    overallCompletionRate: number
+  }
+}
+
+CompetitionMilestone {
+  goalId: string
+  goalName: string
+  discipline: TrainingType
+  competitionDate: string
+  goalDistanceKm: number | null
+  goalTimeSeconds: number | null
+  resultDistanceKm: number | null
+  resultTimeSeconds: number | null
+  achievementStatus: 'achieved' | 'missed' | 'pending'
+}
+```
+
+## Relationships
+
+```
+Goal (1) ←→ (0..1) TrainingSession  [via training_sessions.goal_id]
+Goal (1) ←→ (N) WeekPlan            [computed: weeks where week_start falls in prep window]
+auth.users (1) ←→ (N) Goal          [via goals.athlete_id]
+```
+
+## State Transitions
+
+### Goal Lifecycle
+
+```
+Created → Active (prep weeks in progress)
+  ├→ Competition Day (competition session exists, result pending)
+  │   ├→ Achieved (result meets/exceeds target)
+  │   └→ Missed (result below target)
+  └→ Deleted (cascade removes competition session link)
+```
+
+Achievement status is computed (not stored), derived from comparing `result_distance_km` / `result_time_seconds` against `goal_distance_km` / `goal_time_seconds`.
+
+## Query Key Extensions
+
+```
+queryKeys.goals = {
+  all: ['goals'] as const,
+  byAthlete: (athleteId: string) => ['goals', 'athlete', athleteId] as const,
+  byId: (goalId: string) => ['goals', goalId] as const,
+}
+
+queryKeys.analytics = {
+  all: ['analytics'] as const,
+  byParams: (params: AnalyticsParams) => ['analytics', params] as const,
+}
+```
+
+## Migration Plan
+
+Single migration file adding:
+1. `goals` table with constraints and RLS
+2. `goal_id` column on `training_sessions` (nullable FK)
+3. `result_distance_km`, `result_time_seconds`, `result_pace` columns on `training_sessions`
+4. Indexes on new columns
+5. Updated RLS policies on `training_sessions` for competition result editing
+6. Supabase RPC function `get_analytics_summary` for server-side period aggregation

--- a/specs/014-goals-analytics/plan.md
+++ b/specs/014-goals-analytics/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Goal Management & Analytics Dashboard
+
+**Branch**: `014-goals-analytics` | **Date**: 2026-03-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/014-goals-analytics/spec.md`
+
+## Summary
+
+Add competition goals with automatic preparation-window tracking, extend the week summary with a per-sport breakdown toggle, and provide a longitudinal analytics view for coaches and athletes. The implementation adds a `goals` table, a `competition` session variant, a sport-breakdown computation utility, and a new analytics route — all following existing query/hook/component patterns.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (strict)
+**Primary Dependencies**: React 19, React Router 7 (SPA), TanStack Query 5, shadcn/ui (New York), i18next, date-fns 4, Zod 4
+**Storage**: Supabase (PostgreSQL) with RLS; existing `week_plans` + `training_sessions` tables
+**Testing**: Vitest (unit in `app/test/unit/`, integration in `app/test/integration/`)
+**Target Platform**: Web (SPA), desktop + mobile responsive
+**Project Type**: Web application (SPA, no SSR)
+**Performance Goals**: Optimistic updates within one render frame (~16ms); analytics view loads within 2s for one year of data
+**Constraints**: No new major dependencies; all new code must pass `pnpm typecheck`; both `en/` and `pl/` i18n files updated simultaneously
+**Scale/Scope**: Single-athlete view (coach views one athlete at a time); tens of goals per athlete, hundreds of sessions per year
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Lean & Purposeful | PASS | Every addition maps to a spec requirement (FR-001–FR-021). No speculative abstractions. |
+| II. Configuration Over Hardcoding | PASS | Competition colors go in `training-types.ts` config. Sport breakdown reads from existing config. No inline color literals. i18n added to both `en/` and `pl/`. |
+| III. Type Safety & Boundary Validation | PASS | New `Goal` type, `CompetitionData` variant in discriminated union, Zod validation at DB boundary, row mappers for new tables. |
+| IV. Modularity & Testability | PASS | Goals go through `queries/goals.ts` → `hooks/useGoals.ts`. Mock implementation first. Full optimistic-update cycle on all mutations. |
+| V. Performance & Operational Discipline | PASS | No new heavy dependencies. Analytics queries select specific columns. Optimistic updates for goal CRUD. `pnpm typecheck` gate. |
+| Security | PASS | RLS on `goals` table scoped to athlete. Self-plan flag checked at query level. No new public forms (no honeypot needed). |
+| Merge Gates | PASS | Type check, mock parity, i18n, optimistic updates, no hardcoded colors, no direct DB in components, constitution check — all covered in design. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-goals-analytics/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── analytics-api.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── types/
+│   └── training.ts                    # Extended: Goal type, competition result fields on TrainingSession
+├── lib/
+│   ├── queries/
+│   │   ├── keys.ts                    # Extended: goalKeys, analyticsKeys
+│   │   ├── goals.ts                   # NEW: goal CRUD (real + mock)
+│   │   └── analytics.ts              # NEW: analytics aggregation queries (real + mock)
+│   ├── hooks/
+│   │   ├── useGoals.ts               # NEW: useGoals, useCreateGoal, useUpdateGoal, useDeleteGoal
+│   │   ├── useAnalytics.ts           # NEW: useAnalytics query hook
+│   │   └── useWeekView.ts            # Extended: sport breakdown stats computation
+│   ├── utils/
+│   │   ├── training-types.ts         # Extended: competition config (gold/amber)
+│   │   ├── analytics.ts              # NEW: pure aggregation helpers
+│   │   └── goals.ts                  # NEW: goal achievement logic, prep-window computation
+│   └── mock-data/
+│       ├── goals.ts                  # NEW: mock goals store + seed data
+│       └── analytics.ts             # NEW: mock analytics responses
+├── components/
+│   ├── calendar/
+│   │   ├── WeekSummary.tsx           # Extended: sport breakdown toggle
+│   │   ├── SportBreakdown.tsx        # NEW: per-sport stats rows
+│   │   ├── SessionCard.tsx           # Extended: competition visual treatment
+│   │   └── GoalPrepBanner.tsx        # NEW: preparation-week indicator banner
+│   ├── goals/
+│   │   ├── GoalDialog.tsx            # NEW: create/edit goal form modal
+│   │   ├── GoalCard.tsx              # NEW: goal summary card
+│   │   └── GoalList.tsx              # NEW: list of goals for an athlete
+│   └── analytics/
+│       ├── AnalyticsView.tsx         # NEW: main analytics layout
+│       ├── PeriodSelector.tsx        # NEW: year/quarter/month/goal-period picker
+│       ├── SportFilter.tsx           # NEW: sport discipline filter
+│       ├── VolumeChart.tsx           # NEW: training volume over time
+│       └── CompetitionMilestone.tsx  # NEW: competition marker on timeline
+├── routes/
+│   ├── coach/
+│   │   └── analytics.tsx             # NEW: coach analytics route
+│   └── athlete/
+│       └── analytics.tsx             # NEW: athlete analytics route
+└── i18n/resources/
+    ├── en/
+    │   ├── coach.json                # Extended: analytics, breakdown keys
+    │   ├── athlete.json              # Extended: analytics keys
+    │   └── training.json             # Extended: competition, goal keys
+    └── pl/
+        ├── coach.json                # Extended: analytics, breakdown keys
+        ├── athlete.json              # Extended: analytics keys
+        └── training.json             # Extended: competition, goal keys
+
+supabase/
+└── migrations/
+    └── XXX_create_goals.sql          # NEW: goals table + RLS policies
+```
+
+**Structure Decision**: Follows existing SPA architecture. Goals get their own query/hook/mock/component files. Analytics components are isolated in `components/analytics/`. No new directories outside the established pattern. The only new route is `analytics.tsx` under both coach and athlete namespaces.

--- a/specs/014-goals-analytics/quickstart.md
+++ b/specs/014-goals-analytics/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: Goal Management & Analytics Dashboard
+
+**Feature**: 014-goals-analytics
+**Branch**: `014-goals-analytics`
+
+## Prerequisites
+
+- Node.js 18+, pnpm installed
+- Supabase CLI installed (for migrations)
+- `.env.local` with valid Supabase credentials (or omit for mock mode)
+
+## Setup
+
+```bash
+git checkout 014-goals-analytics
+pnpm install
+```
+
+## Development Flow
+
+### 1. Run the migration (if using real Supabase)
+
+```bash
+supabase db push
+```
+
+Or apply manually via Supabase dashboard SQL editor.
+
+### 2. Start dev server
+
+```bash
+pnpm dev
+```
+
+Mock mode activates automatically when Supabase credentials are absent.
+
+### 3. Verify new features
+
+**Goals (P1)**:
+- Navigate to `/coach/week/:weekId` (or athlete equivalent)
+- Look for the "Add Goal" button (near week navigation or in a goals panel)
+- Create a goal: name, discipline, date, distance, prep weeks
+- Verify: competition session appears on the target day with gold/amber styling
+- Verify: prep-week banners appear on weeks within the preparation window
+
+**Sport Breakdown (P2)**:
+- On any week view, look for the "By Sport" toggle in the WeekSummary card header
+- Toggle to see per-sport rows with session count, distance, duration
+- Verify: competition sessions show in a distinct row
+
+**Analytics (P3)**:
+- Navigate to `/coach/analytics` or `/athlete/analytics`
+- Select a period (year/quarter/month/goal)
+- Apply a sport filter
+- Verify: chart shows volume data, competitions appear as milestones
+
+### 4. Run checks
+
+```bash
+pnpm typecheck   # Must pass
+pnpm test         # Run all tests
+```
+
+## Key Files to Review
+
+| Area | Files |
+|------|-------|
+| Types | `app/types/training.ts` — Goal, CompetitionSession extensions |
+| Queries | `app/lib/queries/goals.ts`, `app/lib/queries/analytics.ts` |
+| Hooks | `app/lib/hooks/useGoals.ts`, `app/lib/hooks/useAnalytics.ts` |
+| Utils | `app/lib/utils/goals.ts`, `app/lib/utils/analytics.ts` |
+| Components | `app/components/goals/`, `app/components/analytics/` |
+| Week ext. | `app/components/calendar/WeekSummary.tsx`, `SportBreakdown.tsx`, `GoalPrepBanner.tsx` |
+| Routes | `app/routes/coach/analytics.tsx`, `app/routes/athlete/analytics.tsx` |
+| Config | `app/lib/utils/training-types.ts` — competition color config |
+| i18n | `app/i18n/resources/en/training.json`, `pl/training.json` |
+| Migration | `supabase/migrations/XXX_create_goals.sql` |
+| Mock data | `app/lib/mock-data/goals.ts`, `app/lib/mock-data/analytics.ts` |
+
+## Architecture Notes
+
+- **Goal ↔ Session link**: `training_sessions.goal_id` FK. A session with `goal_id IS NOT NULL` is a competition session.
+- **No new training type enum**: Competitions use the existing discipline type (e.g. `run`) + `goal_id` as the discriminator.
+- **Prep-week indicators**: Computed at query time from `goal.competition_date` and `goal.preparation_weeks`. Not materialized.
+- **Analytics aggregation**: Server-side via `get_analytics_summary` RPC for period views. Client-side computation for single-week sport breakdown.
+- **Achievement status**: Computed (not stored) by comparing result vs goal target.

--- a/specs/014-goals-analytics/research.md
+++ b/specs/014-goals-analytics/research.md
@@ -1,0 +1,93 @@
+# Research: Goal Management & Analytics Dashboard
+
+**Feature**: 014-goals-analytics
+**Date**: 2026-03-28
+
+## R-001: Competition Session — New Type vs Flag on Existing Session
+
+**Decision**: Add `competition` as a new `TrainingType` variant in the existing discriminated union, not a boolean flag on `TrainingSession`.
+
+**Rationale**: The spec states "A Competition session is a first-class session type with its own distinct UI treatment." Adding it as a `TrainingType` value means:
+- It flows naturally through the existing `switch(trainingType)` rendering in `SessionFormFields`
+- The existing `trainingTypeConfig` system provides color/icon config out of the box
+- Query filtering by type works without additional predicates
+- The DB enum `training_type` already supports extension (added `walk`, `hike`, `other` in migration 013)
+
+**Alternatives considered**:
+- Boolean `is_competition` flag on `TrainingSession` — rejected because competition sessions have different aggregation rules (excluded from training volume), and a flag would require filter conditions everywhere stats are computed
+- Separate `competition_sessions` table — rejected as over-engineering; competitions share 90% of fields with training sessions
+
+## R-002: Goal Data Model — Standalone Table vs WeekPlan Extension
+
+**Decision**: Standalone `goals` table with FK to `athlete_id`. Competition session links back to goal via `goal_id` FK on `training_sessions`.
+
+**Rationale**: Goals span multiple weeks (preparation window) and have their own lifecycle (create → prep → compete → achieved/missed). Embedding goal data in `week_plans` would create denormalization across all prep weeks. A standalone table with a computed relationship to weeks (via date range) is cleaner.
+
+**Alternatives considered**:
+- JSONB `goals` array on `week_plans` — rejected because goals span weeks, creating update/sync complexity
+- Separate `goal_weeks` join table — rejected for now; the relationship can be computed from `goal.competition_date` and `goal.preparation_weeks` without materializing it
+
+## R-003: Preparation-Week Indicators — Materialized vs Computed
+
+**Decision**: Computed at query time, not materialized in a join table.
+
+**Rationale**: Given the scale (tens of goals, ~52 weeks/year), computing which weeks fall in a goal's prep window is trivial: `week_start >= (competition_date - preparation_weeks * 7) AND week_start < competition_date`. This avoids a join table that would need updating whenever a goal's date or window changes. The computation happens in the query layer (`queries/goals.ts`) and the result is cached by TanStack Query.
+
+**Alternatives considered**:
+- `goal_week_plans` join table — rejected because it duplicates information derivable from two scalar fields and adds update complexity on goal edits
+
+## R-004: Sport Breakdown Stats — Where to Compute
+
+**Decision**: Compute in a pure utility function `computeSportBreakdown(sessions: TrainingSession[])` in `app/lib/utils/analytics.ts`, called from `useWeekView` hook.
+
+**Rationale**: The existing `WeekStats` is computed in `useWeekView`. Extending it with a `byType` breakdown keeps the computation collocated. A pure function is testable without React. No server-side aggregation needed for a single week's sessions (typically <20 sessions).
+
+**Alternatives considered**:
+- Server-side SQL aggregation — unnecessary for single-week view; adds latency and a new endpoint
+- Denormalized `week_sport_breakdown` table — over-engineering for <20 sessions per week
+
+## R-005: Analytics Aggregation — Client-Side vs Server-Side
+
+**Decision**: Server-side aggregation via Supabase RPC (or a view) for period analytics; client-side for the single-week sport breakdown.
+
+**Rationale**: Analytics spans up to a year of data (hundreds of sessions). Fetching all raw sessions to the client and aggregating in JS would be wasteful. A Supabase RPC function can aggregate distance, duration, session count, and completion rate grouped by month/week/day and optionally filtered by training type — returning a compact payload. The RPC follows the same pattern as other Supabase query functions (real + mock, row mapper).
+
+**Alternatives considered**:
+- Client-side aggregation of all sessions — rejected for year-scale data; too much data transfer
+- Supabase Edge Function — unnecessary; a simple RPC/view suffices for read-only aggregation
+- Materialized view — premature optimization; RPC with proper indexes is sufficient at current scale
+
+## R-006: Analytics Charting — Library Choice
+
+**Decision**: Use Recharts (lightweight, React-native, tree-shakeable).
+
+**Rationale**: The analytics view needs bar charts (volume over time) and milestone markers. Recharts is ~45KB gzipped (within the 50KB constitution limit), built for React, and widely used. It supports responsive containers, tooltips, and custom shapes for milestone markers. No other charting library is currently in the project.
+
+**Alternatives considered**:
+- Chart.js + react-chartjs-2 — heavier bundle (~65KB), canvas-based (harder to style with Tailwind)
+- D3 directly — too low-level for this use case; would require building chart primitives from scratch
+- Nivo — larger bundle, more features than needed
+- No library (CSS-only bars) — insufficient for timeline milestones and tooltips; would be reinventing
+
+**Bundle impact**: ~45KB gzipped. Documented per Principle V. Acceptable given it's the only charting need in the app.
+
+## R-007: Goal Achievement Logic
+
+**Decision**: Pure function comparing result vs target, returning `'achieved' | 'missed' | 'pending'`.
+
+**Rationale**: Per spec clarification, achievement is automatic. The logic is discipline-aware:
+- Distance-based goals (run, cycling, swimming): `resultDistance >= goalDistance` → achieved
+- Time-based goals: `resultTime <= goalTime` → achieved (lower is better)
+- If no result entered yet: `'pending'`
+
+This is a pure utility in `app/lib/utils/goals.ts`, easily unit-testable.
+
+## R-008: Strava Auto-Link for Competition Sessions
+
+**Decision**: Extend existing `strava-sync` Edge Function to check for competition sessions on the synced date.
+
+**Rationale**: The Edge Function already maps Strava activity types to `TrainingType` and matches by week/day. Adding a check for competition sessions on the same date with matching discipline is a small extension. When ambiguous (wrong sport or multiple activities), the function returns a `needs_confirmation` status that the client handles with a prompt dialog.
+
+**Alternatives considered**:
+- Client-side matching after sync — would require fetching raw Strava activities to the client, violating the Edge Function encapsulation
+- Separate Edge Function for competition sync — unnecessary duplication; the existing sync already handles the matching logic

--- a/specs/014-goals-analytics/spec.md
+++ b/specs/014-goals-analytics/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Goal Management & Analytics Dashboard
+
+**Feature Branch**: `014-goals-analytics`
+**Created**: 2026-03-28
+**Status**: Draft
+**Input**: User description: "Design an UX for goal management and analytics dashboard with an athlete performance. 1. Coach can see cumulative plan for all disciplines but also can switch to see a breakdown for all planned sports as part of a week summary. 2. Coach or athlete can set a goal for a selected number of weeks, this goal is visible in every week where an athlete preps for it. The day of the goal has a special session called competition, distinguished on the UI. It can be any of the disciplines. But its distance and performance is treated separately, not as training but as competition. The competitions can then be analysed separately and are distinguished in week summary too. 3. Coach can open a year/quarter/month/goal period view to analyse athlete performance. The performance can be filtered by sport. 4. Make sure the UX is consistent and follow best practices. Reuse existing user journeys/UI patterns where possible."
+
+## Clarifications
+
+### Session 2026-03-28
+
+- Q: Can athletes create, edit, and delete goals? → A: Yes — athletes can create, edit, and delete goals when the self-plan flag is enabled on their profile.
+- Q: Is the analytics view restricted to coaches only? → A: No — the analytics view is accessible to both coaches and athletes; athletes see their own data.
+- Q: Who controls the self-plan flag? → A: Existing functionality — this feature only consumes the flag; nothing new is built around managing it.
+- Q: Who can enter competition results (actual distance/performance)? → A: Both coaches and athletes, regardless of self-plan flag. Competition result entry follows the same pattern as training sessions, including existing integrations (e.g. Strava sync).
+- Q: How should Strava sync handle an activity on competition day? → A: Auto-link if discipline matches; show a confirmation prompt if ambiguous (wrong sport or multiple activities that day).
+- Q: How is "goal achieved" determined for the analytics milestone display? → A: Automatic — the system compares result distance/time against the goal target and sets the achieved status accordingly.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Set a Competition Goal (Priority: P1)
+
+A coach or athlete creates a goal (an upcoming competition event) by specifying the competition date, sport discipline, goal distance, and a preparation window (number of weeks leading up to the competition). Once saved, every week within the preparation window displays a banner or indicator linking it to the goal, and the competition day itself contains a special "Competition" session card that is visually distinct from training sessions.
+
+Athletes with the self-plan flag enabled have the same create/edit/delete rights over goals as coaches.
+
+**Why this priority**: Goals are the anchor for the entire feature. Without goals, there are no competition sessions, no goal-period views, and no contextualisation of the week summary breakdown. It is the foundational data creation flow.
+
+**Independent Test**: A coach or self-plan athlete can create a goal with a future date, verify the competition session appears on the correct day, and confirm prep-week indicators appear on all weeks within the preparation window.
+
+**Acceptance Scenarios**:
+
+1. **Given** a coach is viewing a week plan, **When** they open the goal creation dialog and fill in discipline (e.g. running), competition date, goal distance, and preparation weeks (e.g. 8), **Then** the competition session appears on the competition day and all 8 preceding weeks display a goal preparation indicator.
+2. **Given** a goal exists, **When** the competition day is viewed in the week grid, **Then** the session card is styled distinctly (e.g. trophy/medal icon, gold/accent border) and labelled "Competition" instead of a standard session type name.
+3. **Given** an athlete has the self-plan flag enabled, **When** they open the goal creation dialog and save a goal, **Then** the competition session and preparation indicators appear identically to when a coach creates the goal.
+4. **Given** an athlete does NOT have the self-plan flag enabled, **When** they view a week plan that contains a goal set by their coach, **Then** they can see the goal preparation indicator and competition session card but have no create, edit, or delete controls for the goal.
+5. **Given** a competition goal is being created, **When** the preparation window extends further back than existing weeks, **Then** only weeks that already exist in the plan receive the preparation indicator; no new weeks are auto-created.
+6. **Given** a goal already exists, **When** the goal creator (coach or self-plan athlete) edits the competition date or preparation weeks, **Then** the preparation indicators update on all previously and newly affected weeks.
+
+---
+
+### User Story 2 - Week Summary Sport Breakdown (Priority: P2)
+
+The week summary panel (currently showing aggregate stats) gains a toggle to switch between a single cumulative view (existing behaviour) and a per-sport breakdown view. In breakdown mode, each planned sport appears as a row with its own session count, planned distance, actual distance, and duration. Competition sessions are visually separated from training sessions within the breakdown.
+
+**Why this priority**: The breakdown view provides the coach with actionable, per-discipline insight during weekly planning. It extends the existing WeekSummary component in a backward-compatible way without requiring a new page.
+
+**Independent Test**: A week with sessions of two different sports can be viewed in breakdown mode, showing each sport's stats separately, with competition sessions grouped distinctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the week summary is displayed, **When** the coach clicks the "By Sport" toggle, **Then** the summary switches from cumulative stats to a per-sport breakdown, showing one row per discipline that has at least one session that week.
+2. **Given** breakdown mode is active, **When** the week contains a competition session, **Then** it appears in a separate "Competitions" row (or is highlighted within its sport row) with a visual distinction from training rows.
+3. **Given** breakdown mode is active, **When** the week has only one sport planned, **Then** the breakdown still shows correctly with a single sport row.
+4. **Given** the athlete views their week summary, **When** a breakdown mode toggle is present, **Then** they see the same breakdown view as the coach (read-only when self-plan is disabled).
+5. **Given** the user switches between cumulative and breakdown modes, **Then** their preference persists for the duration of the session (does not reset on navigation).
+
+---
+
+### User Story 3 - Performance Analytics View (Priority: P3)
+
+Both coaches and athletes can access a performance analytics view that displays training data across a selectable time period (year, quarter, month, or a specific goal preparation period). Coaches access it for any athlete they coach; athletes access it for their own data. The view shows training volume (distance, session count, duration) and completion rates. Competitions are shown as milestones on a timeline and can be analysed separately. The data can be filtered by sport discipline.
+
+**Why this priority**: The analytics view provides longitudinal insight to assess training effectiveness and plan future periods. It is a read-only view and does not block any other workflows.
+
+**Independent Test**: A user (coach or athlete) with at least 4 weeks of session data can open the analytics view, select a quarter period, filter by a single sport, and verify the totals match the sum of individual week summaries for that sport.
+
+**Acceptance Scenarios**:
+
+1. **Given** a coach is viewing an athlete's profile or week plan, **When** they navigate to the analytics view, **Then** they see a period selector (year / quarter / month / goal period) defaulting to the current month.
+2. **Given** an athlete is viewing their own week plan or profile, **When** they navigate to the analytics view, **Then** they see the same period selector and filters as a coach, showing only their own data.
+3. **Given** the analytics view is open, **When** the user selects "Year", **Then** the view shows monthly aggregated data for the current calendar year, with one column or bar per month.
+4. **Given** the analytics view is open, **When** the user selects "Goal Period", **Then** a dropdown of all defined goals for the athlete appears; selecting a goal shows data only for the preparation weeks of that goal.
+5. **Given** a period is selected, **When** the user applies a sport filter (e.g. "Running only"), **Then** all metrics (distance, sessions, duration) recalculate to include only sessions of that sport.
+6. **Given** competitions exist within the selected period, **When** they are displayed in the analytics view, **Then** they appear as distinct milestone markers on the timeline (not counted in training totals) with their result distance/performance shown separately.
+7. **Given** no sessions exist for the selected period and filter combination, **When** the analytics view is shown, **Then** an empty-state message is displayed rather than a blank chart.
+
+---
+
+### Edge Cases
+
+- What happens when a competition date falls on a day that already has a training session? → Both can coexist; the competition session is added in addition to, not replacing, the existing training session.
+- What happens when a goal is deleted? → Competition session is removed from the day; preparation-week indicators are removed; historical analytics data retains the completed sessions but no longer marks them as competition-prep.
+- What happens when a goal's preparation window is set to 0 weeks? → Only the competition day receives the session; no weeks receive a preparation indicator.
+- What happens when two goals overlap in preparation windows? → Both goal indicators are shown simultaneously on shared weeks; the week summary breakdown shows each competition goal separately.
+- What happens when the athlete has no sessions in the selected analytics period? → An empty state is displayed with an actionable prompt (e.g. "No sessions planned for this period").
+- What happens when a competition session result is not yet entered (future date)? → The competition appears as a planned milestone; result fields remain empty and editable once the date has passed.
+- What happens when Strava syncs multiple activities on competition day? → The system prompts the user to select which activity to link to the competition session.
+- What happens when a Strava activity on competition day has a different discipline than the competition session? → The system shows a confirmation prompt rather than auto-linking.
+- What happens when the self-plan flag is disabled on an athlete who already has goals they created? → Their existing goals remain visible and active; they lose the ability to create, edit, or delete goals until the flag is re-enabled.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Goal Management**
+
+- **FR-001**: Coaches MUST be able to create a goal by specifying: name, discipline (any supported sport), competition date, goal distance/target, and preparation window in weeks.
+- **FR-002**: Athletes with the self-plan flag enabled MUST be able to create, edit, and delete their own goals with the same capabilities as coaches.
+- **FR-003**: Athletes without the self-plan flag enabled have read-only access to goals; they MUST NOT see create, edit, or delete controls.
+- **FR-004**: The system MUST create a Competition session on the goal's competition date automatically when a goal is saved.
+- **FR-005**: The system MUST display a preparation indicator (e.g. badge or banner) on every week within the goal's preparation window.
+- **FR-006**: Competition sessions MUST be visually distinguished from training sessions across all views (week grid, week summary, analytics).
+- **FR-007**: A Competition session MUST record distance and performance (time/pace) separately from training volume; it MUST NOT be aggregated into planned training totals.
+- **FR-007a**: Both coaches and athletes MUST be able to enter or edit competition results (actual distance, time/pace), regardless of the self-plan flag.
+- **FR-007b**: Competition sessions MUST support the same external sync integrations (e.g. Strava) as training sessions for populating result data.
+- **FR-008**: When a goal is edited (date or preparation window changes), all affected week indicators and the competition session MUST update accordingly.
+- **FR-009**: When a goal is deleted, the competition session and all preparation-week indicators MUST be removed.
+
+**Week Summary Breakdown**
+
+- **FR-010**: The week summary MUST offer a toggle between "Cumulative" (existing behaviour) and "By Sport" views.
+- **FR-011**: In "By Sport" view, the summary MUST show one row per discipline that has at least one session planned or completed in that week, displaying: session count, planned distance, actual distance, and duration.
+- **FR-012**: Competition sessions MUST appear as a separate, visually distinct row in "By Sport" view.
+- **FR-013**: The toggle state MUST persist across week navigation within a session.
+
+**Performance Analytics**
+
+- **FR-014**: Coaches MUST be able to access a performance analytics view for each athlete they coach.
+- **FR-015**: Athletes MUST be able to access a performance analytics view for their own data.
+- **FR-016**: The analytics view MUST support period selection: current year (monthly breakdown), current quarter (weekly breakdown), current month (daily breakdown), and goal period (prep weeks of a selected goal).
+- **FR-017**: The analytics view MUST display for the selected period: total distance, total sessions, total duration, and completion rate — all aggregated and broken down over time.
+- **FR-018**: The analytics view MUST support filtering by sport discipline; the "All Sports" option is the default.
+- **FR-019**: Competitions within the selected period MUST be shown as milestone markers on the timeline, not included in training volume totals.
+- **FR-020**: Competition milestones MUST display: discipline, goal distance, actual result distance/performance, and whether the goal was achieved. Achievement is determined automatically by the system — a goal is achieved when the result meets or exceeds the goal target (distance ≥ goal distance, or finish time ≤ goal time for time-based targets).
+- **FR-021**: The analytics view MUST display an empty state when no sessions exist for the selected period and filter.
+
+### Key Entities
+
+- **Goal**: Represents a competition target. Attributes: name, discipline, competition date, preparation window (weeks), goal distance/target performance. Belongs to a coach–athlete relationship. Editable by coaches and by athletes when self-plan is enabled. Can have one Competition session.
+- **Competition Session**: A special session variant linked to a Goal. Attributes: discipline, date (equals goal date), goal distance, result distance, result performance (time/pace), notes, external sync reference (e.g. Strava activity ID). Not counted as a training session in volume aggregations. Results can be entered manually by coaches or athletes, or synced via existing integrations.
+- **Goal Preparation Indicator**: A marker on a WeekPlan indicating it falls within a goal's preparation window. Attributes: reference to Goal, week number.
+- **Analytics Period**: A time range for the analytics view. Variants: year, quarter, month, goal period (references a Goal).
+- **Self-Plan Flag**: A per-athlete setting that, when enabled, grants the athlete the same goal management rights as a coach for their own training plan.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A coach or self-plan athlete can create a goal and see the competition session and preparation indicators appear across all relevant weeks within 30 seconds of saving.
+- **SC-002**: Users can switch between cumulative and breakdown views in the week summary without a page reload, and the transition completes within 300ms.
+- **SC-003**: A user can open the analytics view, change the period, and apply a sport filter — the view updates within 2 seconds for datasets covering up to one year of sessions.
+- **SC-004**: 90% of users (coaches and athletes) can set up a goal and verify the resulting competition session without needing help documentation, based on first-use observation.
+- **SC-005**: Competition sessions are never counted in training volume totals in either the week summary or analytics view — verified by a 100% pass rate on integration tests covering this boundary.
+- **SC-006**: All goal management and analytics interactions are available to both coaches and athletes on desktop and mobile screen sizes without layout breakage.
+
+## Assumptions
+
+- A Competition session is a first-class session type with its own distinct UI treatment, not a flag on an existing session type.
+- "Performance" for a competition session means time-based metrics (finish time, pace) appropriate to the discipline — not a generic score.
+- The analytics view does not require real-time data; data is fetched on page load and on filter/period changes.
+- The existing sport color system (run = blue, cycling = green, etc.) is reused for the breakdown rows and analytics charts. Competition sessions use a distinct gold/amber accent consistent with the trophy metaphor.
+- "Goal period" in the analytics period selector is only available if at least one goal exists for the athlete.
+- Multiple simultaneous goals are supported; there is no hard limit on the number of goals per athlete.
+- The self-plan flag is an existing per-athlete attribute on the athlete profile; this feature consumes it but does not introduce it.

--- a/specs/014-goals-analytics/tasks.md
+++ b/specs/014-goals-analytics/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Goal Management & Analytics Dashboard
+
+**Input**: Design documents from `/specs/014-goals-analytics/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓, quickstart.md ✓
+
+**Organization**: Tasks grouped by user story (US1 → US2 → US3) to enable independent, incremental delivery.
+
+**Tests**: Unit tests for pure functions and row mappers (`app/test/unit/`). Integration tests for the optimistic-update hook cycle and the WeekSummary toggle (`app/test/integration/`). All test tasks are written before their implementations (TDD: confirm fail → implement → confirm pass).
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no shared dependency)
+- **[Story]**: Which user story this task belongs to
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add the one new dependency and create the database migration.
+
+- [X] T001 Add Recharts dependency via `pnpm add recharts` and verify it appears in `package.json` (~45KB gzip; documented in research.md R-006 per constitution Principle V)
+- [X] T002 Create `supabase/migrations/XXX_goals_and_competition.sql`: `goals` table (id, athlete_id, created_by, name, discipline, competition_date, preparation_weeks, goal_distance_km, goal_time_seconds, notes, created_at, updated_at), FK + check constraints, indexes, RLS policies (coach and self-plan athlete access); add `goal_id UUID REFERENCES goals(id) ON DELETE SET NULL`, `result_distance_km`, `result_time_seconds`, `result_pace` columns to `training_sessions`; add `get_analytics_summary` SQL RPC function per `contracts/analytics-api.md` specification
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: TypeScript types, query keys, utility skeletons, and mock data that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Extend `app/types/training.ts`: add `Goal`, `CreateGoalInput`, `UpdateGoalInput` types per `data-model.md`; add `AnalyticsPeriod`, `AnalyticsParams`, `AnalyticsBucket`, `AnalyticsResponse`, `CompetitionMilestone`, `SportBreakdownEntry`, `CompetitionSummary` types; extend `TrainingSession` with `goalId: string | null`, `resultDistanceKm: number | null`, `resultTimeSeconds: number | null`, `resultPace: string | null`; extend `WeekStats` with `byType: Partial<Record<TrainingType, SportBreakdownEntry>>` and `competitionSessions: CompetitionSummary[]`
+- [X] T004 [P] Extend `app/lib/queries/keys.ts`: add `queryKeys.goals` (`all`, `byAthlete(athleteId)`, `byId(goalId)`) and `queryKeys.analytics` (`all`, `byParams(params)`) following the existing factory pattern with `as const`
+- [X] T005 [P] Create `app/lib/mock-data/goals.ts`: in-memory `Map<string, Goal>`, `resetMockGoals()` with deep-clone seed, `mockFetchGoals(athleteId)`, `mockCreateGoal(input)`, `mockUpdateGoal(input)`, `mockDeleteGoal(id)` — seed with 2 goals for `athlete-1` (one upcoming run competition 8 weeks out, one past cycling competition with result filled)
+- [X] T006 [P] Create `app/lib/mock-data/analytics.ts`: `mockGetAnalytics(params)` returning hardcoded `AnalyticsResponse` with realistic bucket data for each period type and 2 competition milestones matching the mock goals seed
+- [X] T007 [P] Write unit tests for `app/lib/utils/goals.ts` in `app/test/unit/utils/goals.test.ts` — confirm they FAIL before T008: `computeGoalAchievement` — (a) `'pending'` when session has no result, (b) `'achieved'` when `resultDistanceKm >= goalDistanceKm`, (c) `'missed'` when `resultDistanceKm < goalDistanceKm`, (d) `'achieved'` when `resultTimeSeconds <= goalTimeSeconds`, (e) `'missed'` when `resultTimeSeconds > goalTimeSeconds`, (f) `'pending'` when goal has no target set; `isWeekInPrepWindow` — (g) `true` for week inside window, (h) `false` for the competition week itself, (i) `false` for week after competition, (j) `false` when `preparationWeeks` is 0; `getPrepWeekRange` — (k) start is Monday of week `N − preparationWeeks`, end is `competitionDate`, (l) equal start/end when prep weeks is 0
+- [X] T008 [P] Create `app/lib/utils/goals.ts`: pure functions `computeGoalAchievement(goal: Goal, session: Pick<TrainingSession, 'resultDistanceKm' | 'resultTimeSeconds'>): 'achieved' | 'missed' | 'pending'`, `getPrepWeekRange(goal: Goal): { start: string; end: string }`, `isWeekInPrepWindow(weekStart: string, goal: Goal): boolean` — all T007 tests must pass
+
+**Checkpoint**: Types, query keys, mock stores, and pure utilities ready — user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Set a Competition Goal (Priority: P1) 🎯 MVP
+
+**Goal**: Coach and self-plan athlete can create, edit, and delete goals. Competition sessions appear on the goal date with distinct gold/amber styling. Preparation-week banners appear on all prep weeks.
+
+**Independent Test**: In mock mode, create a goal with 4 prep weeks → confirm a gold-bordered competition card appears on the competition day and "Competition prep" banners appear on 4 preceding weeks; edit prep weeks to 2 → banners update; delete goal → banners and competition card disappear.
+
+- [X] T009 [P] [US1] Write unit tests for `toGoal` mapper in `app/test/unit/queries/goals.test.ts` — confirm they FAIL before T010: (a) all snake_case DB columns map to camelCase `Goal` fields (`athlete_id` → `athleteId`, `created_by` → `createdBy`, `competition_date` → `competitionDate`, `preparation_weeks` → `preparationWeeks`, `goal_distance_km` → `goalDistanceKm`, `goal_time_seconds` → `goalTimeSeconds`, `created_at` → `createdAt`, `updated_at` → `updatedAt`); (b) nullable fields (`goal_distance_km`, `goal_time_seconds`, `notes`) preserved as `null`; (c) required string fields (`id`, `name`, `discipline`) forwarded unchanged
+- [X] T010 [P] [US1] Create `app/lib/queries/goals.ts`: `toGoal(row: Record<string, unknown>): Goal` row mapper (all T009 tests must pass); `fetchGoals(athleteId)` — real (explicit column select, ordered by `competition_date`) + mock; `createGoal(input)` — real + mock; `updateGoal(input)` — real (partial update) + mock; `deleteGoal(id)` — real + mock; gate all with `isMockMode`
+- [X] T011 [P] [US1] Extend `app/lib/utils/training-types.ts`: add `competitionConfig` export — `{ color: 'text-amber-700', bgColor: 'bg-amber-100', borderColor: 'border-amber-400', icon: 'Trophy' }`
+- [X] T012 [P] [US1] Add goal and competition i18n keys to `app/i18n/resources/en/training.json` AND `app/i18n/resources/pl/training.json` simultaneously: `goal.create`, `goal.edit`, `goal.delete`, `goal.name`, `goal.discipline`, `goal.competitionDate`, `goal.preparationWeeks`, `goal.goalDistance`, `goal.goalTime`, `goal.notes`, `goal.deleteConfirm`, `competition.label`, `competition.result`, `competition.achieved`, `competition.missed`, `competition.pending`, `goalPrep.banner`
+- [X] T013 [US1] Write integration tests for `useGoals` mutations in `app/test/integration/hooks/useGoals.test.ts` — confirm they FAIL before T014; mock supabase with `vi.mock('~/lib/supabase', () => ({ supabase: { auth: { getSession: vi.fn() } }, isMockMode: true }))` so the mock data store is used; wrap renders in a `QueryClientProvider`; call `resetMockGoals()` in `beforeEach`; test: (a) `useCreateGoal` — after `mutate(input)`, the new goal appears optimistically in the `useGoals` cache before the mutation settles; (b) `useDeleteGoal` — after `mutate(id)`, the goal is removed optimistically; on simulated error (`vi.spyOn(mockDeleteGoal).mockRejectedValueOnce`), the goal is restored in the cache; (c) `useUpdateGoal` — after `mutate(input)`, the updated field is reflected optimistically in cached data (depends on T010 for query functions, T005 for mock store)
+- [X] T014 [US1] Create `app/lib/hooks/useGoals.ts`: `useGoals(athleteId: string)` query with `enabled: !!athleteId`, `placeholderData: prev`; `useCreateGoal()`, `useUpdateGoal()`, `useDeleteGoal()` — each with full `onMutate` (cancel queries + snapshot) → `onError` (rollback to snapshot) → `onSettled` (invalidate `queryKeys.goals.byAthlete`) cycle — all T013 tests must pass (depends on T010)
+- [X] T015 [P] [US1] Create `app/components/goals/GoalDialog.tsx`: modal form (using existing `Dialog` + shadcn fields pattern) — name (text), discipline (select via `TRAINING_TYPES`), competition date (date input), preparation weeks (number 0–52), goal distance km (optional), goal time as hh:mm:ss inputs (optional), notes (textarea); Zod validation; `onSubmit` calls `onCreate` or `onUpdate` prop; `useTranslation('training')` for all labels
+- [X] T016 [P] [US1] Create `app/components/goals/GoalCard.tsx`: shows goal name, discipline badge (`trainingTypeConfig` color), competition date, prep weeks, achievement status badge (amber for achieved, muted for pending/missed); accepts `goal: Goal`, `canEdit: boolean`, `onEdit`, `onDelete` props; two-step delete (show consequence text → require confirm click)
+- [X] T017 [P] [US1] Create `app/components/goals/GoalList.tsx`: list of `GoalCard` components; "Add Goal" button when `canEdit: boolean`; opens `GoalDialog`; empty state; accepts `goals: Goal[]`, `canEdit: boolean`, `athleteId: string` props
+- [X] T018 [P] [US1] Create `app/components/calendar/GoalPrepBanner.tsx`: slim banner above the week grid for each goal whose prep window covers the current week; shows goal name, discipline icon, days until competition; accepts `goals: Goal[]`, `weekStart: string`; calls `isWeekInPrepWindow` to filter; one banner row per overlapping goal
+- [X] T019 [US1] Extend `app/components/calendar/SessionCard.tsx`: when `session.goalId` is set, apply `border-amber-400` border, render Trophy icon from `competitionConfig`, show "Competition" label; display `resultDistanceKm`/`resultTimeSeconds` read-only if filled; no changes to non-competition sessions (depends on T011)
+- [X] T020 [US1] Wire goals into `app/routes/coach/week.$weekId.tsx`: call `useGoals(effectiveAthleteId)`, pass goals to `GoalPrepBanner` above the grid and to `GoalList` (`canEdit: true`) alongside the grid; on goal create call `useCreateSession` to create the competition session on `competitionDate` with `goalId` set and `trainingType` matching the goal discipline (depends on T014, T015, T017, T018, T019)
+- [X] T021 [US1] Wire goal view into `app/routes/athlete/week.$weekId.tsx`: call `useGoals(user.id)`, pass to `GoalPrepBanner`; pass `canEdit: hasSelfPlan` to `GoalList`; competition session cards use gold styling via extended `SessionCard` (depends on T014, T017, T018, T019)
+
+**Checkpoint**: US1 fully functional in mock mode — goals, prep banners, and competition session cards all work.
+
+---
+
+## Phase 4: User Story 2 — Week Summary Sport Breakdown (Priority: P2)
+
+**Goal**: Week summary gains a "Cumulative / By Sport" toggle. Breakdown mode shows one row per discipline with session count, planned/actual distance, and duration. Competition sessions appear as a distinct row.
+
+**Independent Test**: In mock mode on a week with run + cycling + one competition session, toggle to "By Sport" → three rows appear (run, cycling, competitions); toggle back → cumulative restored; navigate away and back → toggle state persists.
+
+- [X] T022 [P] [US2] Write unit tests for `computeSportBreakdown` in `app/test/unit/utils/analytics.test.ts` — confirm they FAIL before T023: (a) groups training sessions by `trainingType`, summing `plannedDistanceKm`, `actualDistanceKm`, `plannedDurationMinutes`, counting sessions per type; (b) sessions with `goalId` set are excluded from `byType` and collected in `competitionSessions`; (c) `achievementStatus` on each competition summary derived from `computeGoalAchievement` (spy/mock that import); (d) empty array → empty `byType`, empty `competitionSessions`; (e) week with only competition sessions → empty `byType`
+- [X] T023 [P] [US2] Create `app/lib/utils/analytics.ts`: `computeSportBreakdown(sessions: TrainingSession[]): { byType: Partial<Record<TrainingType, SportBreakdownEntry>>; competitionSessions: CompetitionSummary[] }` — all T022 tests must pass; pure function, no side effects
+- [X] T024 [P] [US2] Add sport breakdown i18n keys to `app/i18n/resources/en/coach.json` AND `app/i18n/resources/pl/coach.json`: `weekSummary.viewCumulative`, `weekSummary.viewBySport`, `weekSummary.competitions`, `weekSummary.noBreakdown`
+- [X] T025 [US2] Extend `app/lib/hooks/useWeekView.ts`: after computing existing `WeekStats`, call `computeSportBreakdown(sessions)` and merge `byType` and `competitionSessions` into the returned stats (depends on T023)
+- [X] T026 [US2] Create `app/components/calendar/SportBreakdown.tsx`: one row per non-zero entry in `stats.byType` using `trainingTypeConfig` colors/icons; row shows sport icon, name, session count, planned distance, actual distance, duration; "Competitions" row at bottom in amber styling for `stats.competitionSessions`; accepts `stats: WeekStats` prop (depends on T023 types)
+- [X] T027 [US2] Write integration tests for the sport breakdown toggle in `app/test/integration/components/WeekSummary.test.ts` — confirm they FAIL before T028; render `<WeekSummary>` with `stats` containing run sessions, cycling sessions, and one competition session (goalId set); mock `useWeekView` to return controlled stats via `vi.mock`; test: (a) cumulative view renders by default (existing stats grid visible, no sport rows); (b) clicking "By Sport" toggle renders `SportBreakdown` with run row, cycling row, and competition row; (c) clicking "Cumulative" restores the original layout; (d) `sessionStorage.getItem('weekSummary.view')` equals `'by-sport'` after toggling (depends on T025, T026)
+- [X] T028 [US2] Extend `app/components/calendar/WeekSummary.tsx`: add `'cumulative' | 'by-sport'` local state defaulting to `'cumulative'`, persisted in `sessionStorage` key `'weekSummary.view'`; add toggle button pair in `CardHeader` using existing Button/ghost pattern; when `'by-sport'`, render `<SportBreakdown stats={stats} />` in place of the two-column layout — all T027 tests must pass (depends on T025, T026)
+
+**Checkpoint**: US2 fully functional — toggle works, breakdown shows per-sport stats and competition row.
+
+---
+
+## Phase 5: User Story 3 — Performance Analytics View (Priority: P3)
+
+**Goal**: Coach and athlete can navigate to an analytics page, select a period (year/quarter/month/goal), filter by sport, and see a bar chart of training volume with competition milestones.
+
+**Independent Test**: In mock mode, open `/coach/analytics`, select "Quarter", filter "run" — chart shows weekly bars with only run data; switch to "Goal Period", select mock goal — prep-week data shown and competition milestone appears with achievement status.
+
+- [X] T029 [P] [US3] Write unit tests for `toAnalyticsBucket` mapper in `app/test/unit/queries/analytics.test.ts` — confirm they FAIL before T030: (a) all snake_case RPC fields map to camelCase (`start_date` → `startDate`, `end_date` → `endDate`, `total_sessions` → `totalSessions`, `completed_sessions` → `completedSessions`, `total_distance_km` → `totalDistanceKm`, `total_duration_minutes` → `totalDurationMinutes`, `completion_rate` → `completionRate`); (b) `label` string forwarded unchanged; (c) all numeric fields returned as `number` not `string`
+- [X] T030 [P] [US3] Create `app/lib/queries/analytics.ts`: `toAnalyticsBucket(row: Record<string, unknown>): AnalyticsBucket` mapper (all T029 tests must pass); `fetchAnalytics(params: AnalyticsParams): Promise<AnalyticsResponse>` — real calls `supabase.rpc('get_analytics_summary', { p_athlete_id, p_period, p_goal_id: params.goalId ?? null, p_training_type: params.trainingType ?? null, p_reference_date: null })` and maps result; mock calls `mockGetAnalytics(params)`; gate with `isMockMode`
+- [X] T031 [P] [US3] Add analytics i18n keys to `app/i18n/resources/en/coach.json`, `pl/coach.json`, `en/athlete.json`, `pl/athlete.json`: `analytics.title`, `analytics.period.year`, `analytics.period.quarter`, `analytics.period.month`, `analytics.period.goal`, `analytics.period.selectGoal`, `analytics.filter.allSports`, `analytics.chart.distance`, `analytics.chart.sessions`, `analytics.empty`, `analytics.milestone.achieved`, `analytics.milestone.missed`, `analytics.milestone.pending`
+- [X] T032 [US3] Create `app/lib/hooks/useAnalytics.ts`: `useAnalytics(params: AnalyticsParams | null)` — query with `enabled: !!params && !!params.athleteId`, `queryKey: queryKeys.analytics.byParams(params)`, `queryFn: () => fetchAnalytics(params!)`, `placeholderData: prev` (depends on T030)
+- [X] T033 [P] [US3] Create `app/components/analytics/PeriodSelector.tsx`: button group for year / quarter / month / goal; when "Goal Period" selected renders a `Select` dropdown of `goals: Goal[]`; emits `onPeriodChange(period: AnalyticsPeriod, goalId?: string)`; accepts `role: 'coach' | 'athlete'` for i18n namespace
+- [X] T034 [P] [US3] Create `app/components/analytics/SportFilter.tsx`: filter buttons (one per `TrainingType` + "All Sports" default) using `trainingTypeConfig` colors; emits `onFilterChange(type: TrainingType | undefined)`; selected sport uses its `bgColor`
+- [X] T035 [US3] Create `app/components/analytics/VolumeChart.tsx`: Recharts `ResponsiveContainer` + `BarChart` rendering `AnalyticsBucket[]`; X-axis = `label`; Y-axis = `totalDistanceKm`; tooltip shows all bucket fields; empty array shows a text placeholder; accepts `buckets: AnalyticsBucket[]` (depends on T001 Recharts)
+- [X] T036 [US3] Create `app/components/analytics/CompetitionMilestone.tsx`: card showing goal name, discipline badge, competition date, goal target vs actual result, achievement status badge (amber = achieved, muted = missed/pending); accepts `milestone: CompetitionMilestone`
+- [X] T037 [US3] Create `app/components/analytics/AnalyticsView.tsx`: composes `PeriodSelector`, `SportFilter`, `VolumeChart`, list of `CompetitionMilestone` cards; manages `period`, `goalId`, `trainingType` state; calls `useAnalytics`; shows skeleton while loading, i18n empty state when `buckets` is empty; accepts `athleteId: string`, `goals: Goal[]`, `role: 'coach' | 'athlete'` (depends on T032, T033, T034, T035, T036)
+- [X] T038 [P] [US3] Create `app/routes/coach/analytics.tsx`: reads `effectiveAthleteId` from auth context; calls `useGoals(athleteId)`; renders `<AnalyticsView role="coach" />`; page title from i18n (depends on T037)
+- [X] T039 [P] [US3] Create `app/routes/athlete/analytics.tsx`: reads `user.id` from auth context; calls `useGoals(user.id)`; renders `<AnalyticsView role="athlete" />` (depends on T037)
+- [X] T040 [US3] Register new routes in `app/routes.ts`: add `route('analytics', 'routes/coach/analytics.tsx')` inside the coach layout prefix; add `route('analytics', 'routes/athlete/analytics.tsx')` inside the athlete layout prefix; run `pnpm typecheck` after to regenerate React Router types (depends on T038, T039)
+
+**Checkpoint**: All 3 user stories independently functional in mock mode.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T041 Run `pnpm typecheck` and fix all TypeScript errors — no `any`, no `@ts-ignore` without documented justification
+- [X] T042 [P] Audit i18n completeness: every key in `en/` has a matching key in `pl/` across all modified files — use `/i18n-check` skill or manual diff
+- [X] T043 Validate feature end-to-end against `specs/014-goals-analytics/quickstart.md` acceptance scenarios in mock mode: goal creation → competition session → prep banners → sport breakdown toggle → analytics view with period/filter
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — **BLOCKS all user stories**
+- **US1 (Phase 3)**: Depends on Phase 2
+- **US2 (Phase 4)**: Depends on Phase 2; independently startable alongside US1
+- **US3 (Phase 5)**: Depends on Phase 2 + T001 (Recharts); independently startable alongside US1/US2
+- **Polish (Phase 6)**: Depends on all desired stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Fully independent after Phase 2
+- **US2 (P2)**: Reads `session.goalId` type from Phase 2; independently testable before US1 is wired
+- **US3 (P3)**: Uses `Goal[]` type from Phase 2; independently testable
+
+### Within Each User Story
+
+- Unit tests before implementations: T007→T008, T009→T010, T022→T023, T029→T030
+- Integration tests before the component/hook they exercise: T013→T014, T027→T028
+- Queries before hooks: T010→T014, T030→T032
+- Utilities before components: T023→T026
+- Components before route wiring: T015–T019→T020–T021
+- Route files before route registration: T038–T039→T040
+
+---
+
+## Parallel Opportunities
+
+### Phase 2 (after T003)
+```
+T004 (keys.ts) | T005 (mock/goals.ts) | T006 (mock/analytics.ts) | T007 (unit: goals utils)
+→ T008 (utils/goals.ts — after T007 confirmed failing)
+```
+
+### Phase 3 US1 (first wave, after Phase 2)
+```
+T009 (unit: toGoal) | T011 (training-types.ts) | T012 (i18n)
+→ T010 (queries/goals.ts — after T009 confirmed failing)
+T015 (GoalDialog) | T016 (GoalCard) | T017 (GoalList) | T018 (GoalPrepBanner)
+```
+
+### Phase 4 US2 (after Phase 2)
+```
+T022 (unit: computeSportBreakdown) | T024 (i18n)
+→ T023 (utils/analytics.ts — after T022 confirmed failing)
+```
+
+### Phase 5 US3 (after Phase 2 + T001)
+```
+T029 (unit: toAnalyticsBucket) | T031 (i18n) | T033 (PeriodSelector) | T034 (SportFilter)
+→ T030 (queries/analytics.ts — after T029 confirmed failing)
+T038 (coach analytics route) | T039 (athlete analytics route)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational ← **blocks everything**
+3. Complete Phase 3: US1 (goals, competition sessions, prep banners)
+4. **STOP and VALIDATE**: Create a goal in mock mode, verify competition card and prep banners appear
+5. Ship US1 behind feature flag or to staging
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready
+2. US1 complete → competition goals visible in week view (**MVP**)
+3. US2 complete → sport breakdown toggle in week summary
+4. US3 complete → analytics page with charts and milestones
+5. Polish → typecheck + i18n audit + quickstart validation
+
+---
+
+## Notes
+
+- **43 tasks total** — 2 setup, 6 foundational, 13 US1, 7 US2, 12 US3, 3 polish
+- **Unit test tasks** (4, `app/test/unit/`): T007, T009, T022, T029 — pure functions and row mappers, no React
+- **Integration test tasks** (2, `app/test/integration/`): T013 (`useGoals` optimistic mutations), T027 (`WeekSummary` sport breakdown toggle)
+- **[P] tasks**: T004–T009, T010–T012, T015–T018, T022–T024, T029–T031, T033–T034, T038–T039, T042
+- Competition sessions use `goal_id IS NOT NULL` as discriminator — not a new `training_type` enum value (research.md R-001)
+- Run `pnpm typecheck` after T040 (route registration) — React Router regenerates types
+- Commit after each checkpoint (end of US1, US2, US3) for clean rollback points

--- a/supabase/migrations/20260328000000_goals_and_competition.sql
+++ b/supabase/migrations/20260328000000_goals_and_competition.sql
@@ -9,7 +9,7 @@
 CREATE TABLE goals (
   id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   athlete_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  created_by          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_by          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
   name                TEXT        NOT NULL,
   discipline          TEXT        NOT NULL,  -- matches training_type values
   competition_date    DATE        NOT NULL,

--- a/supabase/migrations/20260328000000_goals_and_competition.sql
+++ b/supabase/migrations/20260328000000_goals_and_competition.sql
@@ -1,0 +1,295 @@
+-- Goals & Competition Sessions
+-- Adds: goals table, goal_id + result columns on training_sessions,
+--        get_analytics_summary RPC for the analytics dashboard.
+
+-- ============================================================
+-- 1. Goals table
+-- ============================================================
+
+CREATE TABLE goals (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  athlete_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_by          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  name                TEXT        NOT NULL,
+  discipline          TEXT        NOT NULL,  -- matches training_type values
+  competition_date    DATE        NOT NULL,
+  preparation_weeks   INTEGER     NOT NULL DEFAULT 0,
+  goal_distance_km    DECIMAL(8,2),
+  goal_time_seconds   INTEGER,
+  notes               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT goals_prep_weeks_non_negative CHECK (preparation_weeks >= 0),
+  CONSTRAINT goals_distance_positive       CHECK (goal_distance_km IS NULL OR goal_distance_km > 0),
+  CONSTRAINT goals_time_positive           CHECK (goal_time_seconds IS NULL OR goal_time_seconds > 0)
+);
+
+CREATE INDEX idx_goals_athlete_date ON goals (athlete_id, competition_date);
+
+CREATE TRIGGER trg_goals_updated
+  BEFORE UPDATE ON goals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE goals ENABLE ROW LEVEL SECURITY;
+
+-- Athletes can read their own goals; coaches can read goals for athletes they coach
+CREATE POLICY "goals_select" ON goals
+  FOR SELECT USING (
+    auth.uid() = athlete_id
+    OR EXISTS (
+      SELECT 1 FROM coach_athletes car
+      WHERE car.coach_id = auth.uid()
+        AND car.athlete_id = goals.athlete_id
+    )
+  );
+
+-- Coaches can insert goals for their athletes; athletes with self-plan can insert their own
+CREATE POLICY "goals_insert" ON goals
+  FOR INSERT WITH CHECK (
+    -- Coach inserting for their athlete
+    (
+      auth.uid() = created_by
+      AND auth.uid() != athlete_id
+      AND EXISTS (
+        SELECT 1 FROM coach_athletes car
+        WHERE car.coach_id = auth.uid()
+          AND car.athlete_id = goals.athlete_id
+      )
+    )
+    OR
+    -- Self-plan athlete inserting their own goal
+    (
+      auth.uid() = athlete_id
+      AND auth.uid() = created_by
+      AND EXISTS (
+        SELECT 1 FROM profiles p
+        WHERE p.id = auth.uid()
+          AND p.can_self_plan = true
+      )
+    )
+  );
+
+-- Same rules for update/delete
+CREATE POLICY "goals_update" ON goals
+  FOR UPDATE USING (
+    auth.uid() = created_by
+    OR EXISTS (
+      SELECT 1 FROM coach_athletes car
+      WHERE car.coach_id = auth.uid()
+        AND car.athlete_id = goals.athlete_id
+    )
+  );
+
+CREATE POLICY "goals_delete" ON goals
+  FOR DELETE USING (
+    auth.uid() = created_by
+    OR EXISTS (
+      SELECT 1 FROM coach_athletes car
+      WHERE car.coach_id = auth.uid()
+        AND car.athlete_id = goals.athlete_id
+    )
+  );
+
+-- ============================================================
+-- 2. Extend training_sessions
+-- ============================================================
+
+ALTER TABLE training_sessions
+  ADD COLUMN goal_id            UUID        REFERENCES goals(id) ON DELETE SET NULL,
+  ADD COLUMN result_distance_km DECIMAL(8,2),
+  ADD COLUMN result_time_seconds INTEGER,
+  ADD COLUMN result_pace        TEXT;
+
+CREATE INDEX idx_training_sessions_goal
+  ON training_sessions (goal_id)
+  WHERE goal_id IS NOT NULL;
+
+-- Both coaches and athletes can update result fields on competition sessions
+-- (goal_id IS NOT NULL identifies a competition session)
+-- The existing update policies cover this; result fields use no additional restriction.
+
+-- ============================================================
+-- 3. get_analytics_summary RPC
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION get_analytics_summary(
+  p_athlete_id     UUID,
+  p_period         TEXT,           -- 'year' | 'quarter' | 'month' | 'goal'
+  p_goal_id        UUID    DEFAULT NULL,
+  p_training_type  TEXT    DEFAULT NULL,
+  p_reference_date DATE    DEFAULT CURRENT_DATE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_start_date  DATE;
+  v_end_date    DATE;
+  v_buckets     JSONB;
+  v_competitions JSONB;
+  v_totals      JSONB;
+  v_goal_row    RECORD;
+BEGIN
+  -- Authorization: caller must be the athlete or their coach
+  IF NOT (
+    auth.uid() = p_athlete_id
+    OR EXISTS (
+      SELECT 1 FROM coach_athletes car
+      WHERE car.coach_id = auth.uid()
+        AND car.athlete_id = p_athlete_id
+    )
+  ) THEN
+    RETURN jsonb_build_object('error', 'unauthorized');
+  END IF;
+
+  -- Determine date range based on period
+  IF p_period = 'year' THEN
+    v_start_date := date_trunc('year', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('year', p_reference_date) + interval '1 year - 1 day')::DATE;
+  ELSIF p_period = 'quarter' THEN
+    v_start_date := date_trunc('quarter', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('quarter', p_reference_date) + interval '3 months - 1 day')::DATE;
+  ELSIF p_period = 'month' THEN
+    v_start_date := date_trunc('month', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('month', p_reference_date) + interval '1 month - 1 day')::DATE;
+  ELSIF p_period = 'goal' AND p_goal_id IS NOT NULL THEN
+    SELECT competition_date, preparation_weeks
+    INTO v_goal_row
+    FROM goals
+    WHERE id = p_goal_id AND athlete_id = p_athlete_id;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('buckets', '[]'::JSONB, 'competitions', '[]'::JSONB,
+                                'totals', jsonb_build_object('totalSessions', 0, 'completedSessions', 0,
+                                  'totalDistanceKm', 0, 'totalDurationMinutes', 0, 'overallCompletionRate', 0));
+    END IF;
+
+    v_end_date   := v_goal_row.competition_date;
+    v_start_date := (v_goal_row.competition_date - (v_goal_row.preparation_weeks * 7))::DATE;
+    -- align to Monday
+    v_start_date := (v_start_date - extract(dow from v_start_date)::INTEGER + 1)::DATE;
+  ELSE
+    -- default to current month
+    v_start_date := date_trunc('month', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('month', p_reference_date) + interval '1 month - 1 day')::DATE;
+  END IF;
+
+  -- Build buckets (aggregate training sessions, excluding competition sessions)
+  WITH bucket_series AS (
+    SELECT
+      CASE
+        WHEN p_period = 'year'    THEN to_char(gs, 'Mon')
+        WHEN p_period = 'quarter' THEN 'W' || to_char(gs, 'IW')
+        WHEN p_period = 'month'   THEN to_char(gs, 'DD Mon')
+        WHEN p_period = 'goal'    THEN 'W' || to_char(gs, 'IW')
+        ELSE to_char(gs, 'DD Mon')
+      END AS label,
+      gs::DATE AS start_date,
+      CASE
+        WHEN p_period = 'year'    THEN (gs + interval '1 month - 1 day')::DATE
+        WHEN p_period = 'quarter' THEN (gs + interval '7 days - 1 day')::DATE
+        WHEN p_period = 'month'   THEN gs::DATE
+        WHEN p_period = 'goal'    THEN (gs + interval '7 days - 1 day')::DATE
+        ELSE gs::DATE
+      END AS end_date
+    FROM generate_series(
+      v_start_date,
+      v_end_date,
+      CASE
+        WHEN p_period IN ('year')              THEN '1 month'::INTERVAL
+        WHEN p_period IN ('quarter', 'goal')   THEN '1 week'::INTERVAL
+        ELSE '1 day'::INTERVAL
+      END
+    ) gs
+  ),
+  session_data AS (
+    SELECT
+      ts.id,
+      ts.is_completed,
+      ts.planned_distance_km,
+      ts.actual_distance_km,
+      ts.planned_duration_minutes,
+      ts.actual_duration_minutes,
+      wp.week_start
+    FROM training_sessions ts
+    JOIN week_plans wp ON wp.id = ts.week_plan_id
+    WHERE wp.athlete_id = p_athlete_id
+      AND wp.week_start BETWEEN v_start_date AND v_end_date
+      AND ts.goal_id IS NULL  -- exclude competition sessions
+      AND (p_training_type IS NULL OR ts.training_type = p_training_type)
+  )
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'label',                  b.label,
+      'start_date',             b.start_date,
+      'end_date',               b.end_date,
+      'total_sessions',         COALESCE(COUNT(sd.id), 0),
+      'completed_sessions',     COALESCE(SUM(CASE WHEN sd.is_completed THEN 1 ELSE 0 END), 0),
+      'total_distance_km',      COALESCE(SUM(COALESCE(sd.actual_distance_km, sd.planned_distance_km)), 0),
+      'total_duration_minutes', COALESCE(SUM(COALESCE(sd.actual_duration_minutes, sd.planned_duration_minutes)), 0),
+      'completion_rate',        CASE
+                                  WHEN COUNT(sd.id) = 0 THEN 0
+                                  ELSE ROUND(100.0 * SUM(CASE WHEN sd.is_completed THEN 1 ELSE 0 END) / COUNT(sd.id), 1)
+                                END
+    ) ORDER BY b.start_date
+  )
+  INTO v_buckets
+  FROM bucket_series b
+  LEFT JOIN session_data sd
+    ON sd.week_start BETWEEN b.start_date AND b.end_date;
+
+  -- Build competitions within the period
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'goal_id',             g.id,
+      'goal_name',           g.name,
+      'discipline',          g.discipline,
+      'competition_date',    g.competition_date,
+      'goal_distance_km',    g.goal_distance_km,
+      'goal_time_seconds',   g.goal_time_seconds,
+      'result_distance_km',  ts.result_distance_km,
+      'result_time_seconds', ts.result_time_seconds,
+      'achievement_status',
+        CASE
+          WHEN ts.result_distance_km IS NULL AND ts.result_time_seconds IS NULL THEN 'pending'
+          WHEN g.goal_distance_km IS NOT NULL AND ts.result_distance_km >= g.goal_distance_km THEN 'achieved'
+          WHEN g.goal_time_seconds IS NOT NULL AND ts.result_time_seconds <= g.goal_time_seconds THEN 'achieved'
+          ELSE 'missed'
+        END
+    ) ORDER BY g.competition_date
+  )
+  INTO v_competitions
+  FROM goals g
+  LEFT JOIN training_sessions ts ON ts.goal_id = g.id
+  WHERE g.athlete_id = p_athlete_id
+    AND g.competition_date BETWEEN v_start_date AND v_end_date
+    AND (p_training_type IS NULL OR g.discipline = p_training_type);
+
+  -- Build totals
+  SELECT jsonb_build_object(
+    'totalSessions',          COALESCE(COUNT(ts.id), 0),
+    'completedSessions',      COALESCE(SUM(CASE WHEN ts.is_completed THEN 1 ELSE 0 END), 0),
+    'totalDistanceKm',        COALESCE(SUM(COALESCE(ts.actual_distance_km, ts.planned_distance_km)), 0),
+    'totalDurationMinutes',   COALESCE(SUM(COALESCE(ts.actual_duration_minutes, ts.planned_duration_minutes)), 0),
+    'overallCompletionRate',  CASE
+                                WHEN COUNT(ts.id) = 0 THEN 0
+                                ELSE ROUND(100.0 * SUM(CASE WHEN ts.is_completed THEN 1 ELSE 0 END) / COUNT(ts.id), 1)
+                              END
+  )
+  INTO v_totals
+  FROM training_sessions ts
+  JOIN week_plans wp ON wp.id = ts.week_plan_id
+  WHERE wp.athlete_id = p_athlete_id
+    AND wp.week_start BETWEEN v_start_date AND v_end_date
+    AND ts.goal_id IS NULL
+    AND (p_training_type IS NULL OR ts.training_type = p_training_type);
+
+  RETURN jsonb_build_object(
+    'buckets',      COALESCE(v_buckets, '[]'::JSONB),
+    'competitions', COALESCE(v_competitions, '[]'::JSONB),
+    'totals',       v_totals
+  );
+END;
+$$;

--- a/supabase/migrations/20260328000000_goals_and_competition.sql
+++ b/supabase/migrations/20260328000000_goals_and_competition.sql
@@ -218,6 +218,7 @@ BEGIN
     WHERE wp.athlete_id = p_athlete_id
       AND wp.week_start BETWEEN v_start_date AND v_end_date
       AND ts.goal_id IS NULL  -- exclude competition sessions
+      AND ts.training_type != 'rest_day'  -- exclude rest days from training stats
       AND (p_training_type IS NULL OR ts.training_type = p_training_type)
   )
   SELECT jsonb_agg(
@@ -284,6 +285,7 @@ BEGIN
   WHERE wp.athlete_id = p_athlete_id
     AND wp.week_start BETWEEN v_start_date AND v_end_date
     AND ts.goal_id IS NULL
+    AND ts.training_type != 'rest_day'  -- exclude rest days from training stats
     AND (p_training_type IS NULL OR ts.training_type = p_training_type);
 
   RETURN jsonb_build_object(

--- a/supabase/migrations/20260328000001_add_goal_id_to_secure_sessions_view.sql
+++ b/supabase/migrations/20260328000001_add_goal_id_to_secure_sessions_view.sql
@@ -1,0 +1,91 @@
+-- Rebuild secure_training_sessions to include goal_id and competition result columns
+-- added in 20260328000000_goals_and_competition.sql.
+
+DROP VIEW IF EXISTS secure_training_sessions;
+CREATE VIEW secure_training_sessions
+WITH (security_invoker = true) AS
+SELECT
+  ts.id,
+  ts.week_plan_id,
+  ts.day_of_week,
+  ts.sort_order,
+  ts.training_type,
+  ts.description,
+  ts.coach_comments,
+  ts.planned_duration_minutes,
+  ts.planned_distance_km,
+  ts.type_specific_data,
+  ts.is_completed,
+  ts.completed_at,
+  CASE
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.actual_duration_minutes
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN GREATEST(sa.moving_time_seconds, 0) / 60
+        ELSE NULL
+      END
+    ELSE ts.actual_duration_minutes
+  END AS actual_duration_minutes,
+  CASE
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.actual_distance_km
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN ROUND((sa.distance_meters / 1000.0)::numeric, 2)
+        ELSE NULL
+      END
+    ELSE ts.actual_distance_km
+  END AS actual_distance_km,
+  CASE
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.actual_pace
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN sa.average_pace_per_km
+        ELSE NULL
+      END
+    ELSE ts.actual_pace
+  END AS actual_pace,
+  CASE
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.avg_heart_rate
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN ROUND(sa.average_heartrate)::integer
+        ELSE NULL
+      END
+    ELSE ts.avg_heart_rate
+  END AS avg_heart_rate,
+  CASE
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.max_heart_rate
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN ROUND(sa.max_heartrate)::integer
+        ELSE NULL
+      END
+    ELSE ts.max_heart_rate
+  END AS max_heart_rate,
+  ts.rpe,
+  ts.coach_post_feedback,
+  ts.trainee_notes,
+  ts.strava_activity_id,
+  ts.strava_synced_at,
+  COALESCE(sa.is_confirmed, FALSE) AS is_strava_confirmed,
+  -- Competition / goal columns
+  ts.goal_id,
+  ts.result_distance_km,
+  ts.result_time_seconds,
+  ts.result_pace,
+  ts.created_at,
+  ts.updated_at
+FROM training_sessions ts
+JOIN week_plans wp ON wp.id = ts.week_plan_id
+LEFT JOIN LATERAL (
+  SELECT sa1.*
+  FROM strava_activities sa1
+  WHERE sa1.training_session_id = ts.id
+     OR (ts.strava_activity_id IS NOT NULL AND sa1.strava_id = ts.strava_activity_id)
+  ORDER BY (sa1.training_session_id = ts.id) DESC
+  LIMIT 1
+) sa ON TRUE;
+
+GRANT SELECT ON secure_training_sessions TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260329145130_fix_analytics_exclude_rest_days.sql
+++ b/supabase/migrations/20260329145130_fix_analytics_exclude_rest_days.sql
@@ -1,0 +1,191 @@
+-- Exclude rest_day sessions from get_analytics_summary
+-- Rest days have no meaningful distance/duration and should not count as
+-- training sessions in session totals, completion rates, or chart buckets.
+
+CREATE OR REPLACE FUNCTION public.get_analytics_summary(
+  p_athlete_id    UUID,
+  p_period        TEXT,
+  p_goal_id       UUID    DEFAULT NULL,
+  p_training_type TEXT    DEFAULT NULL,
+  p_reference_date DATE   DEFAULT CURRENT_DATE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_start_date   DATE;
+  v_end_date     DATE;
+  v_buckets      JSONB;
+  v_competitions JSONB;
+  v_totals       JSONB;
+  v_goal_row     RECORD;
+BEGIN
+  IF NOT (
+    auth.uid() = p_athlete_id
+    OR EXISTS (
+      SELECT 1 FROM coach_athletes car
+      WHERE car.coach_id = auth.uid()
+        AND car.athlete_id = p_athlete_id
+    )
+  ) THEN
+    RETURN jsonb_build_object('error', 'unauthorized');
+  END IF;
+
+  -- Determine date range
+  IF p_period = 'year' THEN
+    v_start_date := date_trunc('year', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('year', p_reference_date) + interval '1 year' - interval '1 day')::DATE;
+  ELSIF p_period = 'quarter' THEN
+    v_start_date := date_trunc('quarter', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('quarter', p_reference_date) + interval '3 months' - interval '1 day')::DATE;
+  ELSIF p_period = 'month' THEN
+    v_start_date := date_trunc('month', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('month', p_reference_date) + interval '1 month' - interval '1 day')::DATE;
+  ELSIF p_period = 'goal' AND p_goal_id IS NOT NULL THEN
+    SELECT competition_date, preparation_weeks
+    INTO v_goal_row
+    FROM goals
+    WHERE id = p_goal_id AND athlete_id = p_athlete_id;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'buckets',      '[]'::JSONB,
+        'competitions', '[]'::JSONB,
+        'totals',       jsonb_build_object(
+          'totalSessions', 0, 'completedSessions', 0,
+          'totalDistanceKm', 0, 'totalDurationMinutes', 0, 'overallCompletionRate', 0
+        )
+      );
+    END IF;
+
+    v_end_date   := v_goal_row.competition_date;
+    v_start_date := (v_goal_row.competition_date - (v_goal_row.preparation_weeks * 7))::DATE;
+    v_start_date := (v_start_date - extract(dow from v_start_date)::INTEGER + 1)::DATE;
+  ELSE
+    v_start_date := date_trunc('month', p_reference_date)::DATE;
+    v_end_date   := (date_trunc('month', p_reference_date) + interval '1 month' - interval '1 day')::DATE;
+  END IF;
+
+  -- Build buckets: pre-aggregate per bucket in a subquery, then jsonb_agg
+  SELECT jsonb_agg(q.obj ORDER BY q.start_date)
+  INTO v_buckets
+  FROM (
+    SELECT
+      b.start_date,
+      jsonb_build_object(
+        'label',                  b.label,
+        'start_date',             b.start_date,
+        'end_date',               b.end_date,
+        'total_sessions',         COALESCE(COUNT(sd.id), 0),
+        'completed_sessions',     COALESCE(SUM(CASE WHEN sd.is_completed THEN 1 ELSE 0 END), 0),
+        'total_distance_km',      COALESCE(SUM(COALESCE(sd.actual_distance_km, sd.planned_distance_km)), 0),
+        'total_duration_minutes', COALESCE(SUM(COALESCE(sd.actual_duration_minutes, sd.planned_duration_minutes)), 0),
+        'completion_rate',        CASE
+                                    WHEN COUNT(sd.id) = 0 THEN 0
+                                    ELSE ROUND(100.0 * SUM(CASE WHEN sd.is_completed THEN 1 ELSE 0 END) / COUNT(sd.id), 1)
+                                  END
+      ) AS obj
+    FROM (
+      SELECT
+        CASE
+          WHEN p_period = 'year'    THEN to_char(gs, 'Mon')
+          WHEN p_period = 'quarter' THEN 'W' || to_char(gs, 'IW')
+          WHEN p_period = 'month'   THEN to_char(gs, 'DD Mon')
+          WHEN p_period = 'goal'    THEN 'W' || to_char(gs, 'IW')
+          ELSE to_char(gs, 'DD Mon')
+        END AS label,
+        gs::DATE AS start_date,
+        CASE
+          WHEN p_period = 'year'    THEN (gs + interval '1 month' - interval '1 day')::DATE
+          WHEN p_period = 'quarter' THEN (gs + interval '6 days')::DATE
+          WHEN p_period = 'month'   THEN gs::DATE
+          WHEN p_period = 'goal'    THEN (gs + interval '6 days')::DATE
+          ELSE gs::DATE
+        END AS end_date
+      FROM generate_series(
+        v_start_date,
+        v_end_date,
+        CASE
+          WHEN p_period = 'year'              THEN '1 month'::INTERVAL
+          WHEN p_period IN ('quarter','goal') THEN '1 week'::INTERVAL
+          ELSE '1 day'::INTERVAL
+        END
+      ) gs
+    ) b
+    LEFT JOIN (
+      SELECT
+        ts.id,
+        ts.is_completed,
+        ts.planned_distance_km,
+        ts.actual_distance_km,
+        ts.planned_duration_minutes,
+        ts.actual_duration_minutes,
+        wp.week_start
+      FROM training_sessions ts
+      JOIN week_plans wp ON wp.id = ts.week_plan_id
+      WHERE wp.athlete_id = p_athlete_id
+        AND wp.week_start BETWEEN v_start_date AND v_end_date
+        AND ts.goal_id IS NULL
+        AND ts.training_type != 'rest_day'::training_type
+        AND (p_training_type IS NULL OR ts.training_type = p_training_type::training_type)
+    ) sd ON sd.week_start BETWEEN b.start_date AND b.end_date
+    GROUP BY b.label, b.start_date, b.end_date
+  ) q;
+
+  -- Build competitions within the period
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'goal_id',             g.id,
+      'goal_name',           g.name,
+      'discipline',          g.discipline,
+      'competition_date',    g.competition_date,
+      'goal_distance_km',    g.goal_distance_km,
+      'goal_time_seconds',   g.goal_time_seconds,
+      'result_distance_km',  ts.result_distance_km,
+      'result_time_seconds', ts.result_time_seconds,
+      'achievement_status',
+        CASE
+          WHEN ts.result_distance_km IS NULL AND ts.result_time_seconds IS NULL THEN 'pending'
+          WHEN g.goal_distance_km IS NOT NULL AND ts.result_distance_km >= g.goal_distance_km THEN 'achieved'
+          WHEN g.goal_time_seconds IS NOT NULL AND ts.result_time_seconds <= g.goal_time_seconds THEN 'achieved'
+          ELSE 'missed'
+        END
+    ) ORDER BY g.competition_date
+  )
+  INTO v_competitions
+  FROM goals g
+  LEFT JOIN training_sessions ts ON ts.goal_id = g.id
+  WHERE g.athlete_id = p_athlete_id
+    AND g.competition_date BETWEEN v_start_date AND v_end_date
+    AND (p_training_type IS NULL OR g.discipline = p_training_type);
+
+  -- Build totals
+  SELECT jsonb_build_object(
+    'totalSessions',         COALESCE(COUNT(ts.id), 0),
+    'completedSessions',     COALESCE(SUM(CASE WHEN ts.is_completed THEN 1 ELSE 0 END), 0),
+    'totalDistanceKm',       COALESCE(SUM(COALESCE(ts.actual_distance_km, ts.planned_distance_km)), 0),
+    'totalDurationMinutes',  COALESCE(SUM(COALESCE(ts.actual_duration_minutes, ts.planned_duration_minutes)), 0),
+    'overallCompletionRate', CASE
+                               WHEN COUNT(ts.id) = 0 THEN 0
+                               ELSE ROUND(100.0 * SUM(CASE WHEN ts.is_completed THEN 1 ELSE 0 END) / COUNT(ts.id), 1)
+                             END
+  )
+  INTO v_totals
+  FROM training_sessions ts
+  JOIN week_plans wp ON wp.id = ts.week_plan_id
+  WHERE wp.athlete_id = p_athlete_id
+    AND wp.week_start BETWEEN v_start_date AND v_end_date
+    AND ts.goal_id IS NULL
+    AND ts.training_type != 'rest_day'::training_type
+    AND (p_training_type IS NULL OR ts.training_type = p_training_type::training_type);
+
+  RETURN jsonb_build_object(
+    'buckets',      COALESCE(v_buckets, '[]'::JSONB),
+    'competitions', COALESCE(v_competitions, '[]'::JSONB),
+    'totals',       v_totals
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_analytics_summary(UUID, TEXT, UUID, TEXT, DATE) TO authenticated;


### PR DESCRIPTION
- Goal management: coaches and athletes (with self-plan) can create/edit/delete goals with competition date, discipline, target distance/time, and prep weeks
- Competition sessions: dedicated session type linked to a goal, excluded from training stats, shown separately in WeekSummary per-sport view and cumulative plan/performance columns
- Analytics dashboard: year/quarter/month/goal period views with distance and sessions bar charts, totals strip, sport filter, and competition milestone card (GoalCard reuse) gated to goal period only
- WeekSummary per-sport: competitions on top, Training section header, rest day shown last without plan/performance columns
- Fixed chart tooltips: sessions tooltip now shows completed/total instead of misleading stacked bar labels
- Fixed sport/discipline labels using correct common:trainingTypes i18n keys throughout analytics components
- Fixed PostgreSQL analytics function: interval syntax, training_type cast, nested aggregate restructure, GRANT EXECUTE for authenticated role