### PR TITLE
fix: code review improvements for goals-analytics branch

### DIFF
--- a/app/components/analytics/AnalyticsView.tsx
+++ b/app/components/analytics/AnalyticsView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '~/lib/utils';
 import { PeriodSelector } from '~/components/analytics/PeriodSelector';
@@ -6,6 +6,7 @@ import { SportFilter } from '~/components/analytics/SportFilter';
 import { VolumeChart } from '~/components/analytics/VolumeChart';
 import { GoalCard } from '~/components/goals/GoalCard';
 import { useAnalytics } from '~/lib/hooks/useAnalytics';
+import { formatDuration } from '~/lib/utils/format';
 import { computeGoalAchievement } from '~/lib/utils/goals';
 import type { AnalyticsPeriod, Goal, TrainingType } from '~/types/training';
 
@@ -25,28 +26,31 @@ interface StatChipProps {
 function StatChip({ label, value, sub }: StatChipProps) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[10px] font-bold tracking-[0.15em] text-white/35 uppercase">{label}</span>
+      <span className="text-[10px] font-bold tracking-[0.15em] text-white/35 uppercase">
+        {label}
+      </span>
       <div className="flex items-baseline gap-1">
-        <span className="text-lg font-semibold tabular-nums text-white/90">{value}</span>
+        <span className="text-lg font-semibold text-white/90 tabular-nums">{value}</span>
         {sub && <span className="text-[11px] text-white/40">{sub}</span>}
       </div>
     </div>
   );
 }
 
-function formatTotalDuration(minutes: number): { value: string; unit: string } {
-  if (minutes < 60) return { value: String(minutes), unit: 'min' };
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  if (m === 0) return { value: String(h), unit: 'h' };
-  return { value: `${h}h ${m}`, unit: 'min' };
-}
+const noop = () => {};
 
 export function AnalyticsView({ namespace, athleteId, goals, className }: AnalyticsViewProps) {
   const { t } = useTranslation(namespace);
   const [period, setPeriod] = useState<AnalyticsPeriod>('month');
   const [goalId, setGoalId] = useState<string | undefined>(goals[0]?.id);
   const [sportFilter, setSportFilter] = useState<TrainingType | undefined>(undefined);
+
+  // Sync goalId when goals list changes (initial state is only set once by useState)
+  useEffect(() => {
+    if (goals.length > 0 && !goals.some((g) => g.id === goalId)) {
+      setGoalId(goals[0]?.id);
+    }
+  }, [goals, goalId]);
 
   const { data, isLoading } = useAnalytics({
     athleteId,
@@ -64,11 +68,15 @@ export function AnalyticsView({ namespace, athleteId, goals, className }: Analyt
   const totals = data?.totals;
 
   return (
-    <div className={cn('overflow-hidden rounded-xl border border-white/[0.07] bg-zinc-950', className)}>
+    <div
+      className={cn('overflow-hidden rounded-xl border border-white/[0.07] bg-zinc-950', className)}
+    >
       {/* Header */}
       <div className="px-5 pt-5 pb-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <span className="text-[10px] font-bold tracking-[0.18em] text-white/40 uppercase">{title}</span>
+          <span className="text-[10px] font-bold tracking-[0.18em] text-white/40 uppercase">
+            {title}
+          </span>
           <SportFilter namespace={namespace} value={sportFilter} onChange={setSportFilter} />
         </div>
         <PeriodSelector
@@ -83,34 +91,32 @@ export function AnalyticsView({ namespace, athleteId, goals, className }: Analyt
       </div>
 
       {/* Goal card — shown between header and totals when in goal period */}
-      {period === 'goal' && !isLoading && data?.competitions.map((comp) => {
-        const goal = goals.find((g) => g.id === comp.goalId);
-        if (!goal) return null;
-        return (
-          <div key={comp.goalId} className="border-t border-white/[0.06] px-5 py-4">
-            <GoalCard
-              goal={goal}
-              canEdit={false}
-              achievementStatus={computeGoalAchievement(goal, {
-                resultDistanceKm: comp.resultDistanceKm,
-                resultTimeSeconds: comp.resultTimeSeconds,
-              })}
-              onEdit={() => {}}
-              onDelete={() => {}}
-            />
-          </div>
-        );
-      })}
+      {period === 'goal' &&
+        !isLoading &&
+        data?.competitions.map((comp) => {
+          const goal = goals.find((g) => g.id === comp.goalId);
+          if (!goal) return null;
+          return (
+            <div key={comp.goalId} className="border-t border-white/[0.06] px-5 py-4">
+              <GoalCard
+                goal={goal}
+                canEdit={false}
+                achievementStatus={computeGoalAchievement(goal, {
+                  resultDistanceKm: comp.resultDistanceKm,
+                  resultTimeSeconds: comp.resultTimeSeconds,
+                })}
+                onEdit={noop}
+                onDelete={noop}
+              />
+            </div>
+          );
+        })}
 
       {/* Totals strip */}
       {totals && !isLoading && (
         <div className="grid grid-cols-4 gap-px border-t border-white/[0.06] bg-white/[0.04]">
           <div className="bg-zinc-950 px-4 py-3">
-            <StatChip
-              label={distanceLabel}
-              value={totals.totalDistanceKm.toFixed(1)}
-              sub="km"
-            />
+            <StatChip label={distanceLabel} value={totals.totalDistanceKm.toFixed(1)} sub="km" />
           </div>
           <div className="bg-zinc-950 px-4 py-3">
             <StatChip
@@ -120,7 +126,7 @@ export function AnalyticsView({ namespace, athleteId, goals, className }: Analyt
           </div>
           <div className="bg-zinc-950 px-4 py-3">
             {(() => {
-              const d = formatTotalDuration(totals.totalDurationMinutes);
+              const d = formatDuration(totals.totalDurationMinutes);
               return <StatChip label={timeLabel} value={d.value} sub={d.unit} />;
             })()}
           </div>
@@ -136,13 +142,15 @@ export function AnalyticsView({ namespace, athleteId, goals, className }: Analyt
       {/* Charts / empty / loading */}
       <div className="border-t border-white/[0.06] px-5 py-5">
         {isLoading ? (
-          <div className="flex h-40 items-center justify-center">
+          <div
+            className="flex h-40 items-center justify-center"
+            role="status"
+            aria-label={t('common:loading' as never)}
+          >
             <div className="h-5 w-5 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent" />
           </div>
         ) : !data || data.buckets.length === 0 ? (
-          <p className="py-8 text-center text-sm text-white/30">
-            {t('analytics.empty' as never)}
-          </p>
+          <p className="py-8 text-center text-sm text-white/30">{t('analytics.empty' as never)}</p>
         ) : (
           <VolumeChart namespace={namespace} buckets={data.buckets} />
         )}

--- a/app/components/analytics/PeriodSelector.tsx
+++ b/app/components/analytics/PeriodSelector.tsx
@@ -34,10 +34,12 @@ export function PeriodSelector({
 
   return (
     <div className={cn('flex flex-wrap items-center gap-2', className)}>
-      <div className="flex rounded-lg border border-border/50 bg-muted/30 p-0.5">
+      <div role="tablist" className="flex rounded-lg border border-border/50 bg-muted/30 p-0.5">
         {PERIODS.map((p) => (
           <button
             key={p}
+            role="tab"
+            aria-selected={period === p}
             onClick={() => onPeriodChange(p)}
             className={cn(
               'h-7 rounded-md px-3 text-xs font-semibold transition-all',

--- a/app/components/analytics/VolumeChart.tsx
+++ b/app/components/analytics/VolumeChart.tsx
@@ -1,19 +1,12 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-} from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { cn } from '~/lib/utils';
 import type { AnalyticsBucket } from '~/types/training';
 
 // Explicit hex colors — CSS vars are unreliable in SVG fill attributes
-const COLOR_DISTANCE = '#6366f1';     // indigo-500, pops on dark and light
-const COLOR_COMPLETED = '#10b981';    // emerald-500
+const COLOR_DISTANCE = '#6366f1'; // indigo-500, pops on dark and light
+const COLOR_COMPLETED = '#10b981'; // emerald-500
 const COLOR_PENDING = 'rgba(255,255,255,0.10)';
 const COLOR_GRID = 'rgba(255,255,255,0.06)';
 const COLOR_TICK = 'rgba(255,255,255,0.35)';
@@ -54,7 +47,13 @@ function DistanceTooltip({ active, payload, label }: TooltipProps) {
   );
 }
 
-function SessionsTooltip({ active, payload, label, completedLabel, totalLabel }: TooltipProps & { completedLabel: string; totalLabel: string }) {
+function SessionsTooltip({
+  active,
+  payload,
+  label,
+  completedLabel,
+  totalLabel,
+}: TooltipProps & { completedLabel: string; totalLabel: string }) {
   if (!active || !payload?.length) return null;
   const data = payload[0]?.payload;
   if (!data) return null;
@@ -67,7 +66,9 @@ function SessionsTooltip({ active, payload, label, completedLabel, totalLabel }:
       <div className="flex items-center gap-2">
         <span className="h-2 w-2 rounded-full" style={{ backgroundColor: COLOR_COMPLETED }} />
         <span className="text-white/50">{completedLabel}:</span>
-        <span className="font-medium text-white">{completed}/{total}</span>
+        <span className="font-medium text-white">
+          {completed}/{total}
+        </span>
       </div>
     </div>
   );
@@ -81,19 +82,26 @@ export function VolumeChart({ namespace, buckets, className }: VolumeChartProps)
   const completedLabel = t('analytics.totals.completion' as never);
 
   // Pre-compute pending sessions so stacking shows total = completed + pending
-  const sessionData = buckets.map((b) => ({
-    ...b,
-    pendingSessions: Math.max(0, b.totalSessions - b.completedSessions),
-  }));
+  const sessionData = useMemo(
+    () =>
+      buckets.map((b) => ({
+        ...b,
+        pendingSessions: Math.max(0, b.totalSessions - b.completedSessions),
+      })),
+    [buckets],
+  );
 
   // Determine bar size based on bucket count — fewer buckets = wider bars
   const barSize = buckets.length <= 12 ? 16 : buckets.length <= 31 ? 8 : 5;
 
-  const axisProps = {
-    tick: { fontSize: 10, fill: COLOR_TICK },
-    axisLine: false as const,
-    tickLine: false as const,
-  };
+  const axisProps = useMemo(
+    () => ({
+      tick: { fontSize: 10, fill: COLOR_TICK },
+      axisLine: false as const,
+      tickLine: false as const,
+    }),
+    [],
+  );
 
   return (
     <div className={cn('space-y-6', className)}>
@@ -103,14 +111,15 @@ export function VolumeChart({ namespace, buckets, className }: VolumeChartProps)
           {distanceLabel}
         </p>
         <ResponsiveContainer width="100%" height={180}>
-          <BarChart data={buckets} barSize={barSize} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+          <BarChart
+            data={buckets}
+            barSize={barSize}
+            margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+          >
             <CartesianGrid vertical={false} stroke={COLOR_GRID} />
             <XAxis dataKey="label" {...axisProps} interval="preserveStartEnd" />
             <YAxis {...axisProps} />
-            <Tooltip
-              content={<DistanceTooltip />}
-              cursor={{ fill: COLOR_CURSOR }}
-            />
+            <Tooltip content={<DistanceTooltip />} cursor={{ fill: COLOR_CURSOR }} />
             <Bar
               dataKey="totalDistanceKm"
               name={distanceLabel}
@@ -127,12 +136,18 @@ export function VolumeChart({ namespace, buckets, className }: VolumeChartProps)
           {sessionsLabel}
         </p>
         <ResponsiveContainer width="100%" height={130}>
-          <BarChart data={sessionData} barSize={barSize} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+          <BarChart
+            data={sessionData}
+            barSize={barSize}
+            margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+          >
             <CartesianGrid vertical={false} stroke={COLOR_GRID} />
             <XAxis dataKey="label" {...axisProps} interval="preserveStartEnd" />
             <YAxis {...axisProps} allowDecimals={false} />
             <Tooltip
-              content={<SessionsTooltip completedLabel={completedLabel} totalLabel={sessionsLabel} />}
+              content={
+                <SessionsTooltip completedLabel={completedLabel} totalLabel={sessionsLabel} />
+              }
               cursor={{ fill: COLOR_CURSOR }}
             />
             <Bar

--- a/app/components/calendar/GoalPrepBanner.tsx
+++ b/app/components/calendar/GoalPrepBanner.tsx
@@ -29,9 +29,9 @@ export function GoalPrepBanner({ goals, weekStart, className }: GoalPrepBannerPr
           <div
             key={goal.id}
             className={cn(
-              'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm border',
+              'flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm',
               competitionConfig.bgColor,
-              competitionConfig.borderColor
+              competitionConfig.borderColor,
             )}
           >
             <Trophy className={cn('size-3.5 shrink-0', competitionConfig.color)} />

--- a/app/components/calendar/SessionCard.tsx
+++ b/app/components/calendar/SessionCard.tsx
@@ -12,7 +12,12 @@ import { StravaSyncButton } from '~/components/training/StravaSyncButton';
 import { StravaConfirmButton } from '~/components/training/StravaConfirmButton';
 import { useAuth } from '~/lib/context/AuthContext';
 import { useSessionActions } from '~/lib/context/SessionActionsContext';
-import { trainingTypeConfig, competitionConfig, iconMap, isDistanceBased } from '~/lib/utils/training-types';
+import {
+  trainingTypeConfig,
+  competitionConfig,
+  iconMap,
+  isDistanceBased,
+} from '~/lib/utils/training-types';
 import { getSessionCalendarDate } from '~/lib/utils/date';
 import { cn } from '~/lib/utils';
 import { type TrainingSession, type RunData } from '~/types/training';

--- a/app/components/calendar/SportBreakdown.tsx
+++ b/app/components/calendar/SportBreakdown.tsx
@@ -1,19 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { cn } from '~/lib/utils';
+import { formatDurationCompact } from '~/lib/utils/format';
 import { trainingTypeConfig, competitionConfig, iconMap } from '~/lib/utils/training-types';
 import type { WeekStats, TrainingType } from '~/types/training';
 
 interface SportBreakdownProps {
   stats: WeekStats;
   className?: string;
-}
-
-function formatDuration(min: number): string | null {
-  if (min === 0) return null;
-  if (min < 60) return `${min}m`;
-  const h = Math.floor(min / 60);
-  const m = min % 60;
-  return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
 function ColHeader({ children }: { children: React.ReactNode }) {
@@ -27,8 +20,8 @@ function ColHeader({ children }: { children: React.ReactNode }) {
 function Stat({ value, sub }: { value: React.ReactNode; sub?: string }) {
   return (
     <div>
-      <p className="text-sm font-bold tabular-nums leading-tight">{value}</p>
-      {sub && <p className="mt-0.5 text-[10px] tabular-nums text-muted-foreground/60">{sub}</p>}
+      <p className="text-sm leading-tight font-bold tabular-nums">{value}</p>
+      {sub && <p className="mt-0.5 text-[10px] text-muted-foreground/60 tabular-nums">{sub}</p>}
     </div>
   );
 }
@@ -52,7 +45,7 @@ function SportRow({
   const config = trainingTypeConfig[type];
   const Icon = iconMap[config.icon];
   const hasDistance = plannedDistanceKm > 0 || actualDistanceKm > 0;
-  const duration = formatDuration(totalDurationMinutes);
+  const duration = formatDurationCompact(totalDurationMinutes);
 
   return (
     <div className="flex items-start gap-3 py-3">
@@ -68,7 +61,7 @@ function SportRow({
 
       {/* Sport name + session count */}
       <div className="min-w-0 flex-1">
-        <p className={cn('text-sm font-semibold leading-tight', config.color)}>
+        <p className={cn('text-sm leading-tight font-semibold', config.color)}>
           {t(`common:trainingTypes.${type}` as never)}
         </p>
         <p className="mt-0.5 text-[11px] text-muted-foreground">
@@ -86,7 +79,13 @@ function SportRow({
       <div className="w-20 shrink-0 text-right">
         <ColHeader>{t('coach:weekSummary.colPerformance')}</ColHeader>
         <Stat
-          value={hasDistance ? (actualDistanceKm > 0 ? `${actualDistanceKm.toFixed(1)} km` : '—') : (duration ?? '—')}
+          value={
+            hasDistance
+              ? actualDistanceKm > 0
+                ? `${actualDistanceKm.toFixed(1)} km`
+                : '—'
+              : (duration ?? '—')
+          }
           sub={hasDistance && duration ? duration : undefined}
         />
         {!hasDistance && (
@@ -115,7 +114,7 @@ function RestDayRow({ count }: { count: number }) {
         {Icon && <Icon className={cn('h-4 w-4', config.color)} />}
       </div>
       <div className="min-w-0 flex-1">
-        <p className={cn('text-sm font-semibold leading-tight', config.color)}>
+        <p className={cn('text-sm leading-tight font-semibold', config.color)}>
           {t('common:trainingTypes.rest_day' as never)}
         </p>
         <p className="mt-0.5 text-[11px] text-muted-foreground">
@@ -142,11 +141,12 @@ function CompetitionRow({
   const { t } = useTranslation(['coach', 'common']);
   const Icon = iconMap[competitionConfig.icon];
 
-  const perfValue = actualDistanceKm != null
-    ? `${actualDistanceKm.toFixed(1)} km`
-    : actualDurationMinutes != null
-      ? formatDuration(actualDurationMinutes)
-      : '—';
+  const perfValue =
+    actualDistanceKm != null
+      ? `${actualDistanceKm.toFixed(1)} km`
+      : actualDurationMinutes != null
+        ? formatDurationCompact(actualDurationMinutes)
+        : '—';
 
   return (
     <div className="flex items-start gap-3 py-3">
@@ -159,7 +159,7 @@ function CompetitionRow({
         {Icon && <Icon className={cn('h-4 w-4', competitionConfig.color)} />}
       </div>
       <div className="min-w-0 flex-1">
-        <p className={cn('text-sm font-semibold leading-tight', competitionConfig.color)}>
+        <p className={cn('text-sm leading-tight font-semibold', competitionConfig.color)}>
           {goalName}
         </p>
         <p className="mt-0.5 text-[11px] text-muted-foreground">
@@ -205,7 +205,11 @@ export function SportBreakdown({ stats, className }: SportBreakdownProps) {
     <div className={cn('space-y-0', className)}>
       {/* Competitions first */}
       {stats.competitionSessions.length > 0 && (
-        <div className={cn(regularEntries.length > 0 || restDayEntry ? 'border-b border-border/40 pb-1' : '')}>
+        <div
+          className={cn(
+            regularEntries.length > 0 || restDayEntry ? 'border-b border-border/40 pb-1' : '',
+          )}
+        >
           <p
             className={cn(
               'pt-2 pb-1 text-[10px] font-bold tracking-wider uppercase',
@@ -257,7 +261,12 @@ export function SportBreakdown({ stats, className }: SportBreakdownProps) {
 
       {/* Rest day last — no plan/performance data */}
       {restDayEntry && (
-        <div className={cn((regularEntries.length > 0 || stats.competitionSessions.length > 0) && 'border-t border-border/40')}>
+        <div
+          className={cn(
+            (regularEntries.length > 0 || stats.competitionSessions.length > 0) &&
+              'border-t border-border/40',
+          )}
+        >
           <RestDayRow count={restDayEntry[1].sessionCount} />
         </div>
       )}

--- a/app/components/calendar/WeekSummary.tsx
+++ b/app/components/calendar/WeekSummary.tsx
@@ -6,9 +6,16 @@ import { Input } from '~/components/ui/input';
 import { Textarea } from '~/components/ui/textarea';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
+import { formatTime, formatDuration } from '~/lib/utils/format';
 import { loadTypeConfig } from '~/lib/utils/training-types';
 import { SportBreakdown } from '~/components/calendar/SportBreakdown';
-import { LOAD_TYPES, type WeekPlan, type WeekStats, type Goal, type TrainingSession } from '~/types/training';
+import {
+  LOAD_TYPES,
+  type WeekPlan,
+  type WeekStats,
+  type Goal,
+  type TrainingSession,
+} from '~/types/training';
 
 const VIEW_KEY = 'weekSummary.view';
 type SummaryView = 'cumulative' | 'by-sport';
@@ -39,24 +46,14 @@ function StatValue({ value, unit }: { value: string | number; unit?: string }) {
   );
 }
 
-function formatTime(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-  return `${m}:${String(s).padStart(2, '0')}`;
-}
-
-function formatDuration(minutes: number): { value: string; unit: string } {
-  if (minutes === 0) return { value: '0', unit: 'min' };
-  if (minutes < 60) return { value: minutes.toString(), unit: 'min' };
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  if (m === 0) return { value: h.toString(), unit: 'h' };
-  return { value: `${h}h ${m}`, unit: 'min' };
-}
-
-export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate, competitionGoal, competitionSession }: WeekSummaryProps) {
+export function WeekSummary({
+  weekPlan,
+  stats,
+  readonly = false,
+  onUpdate,
+  competitionGoal,
+  competitionSession,
+}: WeekSummaryProps) {
   const { t } = useTranslation(['coach', 'common']);
   const [isExpanded, setIsExpanded] = useState(true);
   const [isEditingKm, setIsEditingKm] = useState(false);
@@ -141,6 +138,8 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate, compe
               variant="ghost"
               size="icon"
               onClick={() => setIsExpanded((v) => !v)}
+              aria-expanded={isExpanded}
+              aria-label={t(isExpanded ? 'common:collapseDetails' : 'common:expandDetails')}
               className="h-8 w-8 rounded-full text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
             >
               {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
@@ -185,334 +184,352 @@ export function WeekSummary({ weekPlan, stats, readonly = false, onUpdate, compe
               data-testid="cumulative-view"
             >
               <div className="overflow-hidden">
-            <div className={cn('grid grid-cols-1 divide-y divide-border/40 bg-muted/5 md:grid-cols-2 md:divide-x md:divide-y-0')}>
-              {/* ── LEFT: Plan ── */}
-              <div className="space-y-5 px-6 py-5">
-                <p className="flex items-center gap-2 text-[10px] font-bold tracking-[0.2em] text-muted-foreground/60 uppercase">
-                  <span className="h-1.5 w-1.5 rounded-full bg-primary/40" />
-                  {t('coach:weekSummary.plan')}
-                </p>
-
-                {/* Competition block — only on competition weeks */}
-                {competitionGoal && (
-                  <>
-                    <div className="rounded-lg border border-amber-200/60 bg-amber-50/50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20">
-                      <div className="mb-2.5 flex items-center gap-1.5">
-                        <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
-                        <span className="text-[10px] font-bold tracking-widest text-amber-700 uppercase dark:text-amber-300">
-                          {competitionGoal.name}
-                        </span>
-                      </div>
-                      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
-                        <div className="space-y-0.5">
-                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
-                            {t('training:goal.goalDistance' as never)}
-                          </p>
-                          {competitionGoal.goalDistanceKm != null ? (
-                            <StatValue value={competitionGoal.goalDistanceKm} unit="km" />
-                          ) : (
-                            <StatValue value="—" />
-                          )}
-                        </div>
-                        <div className="space-y-0.5">
-                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
-                            {t('training:goal.goalTime' as never)}
-                          </p>
-                          {competitionGoal.goalTimeSeconds != null ? (
-                            <StatValue value={formatTime(competitionGoal.goalTimeSeconds)} />
-                          ) : (
-                            <StatValue value="—" />
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="h-px bg-border/40" />
-                  </>
-                )}
-
-                {/* 2×2 metric grid — mirrors Performance layout */}
-                <div className="grid grid-cols-2 gap-x-6 gap-y-5">
-                  {/* Distance */}
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.plannedKm')}
+                <div
+                  className={cn(
+                    'grid grid-cols-1 divide-y divide-border/40 bg-muted/5 md:grid-cols-2 md:divide-x md:divide-y-0',
+                  )}
+                >
+                  {/* ── LEFT: Plan ── */}
+                  <div className="space-y-5 px-6 py-5">
+                    <p className="flex items-center gap-2 text-[10px] font-bold tracking-[0.2em] text-muted-foreground/60 uppercase">
+                      <span className="h-1.5 w-1.5 rounded-full bg-primary/40" />
+                      {t('coach:weekSummary.plan')}
                     </p>
-                    {readonly ? (
-                      weekPlan.totalPlannedKm != null ? (
-                        <StatValue value={weekPlan.totalPlannedKm} unit="km" />
-                      ) : stats.totalPlannedKm > 0 ? (
-                        <StatValue value={`~${stats.totalPlannedKm.toFixed(1)}`} unit="km" />
-                      ) : (
-                        <StatValue value="—" />
-                      )
-                    ) : isEditingKm ? (
-                      <div className="relative max-w-[100px]">
-                        <Input
-                          type="number"
-                          step="0.1"
-                          placeholder={
-                            stats.totalPlannedKm > 0 ? stats.totalPlannedKm.toFixed(1) : '0'
-                          }
-                          value={plannedKm}
-                          onChange={(e) => setPlannedKm(e.target.value)}
-                          onBlur={() => {
-                            handleBlur('totalPlannedKm', plannedKm);
-                            setIsEditingKm(false);
-                          }}
-                          autoFocus
-                          className="h-9 border-border/60 bg-background pr-8 text-sm font-bold tracking-tight"
-                        />
-                        <span className="absolute top-1/2 right-3 -translate-y-1/2 text-[10px] font-bold text-muted-foreground/50 uppercase">
-                          km
-                        </span>
-                      </div>
-                    ) : weekPlan.totalPlannedKm != null ? (
-                      <div className="space-y-1">
-                        <div className="flex items-baseline gap-1">
-                          <span className="text-xl font-bold tracking-tight text-amber-500">
-                            {weekPlan.totalPlannedKm}
-                          </span>
-                          <span className="text-[10px] font-medium tracking-wider text-amber-500/70 uppercase">
-                            km
-                          </span>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => setIsEditingKm(true)}
-                            className="ml-0.5 h-5 w-5"
-                          >
-                            <Pencil className="h-3 w-3" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => {
-                              setPlannedKm('');
-                              onUpdate?.({ totalPlannedKm: null });
-                            }}
-                            className="h-5 w-5"
-                          >
-                            <X className="h-3 w-3" />
-                          </Button>
+
+                    {/* Competition block — only on competition weeks */}
+                    {competitionGoal && (
+                      <>
+                        <div className="rounded-lg border border-amber-200/60 bg-amber-50/50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20">
+                          <div className="mb-2.5 flex items-center gap-1.5">
+                            <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                            <span className="text-[10px] font-bold tracking-widest text-amber-700 uppercase dark:text-amber-300">
+                              {competitionGoal.name}
+                            </span>
+                          </div>
+                          <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+                            <div className="space-y-0.5">
+                              <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                                {t('training:goal.goalDistance' as never)}
+                              </p>
+                              {competitionGoal.goalDistanceKm != null ? (
+                                <StatValue value={competitionGoal.goalDistanceKm} unit="km" />
+                              ) : (
+                                <StatValue value="—" />
+                              )}
+                            </div>
+                            <div className="space-y-0.5">
+                              <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                                {t('training:goal.goalTime' as never)}
+                              </p>
+                              {competitionGoal.goalTimeSeconds != null ? (
+                                <StatValue value={formatTime(competitionGoal.goalTimeSeconds)} />
+                              ) : (
+                                <StatValue value="—" />
+                              )}
+                            </div>
+                          </div>
                         </div>
-                        <p className="flex items-center gap-1 text-[10px] text-amber-500/70">
-                          <Pencil className="h-2.5 w-2.5" /> {t('coach:weekSummary.manuallySet')}
-                        </p>
-                      </div>
-                    ) : (
+                        <div className="h-px bg-border/40" />
+                      </>
+                    )}
+
+                    {/* 2×2 metric grid — mirrors Performance layout */}
+                    <div className="grid grid-cols-2 gap-x-6 gap-y-5">
+                      {/* Distance */}
                       <div className="space-y-1">
-                        <div className="flex items-baseline gap-1.5">
-                          {stats.totalPlannedKm > 0 ? (
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.plannedKm')}
+                        </p>
+                        {readonly ? (
+                          weekPlan.totalPlannedKm != null ? (
+                            <StatValue value={weekPlan.totalPlannedKm} unit="km" />
+                          ) : stats.totalPlannedKm > 0 ? (
                             <StatValue value={`~${stats.totalPlannedKm.toFixed(1)}`} unit="km" />
                           ) : (
                             <StatValue value="—" />
-                          )}
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => setIsEditingKm(true)}
-                            className="h-5 w-5"
-                          >
-                            <Pencil className="h-3 w-3 text-muted-foreground" />
-                          </Button>
-                        </div>
-                        {stats.totalPlannedKm > 0 && (
-                          <p className="text-[10px] text-muted-foreground/50">
-                            {t('coach:weekSummary.fromSessions')}
-                          </p>
+                          )
+                        ) : isEditingKm ? (
+                          <div className="relative max-w-[100px]">
+                            <Input
+                              type="number"
+                              step="0.1"
+                              placeholder={
+                                stats.totalPlannedKm > 0 ? stats.totalPlannedKm.toFixed(1) : '0'
+                              }
+                              value={plannedKm}
+                              onChange={(e) => setPlannedKm(e.target.value)}
+                              onBlur={() => {
+                                handleBlur('totalPlannedKm', plannedKm);
+                                setIsEditingKm(false);
+                              }}
+                              autoFocus
+                              className="h-9 border-border/60 bg-background pr-8 text-sm font-bold tracking-tight"
+                            />
+                            <span className="absolute top-1/2 right-3 -translate-y-1/2 text-[10px] font-bold text-muted-foreground/50 uppercase">
+                              km
+                            </span>
+                          </div>
+                        ) : weekPlan.totalPlannedKm != null ? (
+                          <div className="space-y-1">
+                            <div className="flex items-baseline gap-1">
+                              <span className="text-xl font-bold tracking-tight text-amber-500">
+                                {weekPlan.totalPlannedKm}
+                              </span>
+                              <span className="text-[10px] font-medium tracking-wider text-amber-500/70 uppercase">
+                                km
+                              </span>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setIsEditingKm(true)}
+                                className="ml-0.5 h-5 w-5"
+                              >
+                                <Pencil className="h-3 w-3" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => {
+                                  setPlannedKm('');
+                                  onUpdate?.({ totalPlannedKm: null });
+                                }}
+                                className="h-5 w-5"
+                              >
+                                <X className="h-3 w-3" />
+                              </Button>
+                            </div>
+                            <p className="flex items-center gap-1 text-[10px] text-amber-500/70">
+                              <Pencil className="h-2.5 w-2.5" />{' '}
+                              {t('coach:weekSummary.manuallySet')}
+                            </p>
+                          </div>
+                        ) : (
+                          <div className="space-y-1">
+                            <div className="flex items-baseline gap-1.5">
+                              {stats.totalPlannedKm > 0 ? (
+                                <StatValue
+                                  value={`~${stats.totalPlannedKm.toFixed(1)}`}
+                                  unit="km"
+                                />
+                              ) : (
+                                <StatValue value="—" />
+                              )}
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setIsEditingKm(true)}
+                                className="h-5 w-5"
+                              >
+                                <Pencil className="h-3 w-3 text-muted-foreground" />
+                              </Button>
+                            </div>
+                            {stats.totalPlannedKm > 0 && (
+                              <p className="text-[10px] text-muted-foreground/50">
+                                {t('coach:weekSummary.fromSessions')}
+                              </p>
+                            )}
+                          </div>
                         )}
                       </div>
-                    )}
-                  </div>
 
-                  {/* Sessions */}
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.plannedSessions')}
-                    </p>
-                    <StatValue value={stats.totalSessions} />
-                  </div>
+                      {/* Sessions */}
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.plannedSessions')}
+                        </p>
+                        <StatValue value={stats.totalSessions} />
+                      </div>
 
-                  {/* Week Load */}
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.loadType')}
-                    </p>
-                    {readonly ? (
-                      weekPlan.loadType ? (
-                        <span
-                          className={cn(
-                            'inline-flex h-7 items-center rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase',
-                            loadTypeConfig[weekPlan.loadType].bgColor,
-                            loadTypeConfig[weekPlan.loadType].color,
-                          )}
-                        >
-                          {t(`common:loadType.${weekPlan.loadType}`)}
-                        </span>
-                      ) : (
-                        <p className="text-sm text-muted-foreground">—</p>
-                      )
-                    ) : (
-                      <div className="flex flex-wrap gap-1.5">
-                        {LOAD_TYPES.map((lt) => {
-                          const config = loadTypeConfig[lt];
-                          const isSelected = weekPlan.loadType === lt;
-                          return (
-                            <Button
-                              key={lt}
-                              variant={isSelected ? 'default' : 'outline'}
-                              size="sm"
+                      {/* Week Load */}
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.loadType')}
+                        </p>
+                        {readonly ? (
+                          weekPlan.loadType ? (
+                            <span
                               className={cn(
-                                'h-7 rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase transition-all',
-                                isSelected
-                                  ? `${config.bgColor} ${config.color} border-0 shadow-sm hover:opacity-90`
-                                  : 'text-muted-foreground/70 hover:text-foreground',
+                                'inline-flex h-7 items-center rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase',
+                                loadTypeConfig[weekPlan.loadType].bgColor,
+                                loadTypeConfig[weekPlan.loadType].color,
                               )}
-                              onClick={() => onUpdate?.({ loadType: isSelected ? null : lt })}
                             >
-                              {t(`common:loadType.${lt}`)}
-                            </Button>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Empty slot — aligns with Completion on the right */}
-                  <div />
-                </div>
-
-                {/* Coach Notes */}
-                <div className="space-y-2">
-                  <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                    {t('coach:weekSummary.coachComments')}
-                  </p>
-                  {readonly ? (
-                    weekPlan.coachComments ? (
-                      <p className="border-l-2 border-primary/20 pl-3 text-sm leading-relaxed text-foreground/80 italic">
-                        "{weekPlan.coachComments}"
-                      </p>
-                    ) : (
-                      <p className="text-sm text-muted-foreground">—</p>
-                    )
-                  ) : (
-                    <Textarea
-                      placeholder={t('coach:weekSummary.coachCommentsPlaceholder')}
-                      value={coachComments}
-                      onChange={(e) => setCoachComments(e.target.value)}
-                      onBlur={() => handleBlur('coachComments', coachComments)}
-                      rows={2}
-                      className="resize-none border-border/60 bg-background text-sm leading-relaxed focus:border-primary/40"
-                    />
-                  )}
-                </div>
-              </div>
-
-              {/* ── RIGHT: Performance ── */}
-              <div className="space-y-5 px-6 py-5">
-                <p className="flex items-center gap-2 text-[10px] font-bold tracking-[0.2em] text-muted-foreground/60 uppercase">
-                  <span className="h-1.5 w-1.5 rounded-full bg-green-500/40" />
-                  {t('coach:weekSummary.performance')}
-                </p>
-
-                {/* Competition result block — only on competition weeks */}
-                {competitionGoal && (
-                  <>
-                    <div className="rounded-lg border border-amber-200/60 bg-amber-50/50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20">
-                      <div className="mb-2.5 flex items-center gap-1.5">
-                        <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
-                        <span className="text-[10px] font-bold tracking-widest text-amber-700 uppercase dark:text-amber-300">
-                          {t('training:competition.result' as never)}
-                        </span>
-                      </div>
-                      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
-                        <div className="space-y-0.5">
-                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
-                            {t('coach:weekSummary.totalDistance')}
-                          </p>
-                          {competitionSession?.actualDistanceKm != null ? (
-                            <StatValue value={competitionSession.actualDistanceKm.toFixed(1)} unit="km" />
+                              {t(`common:loadType.${weekPlan.loadType}`)}
+                            </span>
                           ) : (
-                            <StatValue value="—" />
-                          )}
-                        </div>
-                        <div className="space-y-0.5">
-                          <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
-                            {t('coach:weekSummary.totalTime')}
-                          </p>
-                          {competitionSession?.actualDurationMinutes != null ? (
-                            (() => {
-                              const d = formatDuration(competitionSession.actualDurationMinutes);
-                              return <StatValue value={d.value} unit={d.unit} />;
-                            })()
-                          ) : (
-                            <StatValue value="—" />
-                          )}
-                        </div>
+                            <p className="text-sm text-muted-foreground">—</p>
+                          )
+                        ) : (
+                          <div className="flex flex-wrap gap-1.5">
+                            {LOAD_TYPES.map((lt) => {
+                              const config = loadTypeConfig[lt];
+                              const isSelected = weekPlan.loadType === lt;
+                              return (
+                                <Button
+                                  key={lt}
+                                  variant={isSelected ? 'default' : 'outline'}
+                                  size="sm"
+                                  className={cn(
+                                    'h-7 rounded-md px-2.5 text-[10px] font-bold tracking-wider uppercase transition-all',
+                                    isSelected
+                                      ? `${config.bgColor} ${config.color} border-0 shadow-sm hover:opacity-90`
+                                      : 'text-muted-foreground/70 hover:text-foreground',
+                                  )}
+                                  onClick={() => onUpdate?.({ loadType: isSelected ? null : lt })}
+                                >
+                                  {t(`common:loadType.${lt}`)}
+                                </Button>
+                              );
+                            })}
+                          </div>
+                        )}
                       </div>
+
+                      {/* Empty slot — aligns with Completion on the right */}
+                      <div />
                     </div>
-                    <div className="h-px bg-border/40" />
-                  </>
-                )}
 
-                {/* Stat grid */}
-                <div className="grid grid-cols-2 gap-x-6 gap-y-5">
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.totalDistance')}
-                    </p>
-                    {stats.totalActualDistanceKm > 0 ? (
-                      <StatValue value={stats.totalActualDistanceKm.toFixed(1)} unit="km" />
-                    ) : (
-                      <StatValue value="—" />
-                    )}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.completedSessions')}
-                    </p>
-                    <div className="flex items-baseline gap-0.5">
-                      <span className="text-xl font-bold tracking-tight">{stats.completedSessions}</span>
-                      {stats.totalSessions > 0 && (
-                        <span className="text-sm font-medium text-muted-foreground/60">
-                          {' '}/ {stats.totalSessions}
-                        </span>
+                    {/* Coach Notes */}
+                    <div className="space-y-2">
+                      <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                        {t('coach:weekSummary.coachComments')}
+                      </p>
+                      {readonly ? (
+                        weekPlan.coachComments ? (
+                          <p className="border-l-2 border-primary/20 pl-3 text-sm leading-relaxed text-foreground/80 italic">
+                            "{weekPlan.coachComments}"
+                          </p>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">—</p>
+                        )
+                      ) : (
+                        <Textarea
+                          placeholder={t('coach:weekSummary.coachCommentsPlaceholder')}
+                          value={coachComments}
+                          onChange={(e) => setCoachComments(e.target.value)}
+                          onBlur={() => handleBlur('coachComments', coachComments)}
+                          rows={2}
+                          className="resize-none border-border/60 bg-background text-sm leading-relaxed focus:border-primary/40"
+                        />
                       )}
                     </div>
                   </div>
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.totalTime')}
+
+                  {/* ── RIGHT: Performance ── */}
+                  <div className="space-y-5 px-6 py-5">
+                    <p className="flex items-center gap-2 text-[10px] font-bold tracking-[0.2em] text-muted-foreground/60 uppercase">
+                      <span className="h-1.5 w-1.5 rounded-full bg-green-500/40" />
+                      {t('coach:weekSummary.performance')}
                     </p>
-                    <StatValue value={duration.value} unit={duration.unit} />
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
-                      {t('coach:weekSummary.progress')}
-                    </p>
-                    <StatValue
-                      value={stats.totalSessions > 0 ? Math.round(stats.completionPercentage) : '—'}
-                      unit={stats.totalSessions > 0 ? '%' : undefined}
-                    />
+
+                    {/* Competition result block — only on competition weeks */}
+                    {competitionGoal && (
+                      <>
+                        <div className="rounded-lg border border-amber-200/60 bg-amber-50/50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20">
+                          <div className="mb-2.5 flex items-center gap-1.5">
+                            <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                            <span className="text-[10px] font-bold tracking-widest text-amber-700 uppercase dark:text-amber-300">
+                              {t('training:competition.result' as never)}
+                            </span>
+                          </div>
+                          <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+                            <div className="space-y-0.5">
+                              <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                                {t('coach:weekSummary.totalDistance')}
+                              </p>
+                              {competitionSession?.actualDistanceKm != null ? (
+                                <StatValue
+                                  value={competitionSession.actualDistanceKm.toFixed(1)}
+                                  unit="km"
+                                />
+                              ) : (
+                                <StatValue value="—" />
+                              )}
+                            </div>
+                            <div className="space-y-0.5">
+                              <p className="text-[10px] font-semibold tracking-wide text-muted-foreground/70 uppercase">
+                                {t('coach:weekSummary.totalTime')}
+                              </p>
+                              {competitionSession?.actualDurationMinutes != null ? (
+                                (() => {
+                                  const d = formatDuration(
+                                    competitionSession.actualDurationMinutes,
+                                  );
+                                  return <StatValue value={d.value} unit={d.unit} />;
+                                })()
+                              ) : (
+                                <StatValue value="—" />
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="h-px bg-border/40" />
+                      </>
+                    )}
+
+                    {/* Stat grid */}
+                    <div className="grid grid-cols-2 gap-x-6 gap-y-5">
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.totalDistance')}
+                        </p>
+                        {stats.totalActualDistanceKm > 0 ? (
+                          <StatValue value={stats.totalActualDistanceKm.toFixed(1)} unit="km" />
+                        ) : (
+                          <StatValue value="—" />
+                        )}
+                      </div>
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.completedSessions')}
+                        </p>
+                        <div className="flex items-baseline gap-0.5">
+                          <span className="text-xl font-bold tracking-tight">
+                            {stats.completedSessions}
+                          </span>
+                          {stats.totalSessions > 0 && (
+                            <span className="text-sm font-medium text-muted-foreground/60">
+                              {' '}
+                              / {stats.totalSessions}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.totalTime')}
+                        </p>
+                        <StatValue value={duration.value} unit={duration.unit} />
+                      </div>
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+                          {t('coach:weekSummary.progress')}
+                        </p>
+                        <StatValue
+                          value={
+                            stats.totalSessions > 0 ? Math.round(stats.completionPercentage) : '—'
+                          }
+                          unit={stats.totalSessions > 0 ? '%' : undefined}
+                        />
+                      </div>
+                    </div>
+
+                    {/* Progress bar */}
+                    {stats.totalSessions > 0 && (
+                      <div className="pt-2">
+                        <div className="h-1.5 overflow-hidden rounded-full border border-border/10 bg-muted shadow-inner">
+                          <div
+                            className={cn(
+                              'h-full rounded-full shadow-[0_0_8px_rgba(0,0,0,0.1)] transition-all duration-700 ease-out',
+                              stats.completionPercentage >= 100 ? 'bg-green-500' : 'bg-primary',
+                            )}
+                            style={{ width: `${stats.completionPercentage}%` }}
+                          />
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
-
-                {/* Progress bar */}
-                {stats.totalSessions > 0 && (
-                  <div className="pt-2">
-                    <div className="h-1.5 overflow-hidden rounded-full border border-border/10 bg-muted shadow-inner">
-                      <div
-                        className={cn(
-                          'h-full rounded-full shadow-[0_0_8px_rgba(0,0,0,0.1)] transition-all duration-700 ease-out',
-                          stats.completionPercentage >= 100 ? 'bg-green-500' : 'bg-primary',
-                        )}
-                        style={{ width: `${stats.completionPercentage}%` }}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
               </div>
             </div>
           </CardContent>

--- a/app/components/goals/GoalCard.tsx
+++ b/app/components/goals/GoalCard.tsx
@@ -6,7 +6,8 @@ import { Badge } from '~/components/ui/badge';
 import { trainingTypeConfig, competitionConfig } from '~/lib/utils/training-types';
 import type { Goal, AchievementStatus } from '~/types/training';
 import { cn } from '~/lib/utils';
-import { format, parseISO } from 'date-fns';
+import { format, parseISO, isPast as isDatePast } from 'date-fns';
+import { formatTime } from '~/lib/utils/format';
 
 interface GoalCardProps {
   goal: Goal;
@@ -17,15 +18,14 @@ interface GoalCardProps {
   className?: string;
 }
 
-function formatTime(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-  return `${m}:${String(s).padStart(2, '0')}`;
-}
-
-export function GoalCard({ goal, canEdit, achievementStatus, onEdit, onDelete, className }: GoalCardProps) {
+export function GoalCard({
+  goal,
+  canEdit,
+  achievementStatus,
+  onEdit,
+  onDelete,
+  className,
+}: GoalCardProps) {
   const { t } = useTranslation('training');
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -37,28 +37,30 @@ export function GoalCard({ goal, canEdit, achievementStatus, onEdit, onDelete, c
       ? cn(competitionConfig.color, competitionConfig.bgColor)
       : 'text-muted-foreground bg-muted';
 
-  const isPast = new Date(goal.competitionDate) < new Date();
+  const isPast = isDatePast(parseISO(goal.competitionDate));
 
   return (
     <div
-      className={cn(
-        'rounded-lg border p-4 flex flex-col gap-3',
-        isPast && 'opacity-80',
-        className
-      )}
+      className={cn('flex flex-col gap-3 rounded-lg border p-4', isPast && 'opacity-80', className)}
     >
       {/* Header */}
       <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
           <Trophy className={cn('size-4 shrink-0', competitionConfig.color)} />
-          <span className="font-semibold truncate">{goal.name}</span>
-          <Badge className={cn('text-xs shrink-0', typeConfig.color, typeConfig.bgColor)}>
+          <span className="truncate font-semibold">{goal.name}</span>
+          <Badge className={cn('shrink-0 text-xs', typeConfig.color, typeConfig.bgColor)}>
             {t(`common:trainingTypes.${goal.discipline}` as never)}
           </Badge>
         </div>
         {canEdit && (
-          <div className="flex gap-1 shrink-0">
-            <Button variant="ghost" size="icon" className="size-7" onClick={() => onEdit(goal)}>
+          <div className="flex shrink-0 gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={() => onEdit(goal)}
+              aria-label={t('goal.edit')}
+            >
               <Pencil className="size-3.5" />
             </Button>
             <Button
@@ -66,6 +68,7 @@ export function GoalCard({ goal, canEdit, achievementStatus, onEdit, onDelete, c
               size="icon"
               className="size-7 text-destructive hover:text-destructive"
               onClick={() => setConfirmDelete(true)}
+              aria-label={t('goal.delete')}
             >
               <Trash2 className="size-3.5" />
             </Button>
@@ -110,15 +113,13 @@ export function GoalCard({ goal, canEdit, achievementStatus, onEdit, onDelete, c
       )}
 
       {/* Notes */}
-      {goal.notes && (
-        <p className="text-xs text-muted-foreground line-clamp-2">{goal.notes}</p>
-      )}
+      {goal.notes && <p className="line-clamp-2 text-xs text-muted-foreground">{goal.notes}</p>}
 
       {/* Delete confirmation */}
       {confirmDelete && (
-        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3 flex flex-col gap-2">
+        <div className="flex flex-col gap-2 rounded-md border border-destructive/20 bg-destructive/10 p-3">
           <p className="text-sm text-destructive">{t('goal.deleteConfirm')}</p>
-          <div className="flex gap-2 justify-end">
+          <div className="flex justify-end gap-2">
             <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)}>
               {t('common:actions.cancel' as never)}
             </Button>

--- a/app/components/goals/GoalDialog.tsx
+++ b/app/components/goals/GoalDialog.tsx
@@ -103,7 +103,7 @@ export function GoalDialog({
       setForm(DEFAULT_FORM_STATE);
     }
     setErrors({});
-  }, [open, goal?.id]);
+  }, [open, goal]);
 
   function set<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -112,10 +112,11 @@ export function GoalDialog({
 
   function validate(): boolean {
     const next: typeof errors = {};
-    if (!form.name.trim()) next.name = 'Required';
-    if (!form.competitionDate) next.competitionDate = 'Required';
+    if (!form.name.trim()) next.name = t('goal.validation.required');
+    if (!form.competitionDate) next.competitionDate = t('goal.validation.required');
     const weeks = parseInt(form.preparationWeeks, 10);
-    if (isNaN(weeks) || weeks < 0 || weeks > 52) next.preparationWeeks = '0–52';
+    if (isNaN(weeks) || weeks < 0 || weeks > 52)
+      next.preparationWeeks = t('goal.validation.prepWeeksRange');
     setErrors(next);
     return Object.keys(next).length === 0;
   }
@@ -181,7 +182,10 @@ export function GoalDialog({
         {/* Discipline */}
         <div className="flex flex-col gap-1.5">
           <Label>{t('goal.discipline')}</Label>
-          <Select value={form.discipline} onValueChange={(v) => set('discipline', v as TrainingType)}>
+          <Select
+            value={form.discipline}
+            onValueChange={(v) => set('discipline', v as TrainingType)}
+          >
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>
@@ -237,7 +241,7 @@ export function GoalDialog({
             step={0.1}
             value={form.goalDistanceKm}
             onChange={(e) => set('goalDistanceKm', e.target.value)}
-            placeholder="e.g. 10"
+            placeholder={t('goal.placeholder.distance')}
           />
         </div>
 

--- a/app/components/goals/GoalList.tsx
+++ b/app/components/goals/GoalList.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import { Button } from '~/components/ui/button';
 import { GoalCard } from './GoalCard';
 import { GoalDialog } from './GoalDialog';
-import { useCreateGoal, useUpdateGoal, useDeleteGoal } from '~/lib/hooks/useGoals';
+import { useGoalDialogState } from '~/lib/hooks/useGoalDialogState';
 import { computeGoalAchievement } from '~/lib/utils/goals';
 import type { Goal } from '~/types/training';
 import { cn } from '~/lib/utils';
@@ -19,61 +18,33 @@ interface GoalListProps {
 
 export function GoalList({ goals, canEdit, athleteId, createdBy, className }: GoalListProps) {
   const { t } = useTranslation('training');
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingGoal, setEditingGoal] = useState<Goal | undefined>();
-
-  const createGoalMutation = useCreateGoal();
-  const updateGoalMutation = useUpdateGoal();
-  const deleteGoalMutation = useDeleteGoal();
-
-  function handleCreate(input: import('~/types/training').CreateGoalInput) {
-    createGoalMutation.mutate(
-      { ...input, createdBy },
-      { onSuccess: () => setDialogOpen(false) }
-    );
-  }
-
-  function handleUpdate(input: import('~/types/training').UpdateGoalInput) {
-    updateGoalMutation.mutate(
-      { ...input, athleteId },
-      { onSuccess: () => { setDialogOpen(false); setEditingGoal(undefined); } }
-    );
-  }
-
-  function handleDelete(goal: Goal) {
-    deleteGoalMutation.mutate({ id: goal.id, athleteId });
-  }
-
-  function handleEditClick(goal: Goal) {
-    setEditingGoal(goal);
-    setDialogOpen(true);
-  }
-
-  function handleClose() {
-    setDialogOpen(false);
-    setEditingGoal(undefined);
-  }
-
-  const isSaving = createGoalMutation.isPending || updateGoalMutation.isPending;
+  const {
+    dialogOpen,
+    editingGoal,
+    isSaving,
+    handleCreate,
+    handleUpdate,
+    handleDelete,
+    handleEditClick,
+    handleClose,
+    handleOpenNew,
+  } = useGoalDialogState({ athleteId, createdBy });
 
   return (
     <div className={cn('flex flex-col gap-3', className)}>
       {goals.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-2">{t('goal.noGoals')}</p>
+        <p className="py-2 text-sm text-muted-foreground">{t('goal.noGoals')}</p>
       ) : (
         goals.map((goal) => {
-          // We don't have session result here — show 'pending' for future, derive status only when result is available
           return (
             <GoalCard
               key={goal.id}
               goal={goal}
               canEdit={canEdit}
-              achievementStatus={
-                computeGoalAchievement(goal, {
-                  resultDistanceKm: null,
-                  resultTimeSeconds: null,
-                })
-              }
+              achievementStatus={computeGoalAchievement(goal, {
+                resultDistanceKm: null,
+                resultTimeSeconds: null,
+              })}
               onEdit={handleEditClick}
               onDelete={handleDelete}
             />
@@ -82,13 +53,8 @@ export function GoalList({ goals, canEdit, athleteId, createdBy, className }: Go
       )}
 
       {canEdit && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="self-start"
-          onClick={() => { setEditingGoal(undefined); setDialogOpen(true); }}
-        >
-          <Plus className="size-4 mr-1" />
+        <Button variant="outline" size="sm" className="self-start" onClick={handleOpenNew}>
+          <Plus className="mr-1 size-4" />
           {t('goal.create')}
         </Button>
       )}

--- a/app/components/goals/GoalListView.tsx
+++ b/app/components/goals/GoalListView.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import { Button } from '~/components/ui/button';
 import { AppLoader } from '~/components/ui/app-loader';
 import { GoalCard } from './GoalCard';
 import { GoalDialog } from './GoalDialog';
-import { useGoals, useCreateGoal, useUpdateGoal, useDeleteGoal } from '~/lib/hooks/useGoals';
+import { useGoals } from '~/lib/hooks/useGoals';
+import { useGoalDialogState } from '~/lib/hooks/useGoalDialogState';
 import { computeGoalAchievement } from '~/lib/utils/goals';
-import type { Goal, CreateGoalInput, UpdateGoalInput } from '~/types/training';
 import { cn } from '~/lib/utils';
 
 interface GoalListViewProps {
@@ -20,48 +19,18 @@ interface GoalListViewProps {
 export function GoalListView({ athleteId, createdBy, canManage, className }: GoalListViewProps) {
   const { t } = useTranslation('training');
 
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingGoal, setEditingGoal] = useState<Goal | undefined>();
-
   const { data: goals = [], isLoading } = useGoals(athleteId);
-  const createGoalMutation = useCreateGoal();
-  const updateGoalMutation = useUpdateGoal();
-  const deleteGoalMutation = useDeleteGoal();
-
-  function handleCreate(input: CreateGoalInput) {
-    createGoalMutation.mutate(
-      { ...input, createdBy },
-      { onSuccess: () => setDialogOpen(false) },
-    );
-  }
-
-  function handleUpdate(input: UpdateGoalInput) {
-    updateGoalMutation.mutate(
-      { ...input, athleteId },
-      {
-        onSuccess: () => {
-          setDialogOpen(false);
-          setEditingGoal(undefined);
-        },
-      },
-    );
-  }
-
-  function handleDelete(goal: Goal) {
-    deleteGoalMutation.mutate({ id: goal.id, athleteId });
-  }
-
-  function handleEditClick(goal: Goal) {
-    setEditingGoal(goal);
-    setDialogOpen(true);
-  }
-
-  function handleClose() {
-    setDialogOpen(false);
-    setEditingGoal(undefined);
-  }
-
-  const isSaving = createGoalMutation.isPending || updateGoalMutation.isPending;
+  const {
+    dialogOpen,
+    editingGoal,
+    isSaving,
+    handleCreate,
+    handleUpdate,
+    handleDelete,
+    handleEditClick,
+    handleClose,
+    handleOpenNew,
+  } = useGoalDialogState({ athleteId, createdBy });
 
   if (isLoading) return <AppLoader />;
 
@@ -70,12 +39,7 @@ export function GoalListView({ athleteId, createdBy, canManage, className }: Goa
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">{t('goal.library')}</h1>
         {canManage && (
-          <Button
-            onClick={() => {
-              setEditingGoal(undefined);
-              setDialogOpen(true);
-            }}
-          >
+          <Button onClick={handleOpenNew}>
             <Plus className="mr-1.5 size-4" />
             {t('goal.create')}
           </Button>

--- a/app/components/layout/BottomNav.tsx
+++ b/app/components/layout/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, Dumbbell, Trophy, Settings, Users } from 'lucide-react';
+import { BarChart3, CalendarDays, Dumbbell, Trophy, Settings, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useLocation } from 'react-router';
 import { cn } from '~/lib/utils';
@@ -52,6 +52,7 @@ export function BottomNav() {
     pathname.includes('/week') && (user.role === 'athlete' || !!selectedAthleteId);
   const isStrengthActive = pathname.includes('/strength');
   const isGoalsActive = pathname.includes('/goals');
+  const isAnalyticsActive = pathname.includes('/analytics');
   const isSettingsActive = pathname.includes('/settings');
 
   return (
@@ -83,6 +84,12 @@ export function BottomNav() {
           icon={Trophy}
           label={t('nav.goals')}
           isActive={isGoalsActive}
+        />
+        <NavItem
+          to={localePath(`/${user.role}/analytics`)}
+          icon={BarChart3}
+          label={t('nav.analytics')}
+          isActive={isAnalyticsActive}
         />
         <NavItem
           to={localePath('/settings')}

--- a/app/i18n/resources/en/common.json
+++ b/app/i18n/resources/en/common.json
@@ -37,6 +37,9 @@
     "close": "Close",
     "confirm": "Confirm"
   },
+  "loading": "Loading",
+  "expandDetails": "Expand details",
+  "collapseDetails": "Collapse details",
   "loadType": {
     "easy": "Easy",
     "medium": "Medium",

--- a/app/i18n/resources/en/training.json
+++ b/app/i18n/resources/en/training.json
@@ -228,7 +228,14 @@
     "namePlaceholder": "e.g. Spring 10K",
     "notesPlaceholder": "Add context or motivation…",
     "noGoals": "No goals set yet.",
-    "prepWeeksShort": "{{weeks}}w prep"
+    "prepWeeksShort": "{{weeks}}w prep",
+    "validation": {
+      "required": "Required",
+      "prepWeeksRange": "0–52"
+    },
+    "placeholder": {
+      "distance": "e.g. 10"
+    }
   },
   "competition": {
     "label": "Competition",

--- a/app/i18n/resources/pl/common.json
+++ b/app/i18n/resources/pl/common.json
@@ -37,6 +37,9 @@
     "close": "Zamknij",
     "confirm": "Potwierdź"
   },
+  "loading": "Ładowanie",
+  "expandDetails": "Rozwiń szczegóły",
+  "collapseDetails": "Zwiń szczegóły",
   "loadType": {
     "easy": "Lekki",
     "medium": "Średni",

--- a/app/i18n/resources/pl/training.json
+++ b/app/i18n/resources/pl/training.json
@@ -228,7 +228,14 @@
     "namePlaceholder": "np. Wiosenny 10K",
     "notesPlaceholder": "Dodaj kontekst lub motywację…",
     "noGoals": "Nie ustawiono jeszcze żadnych celów.",
-    "prepWeeksShort": "{{weeks}} tyg. przyg."
+    "prepWeeksShort": "{{weeks}} tyg. przyg.",
+    "validation": {
+      "required": "Wymagane",
+      "prepWeeksRange": "0–52"
+    },
+    "placeholder": {
+      "distance": "np. 10"
+    }
   },
   "competition": {
     "label": "Zawody",

--- a/app/lib/hooks/useGoalDialogState.ts
+++ b/app/lib/hooks/useGoalDialogState.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useCreateGoal, useUpdateGoal, useDeleteGoal } from '~/lib/hooks/useGoals';
+import type { Goal, CreateGoalInput, UpdateGoalInput } from '~/types/training';
+
+interface UseGoalDialogStateOptions {
+  athleteId: string;
+  createdBy: string;
+}
+
+export function useGoalDialogState({ athleteId, createdBy }: UseGoalDialogStateOptions) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingGoal, setEditingGoal] = useState<Goal | undefined>();
+
+  const createGoalMutation = useCreateGoal();
+  const updateGoalMutation = useUpdateGoal();
+  const deleteGoalMutation = useDeleteGoal();
+
+  function handleCreate(input: CreateGoalInput) {
+    createGoalMutation.mutate({ ...input, createdBy }, { onSuccess: () => setDialogOpen(false) });
+  }
+
+  function handleUpdate(input: UpdateGoalInput) {
+    updateGoalMutation.mutate(
+      { ...input, athleteId },
+      {
+        onSuccess: () => {
+          setDialogOpen(false);
+          setEditingGoal(undefined);
+        },
+      },
+    );
+  }
+
+  function handleDelete(goal: Goal) {
+    deleteGoalMutation.mutate({ id: goal.id, athleteId });
+  }
+
+  function handleEditClick(goal: Goal) {
+    setEditingGoal(goal);
+    setDialogOpen(true);
+  }
+
+  function handleClose() {
+    setDialogOpen(false);
+    setEditingGoal(undefined);
+  }
+
+  function handleOpenNew() {
+    setEditingGoal(undefined);
+    setDialogOpen(true);
+  }
+
+  const isSaving = createGoalMutation.isPending || updateGoalMutation.isPending;
+
+  return {
+    dialogOpen,
+    editingGoal,
+    isSaving,
+    handleCreate,
+    handleUpdate,
+    handleDelete,
+    handleEditClick,
+    handleClose,
+    handleOpenNew,
+  };
+}

--- a/app/lib/hooks/useGoals.ts
+++ b/app/lib/hooks/useGoals.ts
@@ -48,8 +48,9 @@ export function useCreateGoal() {
             : undefined,
           goalId: goal.id,
         });
-      } catch {
+      } catch (err) {
         // Session creation is best-effort; the goal itself is saved.
+        console.warn('[useCreateGoal] Failed to auto-create competition session:', err);
       }
     },
     onMutate: async (input) => {
@@ -75,9 +76,8 @@ export function useCreateGoal() {
 
       qc.setQueryData<Goal[]>(key, (prev = []) =>
         [...prev, optimistic].sort(
-          (a, b) =>
-            new Date(a.competitionDate).getTime() - new Date(b.competitionDate).getTime()
-        )
+          (a, b) => new Date(a.competitionDate).getTime() - new Date(b.competitionDate).getTime(),
+        ),
       );
 
       return { snapshot, athleteId: input.athleteId };
@@ -117,9 +117,8 @@ export function useUpdateGoal() {
           const patch: Parameters<typeof updateSession>[0] = { id: linked.id };
           if (variables.name !== undefined) patch.description = variables.name;
           if (variables.goalTimeSeconds !== undefined)
-            patch.plannedDurationMinutes = variables.goalTimeSeconds != null
-              ? Math.round(variables.goalTimeSeconds / 60)
-              : null;
+            patch.plannedDurationMinutes =
+              variables.goalTimeSeconds != null ? Math.round(variables.goalTimeSeconds / 60) : null;
           if (variables.goalDistanceKm !== undefined)
             patch.plannedDistanceKm = variables.goalDistanceKm ?? null;
 
@@ -156,8 +155,8 @@ export function useUpdateGoal() {
                 ...(input.notes !== undefined && { notes: input.notes }),
                 updatedAt: new Date().toISOString(),
               }
-            : g
-        )
+            : g,
+        ),
       );
 
       return { snapshot, athleteId: input.athleteId };

--- a/app/lib/hooks/useSessions.ts
+++ b/app/lib/hooks/useSessions.ts
@@ -110,16 +110,18 @@ export function useUpdateSession() {
       // Keep linked goal in sync when a competition session's key fields change
       if (data.goalId) {
         const patch: Parameters<typeof updateGoal>[0] = { id: data.goalId };
-        if (variables.description != null && variables.description !== '') patch.name = variables.description;
+        if (variables.description != null && variables.description !== '')
+          patch.name = variables.description;
         if (variables.plannedDurationMinutes !== undefined)
-          patch.goalTimeSeconds = variables.plannedDurationMinutes != null
-            ? variables.plannedDurationMinutes * 60
-            : null;
+          patch.goalTimeSeconds =
+            variables.plannedDurationMinutes != null ? variables.plannedDurationMinutes * 60 : null;
         if (variables.plannedDistanceKm !== undefined)
           patch.goalDistanceKm = variables.plannedDistanceKm ?? null;
 
         if (Object.keys(patch).length > 1) {
-          await updateGoal(patch).catch(() => {});
+          await updateGoal(patch).catch((err) => {
+            console.warn('[useUpdateSession] Failed to sync goal:', err);
+          });
           qc.invalidateQueries({ queryKey: queryKeys.goals.all });
         }
       }

--- a/app/lib/hooks/useWeekView.ts
+++ b/app/lib/hooks/useWeekView.ts
@@ -137,7 +137,11 @@ export function useWeekView({
   const stats = useMemo(() => {
     const base = computeWeekStats(sessionsForStats ?? sessions);
     const breakdown = computeSportBreakdown(sessionsForStats ?? sessions);
-    return { ...base, byType: breakdown.byType, competitionSessions: breakdown.competitionSessions };
+    return {
+      ...base,
+      byType: breakdown.byType,
+      competitionSessions: breakdown.competitionSessions,
+    };
   }, [sessionsForStats, sessions]);
 
   const handleFormSubmit = useCallback(

--- a/app/lib/mock-data/analytics.ts
+++ b/app/lib/mock-data/analytics.ts
@@ -12,7 +12,7 @@ function makeBucket(
   totalSessions: number,
   completedSessions: number,
   totalDistanceKm: number,
-  totalDurationMinutes: number
+  totalDurationMinutes: number,
 ): AnalyticsBucket {
   return {
     label,
@@ -22,7 +22,8 @@ function makeBucket(
     completedSessions,
     totalDistanceKm,
     totalDurationMinutes,
-    completionRate: totalSessions === 0 ? 0 : Math.round((completedSessions / totalSessions) * 1000) / 10,
+    completionRate:
+      totalSessions === 0 ? 0 : Math.round((completedSessions / totalSessions) * 1000) / 10,
   };
 }
 
@@ -128,7 +129,7 @@ const MONTH_RESPONSE: AnalyticsResponse = {
       hasSessions ? 1 : 0,
       hasSessions && d <= 6 ? 1 : 0,
       hasSessions ? 8 + d : 0,
-      hasSessions ? 50 + d * 3 : 0
+      hasSessions ? 50 + d * 3 : 0,
     );
   }),
   competitions: [],

--- a/app/lib/mock-data/goals.ts
+++ b/app/lib/mock-data/goals.ts
@@ -69,11 +69,13 @@ export async function mockFetchGoals(athleteId: string): Promise<Goal[]> {
     if (g.athleteId === athleteId) result.push(g);
   }
   return result.sort(
-    (a, b) => new Date(a.competitionDate).getTime() - new Date(b.competitionDate).getTime()
+    (a, b) => new Date(a.competitionDate).getTime() - new Date(b.competitionDate).getTime(),
   );
 }
 
-export async function mockCreateGoal(input: CreateGoalInput & { createdBy: string }): Promise<Goal> {
+export async function mockCreateGoal(
+  input: CreateGoalInput & { createdBy: string },
+): Promise<Goal> {
   await delay();
   const now = new Date().toISOString();
   const goal: Goal = {

--- a/app/lib/mock-data/sessions.ts
+++ b/app/lib/mock-data/sessions.ts
@@ -30,6 +30,14 @@ export function resetMockSessions() {
   }
 }
 
+export async function mockFetchSessionByGoalId(goalId: string): Promise<TrainingSession | null> {
+  await delay();
+  for (const s of sessions.values()) {
+    if (s.goalId === goalId) return s;
+  }
+  return null;
+}
+
 export async function mockFetchSessionsByWeekPlan(weekPlanId: string): Promise<TrainingSession[]> {
   await delay();
   const result: TrainingSession[] = [];

--- a/app/lib/queries/goals.ts
+++ b/app/lib/queries/goals.ts
@@ -46,9 +46,7 @@ async function realFetchGoals(athleteId: string): Promise<Goal[]> {
   return (data ?? []).map((r) => toGoal(r as Record<string, unknown>));
 }
 
-async function realCreateGoal(
-  input: CreateGoalInput & { createdBy: string }
-): Promise<Goal> {
+async function realCreateGoal(input: CreateGoalInput & { createdBy: string }): Promise<Goal> {
   const { data, error } = await supabase
     .from('goals')
     .insert({
@@ -104,9 +102,7 @@ export async function fetchGoals(athleteId: string): Promise<Goal[]> {
   return realFetchGoals(athleteId);
 }
 
-export async function createGoal(
-  input: CreateGoalInput & { createdBy: string }
-): Promise<Goal> {
+export async function createGoal(input: CreateGoalInput & { createdBy: string }): Promise<Goal> {
   if (isMockMode) return mockCreateGoal(input);
   return realCreateGoal(input);
 }

--- a/app/lib/queries/keys.ts
+++ b/app/lib/queries/keys.ts
@@ -1,3 +1,5 @@
+import type { AnalyticsParams } from '~/types/training';
+
 export const queryKeys = {
   weeks: {
     all: ['weeks'] as const,
@@ -50,7 +52,7 @@ export const queryKeys = {
   },
   analytics: {
     all: ['analytics'] as const,
-    byParams: (params: unknown) => ['analytics', params] as const,
+    byParams: (params: AnalyticsParams) => ['analytics', params] as const,
   },
   // PoC: Junction Garmin integration — remove after evaluation
   junctionPoc: {

--- a/app/lib/queries/sessions.ts
+++ b/app/lib/queries/sessions.ts
@@ -1,5 +1,6 @@
 import { supabase, isMockMode } from '~/lib/supabase';
 import {
+  mockFetchSessionByGoalId,
   mockFetchSessionsByWeekPlan,
   mockCreateSession,
   mockUpdateSession,
@@ -77,10 +78,12 @@ export async function bulkConfirmStravaSessions(weekPlanId: string): Promise<voi
 }
 
 export async function fetchSessionByGoalId(goalId: string): Promise<TrainingSession | null> {
-  if (isMockMode) return null;
+  if (isMockMode) return mockFetchSessionByGoalId(goalId);
   const { data, error } = await supabase
     .from('training_sessions')
-    .select('id, week_plan_id, day_of_week, sort_order, training_type, description, coach_comments, planned_duration_minutes, planned_distance_km, type_specific_data, is_completed, completed_at, actual_duration_minutes, actual_distance_km, actual_pace, avg_heart_rate, max_heart_rate, rpe, coach_post_feedback, trainee_notes, strava_activity_id, strava_synced_at, goal_id, result_distance_km, result_time_seconds, result_pace, created_at, updated_at')
+    .select(
+      'id, week_plan_id, day_of_week, sort_order, training_type, description, coach_comments, planned_duration_minutes, planned_distance_km, type_specific_data, is_completed, completed_at, actual_duration_minutes, actual_distance_km, actual_pace, avg_heart_rate, max_heart_rate, rpe, coach_post_feedback, trainee_notes, strava_activity_id, strava_synced_at, goal_id, result_distance_km, result_time_seconds, result_pace, is_strava_confirmed, created_at, updated_at',
+    )
     .eq('goal_id', goalId)
     .maybeSingle();
 

--- a/app/lib/utils/analytics.ts
+++ b/app/lib/utils/analytics.ts
@@ -42,8 +42,7 @@ export function computeSportBreakdown(sessions: TrainingSession[]): SportBreakdo
     const existing = byType[type];
 
     const actualDistance = session.actualDistanceKm ?? null;
-    const durationMinutes =
-      session.actualDurationMinutes ?? session.plannedDurationMinutes ?? 0;
+    const durationMinutes = session.actualDurationMinutes ?? session.plannedDurationMinutes ?? 0;
 
     const completed = session.isCompleted ? 1 : 0;
 

--- a/app/lib/utils/format.ts
+++ b/app/lib/utils/format.ts
@@ -1,0 +1,33 @@
+/**
+ * Format seconds to a time string (e.g. "1:23:45" or "5:30")
+ */
+export function formatTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * Format minutes to a value+unit pair (e.g. { value: "2h 30", unit: "min" })
+ */
+export function formatDuration(minutes: number): { value: string; unit: string } {
+  if (minutes === 0) return { value: '0', unit: 'min' };
+  if (minutes < 60) return { value: minutes.toString(), unit: 'min' };
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (m === 0) return { value: h.toString(), unit: 'h' };
+  return { value: `${h}h ${m}`, unit: 'min' };
+}
+
+/**
+ * Format minutes to a compact string (e.g. "2h 30m" or null for 0)
+ */
+export function formatDurationCompact(min: number): string | null {
+  if (min === 0) return null;
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}

--- a/app/lib/utils/goals.ts
+++ b/app/lib/utils/goals.ts
@@ -8,8 +8,7 @@ type SessionResult = Pick<TrainingSession, 'resultDistanceKm' | 'resultTimeSecon
  * Priority: distance check first, then time check. If no target set on the goal, returns pending.
  */
 export function computeGoalAchievement(goal: Goal, session: SessionResult): AchievementStatus {
-  const hasResult =
-    session.resultDistanceKm != null || session.resultTimeSeconds != null;
+  const hasResult = session.resultDistanceKm != null || session.resultTimeSeconds != null;
 
   if (!hasResult) return 'pending';
 

--- a/app/lib/utils/week-view.ts
+++ b/app/lib/utils/week-view.ts
@@ -34,12 +34,11 @@ export function computeWeekStats(sessions: TrainingSession[]): WeekStats {
   const totalPlannedKm = training.reduce((sum, s) => sum + (s.plannedDistanceKm ?? 0), 0);
   const totalCompletedKm = training
     .filter((s) => s.isCompleted)
-    .reduce((sum, s) => sum + (s.plannedDistanceKm ?? 0), 0);
+    .reduce((sum, s) => sum + (s.actualDistanceKm ?? s.plannedDistanceKm ?? 0), 0);
   const totalActualDurationMinutes = training
     .filter((s) => s.trainingType !== 'rest_day' && s.isCompleted)
     .reduce((sum, s) => sum + (s.actualDurationMinutes ?? s.plannedDurationMinutes ?? 0), 0);
-  const totalActualDistanceKm = training
-    .reduce((sum, s) => sum + (s.actualDistanceKm ?? 0), 0);
+  const totalActualDistanceKm = training.reduce((sum, s) => sum + (s.actualDistanceKm ?? 0), 0);
 
   return {
     totalSessions,

--- a/app/routes/athlete/goals.tsx
+++ b/app/routes/athlete/goals.tsx
@@ -6,10 +6,6 @@ export default function AthleteGoals() {
   const { user } = useAuth();
   const { data: canManage = false } = useSelfPlanPermission(user?.id ?? '');
   return (
-    <GoalListView
-      athleteId={user?.id ?? ''}
-      createdBy={user?.id ?? ''}
-      canManage={canManage}
-    />
+    <GoalListView athleteId={user?.id ?? ''} createdBy={user?.id ?? ''} canManage={canManage} />
   );
 }

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -19,7 +19,7 @@ import { useSelfPlanPermission } from '~/lib/hooks/useProfile';
 import { useGoals } from '~/lib/hooks/useGoals';
 import { useAuth } from '~/lib/context/AuthContext';
 import { queryKeys } from '~/lib/queries/keys';
-import { weekIdToMonday, parseWeekId, getTodayDayOfWeek } from '~/lib/utils/date';
+import { weekIdToMonday, getTodayDayOfWeek } from '~/lib/utils/date';
 import { isCompetitionWeek } from '~/lib/utils/goals';
 import { computeWeekStats, augmentSessionsWithGarmin } from '~/lib/utils/week-view';
 import { computeSportBreakdown } from '~/lib/utils/analytics';

--- a/app/routes/coach/goals.tsx
+++ b/app/routes/coach/goals.tsx
@@ -4,11 +4,5 @@ import { GoalListView } from '~/components/goals/GoalListView';
 export default function CoachGoals() {
   const { user, effectiveAthleteId } = useAuth();
   const athleteId = effectiveAthleteId ?? user?.id ?? '';
-  return (
-    <GoalListView
-      athleteId={athleteId}
-      createdBy={user?.id ?? ''}
-      canManage={true}
-    />
-  );
+  return <GoalListView athleteId={athleteId} createdBy={user?.id ?? ''} canManage={true} />;
 }

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -81,7 +81,8 @@ export default function CoachWeekView() {
     [goals, weekStart],
   );
   const competitionSession = useMemo(
-    () => (competitionGoal ? (sessions.find((s) => s.goalId === competitionGoal.id) ?? null) : null),
+    () =>
+      competitionGoal ? (sessions.find((s) => s.goalId === competitionGoal.id) ?? null) : null,
     [competitionGoal, sessions],
   );
 

--- a/app/test/integration/WeekSummary.test.tsx
+++ b/app/test/integration/WeekSummary.test.tsx
@@ -28,8 +28,20 @@ const STATS_WITH_BREAKDOWN: WeekStats = {
   totalActualDistanceKm: 10,
   totalActualDurationMinutes: 90,
   byType: {
-    run: { sessionCount: 2, completedSessionCount: 1, plannedDistanceKm: 15, actualDistanceKm: 10, totalDurationMinutes: 60 },
-    cycling: { sessionCount: 1, completedSessionCount: 0, plannedDistanceKm: 5, actualDistanceKm: 0, totalDurationMinutes: 30 },
+    run: {
+      sessionCount: 2,
+      completedSessionCount: 1,
+      plannedDistanceKm: 15,
+      actualDistanceKm: 10,
+      totalDurationMinutes: 60,
+    },
+    cycling: {
+      sessionCount: 1,
+      completedSessionCount: 0,
+      plannedDistanceKm: 5,
+      actualDistanceKm: 0,
+      totalDurationMinutes: 30,
+    },
   },
   competitionSessions: [],
 };

--- a/app/test/integration/useGoals.test.tsx
+++ b/app/test/integration/useGoals.test.tsx
@@ -17,9 +17,8 @@ import { queryKeys } from '~/lib/queries/keys';
 // ---------------------------------------------------------------------------
 
 vi.mock('~/lib/queries/goals', async () => {
-  const { mockFetchGoals, mockCreateGoal, mockUpdateGoal, mockDeleteGoal } = await import(
-    '~/lib/mock-data/goals'
-  );
+  const { mockFetchGoals, mockCreateGoal, mockUpdateGoal, mockDeleteGoal } =
+    await import('~/lib/mock-data/goals');
   return {
     fetchGoals: mockFetchGoals,
     createGoal: mockCreateGoal,
@@ -58,7 +57,7 @@ describe('useGoals', () => {
     expect(result.current.data!.length).toBe(2);
     // Sorted by competition date ascending
     expect(result.current.data![0].competitionDate < result.current.data![1].competitionDate).toBe(
-      true
+      true,
     );
   });
 
@@ -99,7 +98,7 @@ describe('useCreateGoal', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const cached = queryClient.getQueryData<Awaited<ReturnType<typeof mockFetchGoals>>>(
-      queryKeys.goals.byAthlete(ATHLETE_ID)
+      queryKeys.goals.byAthlete(ATHLETE_ID),
     );
     expect(cached?.some((g) => g.name === 'City Half Marathon')).toBe(true);
   });
@@ -117,10 +116,7 @@ describe('useDeleteGoal', () => {
     queryClient.setQueryData(queryKeys.goals.byAthlete(ATHLETE_ID), initialGoals);
     const targetId = initialGoals[0].id;
 
-    const { result } = renderHook(
-      () => useDeleteGoal(),
-      { wrapper: Wrapper }
-    );
+    const { result } = renderHook(() => useDeleteGoal(), { wrapper: Wrapper });
 
     await act(async () => {
       result.current.mutate({ id: targetId, athleteId: ATHLETE_ID });
@@ -128,7 +124,7 @@ describe('useDeleteGoal', () => {
 
     // Optimistic: should be gone immediately from cache
     const cached = queryClient.getQueryData<typeof initialGoals>(
-      queryKeys.goals.byAthlete(ATHLETE_ID)
+      queryKeys.goals.byAthlete(ATHLETE_ID),
     );
     expect(cached?.find((g) => g.id === targetId)).toBeUndefined();
 
@@ -143,10 +139,6 @@ describe('useDeleteGoal', () => {
     const targetId = initialGoals[0].id;
 
     // Make delete fail
-    const { deleteGoal } = await import('~/lib/queries/goals');
-    vi.spyOn({ deleteGoal }, 'deleteGoal').mockRejectedValueOnce(new Error('Network error'));
-
-    // We mock the actual query module function
     const goalsMod = await import('~/lib/queries/goals');
     const spy = vi.spyOn(goalsMod, 'deleteGoal').mockRejectedValueOnce(new Error('fail'));
 
@@ -159,7 +151,7 @@ describe('useDeleteGoal', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     const cached = queryClient.getQueryData<typeof initialGoals>(
-      queryKeys.goals.byAthlete(ATHLETE_ID)
+      queryKeys.goals.byAthlete(ATHLETE_ID),
     );
     // Goal should be restored after rollback
     expect(cached?.find((g) => g.id === targetId)).toBeDefined();
@@ -193,7 +185,7 @@ describe('useUpdateGoal', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const cached = queryClient.getQueryData<typeof initialGoals>(
-      queryKeys.goals.byAthlete(ATHLETE_ID)
+      queryKeys.goals.byAthlete(ATHLETE_ID),
     );
     expect(cached?.find((g) => g.id === target.id)?.name).toBe('Updated Goal Name');
   });

--- a/app/test/unit/analytics.test.ts
+++ b/app/test/unit/analytics.test.ts
@@ -40,9 +40,26 @@ function makeSession(overrides: Partial<TrainingSession>): TrainingSession {
   };
 }
 
-const RUN_SESSION = makeSession({ id: 's-run-1', trainingType: 'run', plannedDistanceKm: 10, plannedDurationMinutes: 60 });
-const RUN_SESSION_2 = makeSession({ id: 's-run-2', trainingType: 'run', plannedDistanceKm: 5, plannedDurationMinutes: 30, actualDistanceKm: 5.2, actualDurationMinutes: 28 });
-const CYCLING_SESSION = makeSession({ id: 's-cyc-1', trainingType: 'cycling', plannedDistanceKm: 40, plannedDurationMinutes: 90 });
+const RUN_SESSION = makeSession({
+  id: 's-run-1',
+  trainingType: 'run',
+  plannedDistanceKm: 10,
+  plannedDurationMinutes: 60,
+});
+const RUN_SESSION_2 = makeSession({
+  id: 's-run-2',
+  trainingType: 'run',
+  plannedDistanceKm: 5,
+  plannedDurationMinutes: 30,
+  actualDistanceKm: 5.2,
+  actualDurationMinutes: 28,
+});
+const CYCLING_SESSION = makeSession({
+  id: 's-cyc-1',
+  trainingType: 'cycling',
+  plannedDistanceKm: 40,
+  plannedDurationMinutes: 90,
+});
 const COMPETITION_SESSION = makeSession({
   id: 's-comp-1',
   trainingType: 'run',
@@ -106,5 +123,30 @@ describe('computeSportBreakdown', () => {
     // RUN_SESSION_2: has actual values → uses actual (5.2km, 28min)
     expect(result.byType.run!.actualDistanceKm).toBeCloseTo(5.2);
     expect(result.byType.run!.totalDurationMinutes).toBe(88); // 60 + 28
+  });
+
+  it('(f) rest_day sessions are aggregated into byType like any other sport', () => {
+    const restSession = makeSession({
+      id: 's-rest-1',
+      trainingType: 'rest_day',
+      plannedDistanceKm: 0,
+      plannedDurationMinutes: 0,
+    });
+    const restSession2 = makeSession({
+      id: 's-rest-2',
+      trainingType: 'rest_day',
+      plannedDistanceKm: 0,
+      plannedDurationMinutes: 0,
+      isCompleted: true,
+    });
+
+    const result = computeSportBreakdown([RUN_SESSION, restSession, restSession2]);
+
+    // rest_day sessions appear in byType
+    expect(result.byType.rest_day).toBeDefined();
+    expect(result.byType.rest_day!.sessionCount).toBe(2);
+    expect(result.byType.rest_day!.completedSessionCount).toBe(1);
+    // run sessions still aggregated separately
+    expect(result.byType.run!.sessionCount).toBe(1);
   });
 });

--- a/app/test/unit/goals.test.ts
+++ b/app/test/unit/goals.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { computeGoalAchievement, getPrepWeekRange, isWeekInPrepWindow } from '~/lib/utils/goals';
+import {
+  computeGoalAchievement,
+  getPrepWeekRange,
+  isWeekInPrepWindow,
+  isCompetitionWeek,
+} from '~/lib/utils/goals';
 import type { Goal } from '~/types/training';
 
 // ---------------------------------------------------------------------------
@@ -28,37 +33,37 @@ const baseGoal: Goal = {
 describe('computeGoalAchievement', () => {
   it('(a) returns pending when session has no result', () => {
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: null })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: null }),
     ).toBe('pending');
   });
 
   it('(b) returns achieved when resultDistanceKm >= goalDistanceKm', () => {
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: 10, resultTimeSeconds: null })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: 10, resultTimeSeconds: null }),
     ).toBe('achieved');
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: 10.5, resultTimeSeconds: null })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: 10.5, resultTimeSeconds: null }),
     ).toBe('achieved');
   });
 
   it('(c) returns missed when resultDistanceKm < goalDistanceKm', () => {
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: 9.5, resultTimeSeconds: null })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: 9.5, resultTimeSeconds: null }),
     ).toBe('missed');
   });
 
   it('(d) returns achieved when resultTimeSeconds <= goalTimeSeconds', () => {
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 2880 })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 2880 }),
     ).toBe('achieved');
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 3000 })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 3000 }),
     ).toBe('achieved');
   });
 
   it('(e) returns missed when resultTimeSeconds > goalTimeSeconds', () => {
     expect(
-      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 3120 })
+      computeGoalAchievement(baseGoal, { resultDistanceKm: null, resultTimeSeconds: 3120 }),
     ).toBe('missed');
   });
 
@@ -69,7 +74,7 @@ describe('computeGoalAchievement', () => {
       goalTimeSeconds: null,
     };
     expect(
-      computeGoalAchievement(noTargetGoal, { resultDistanceKm: 10, resultTimeSeconds: 2880 })
+      computeGoalAchievement(noTargetGoal, { resultDistanceKm: 10, resultTimeSeconds: 2880 }),
     ).toBe('pending');
   });
 });
@@ -124,5 +129,27 @@ describe('getPrepWeekRange', () => {
     const range = getPrepWeekRange(noPrep);
     expect(range.start).toBe('2026-05-23');
     expect(range.end).toBe('2026-05-23');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCompetitionWeek
+// ---------------------------------------------------------------------------
+
+describe('isCompetitionWeek', () => {
+  // competitionDate: 2026-05-23 (Saturday) → competition week Monday: 2026-05-18
+
+  it('(m) returns true when weekStart matches the competition date Monday', () => {
+    expect(isCompetitionWeek('2026-05-18', baseGoal)).toBe(true);
+  });
+
+  it('(n) returns false for prep weeks before the competition week', () => {
+    expect(isCompetitionWeek('2026-05-11', baseGoal)).toBe(false);
+    expect(isCompetitionWeek('2026-04-27', baseGoal)).toBe(false);
+  });
+
+  it('(o) returns false for weeks after the competition', () => {
+    expect(isCompetitionWeek('2026-05-25', baseGoal)).toBe(false);
+    expect(isCompetitionWeek('2026-06-01', baseGoal)).toBe(false);
   });
 });

--- a/app/test/unit/week-view.test.ts
+++ b/app/test/unit/week-view.test.ts
@@ -29,6 +29,10 @@ function makeSession(overrides: Partial<TrainingSession> = {}): TrainingSession 
     athleteNotes: null,
     stravaActivityId: null,
     stravaSyncedAt: null,
+    goalId: undefined,
+    resultDistanceKm: undefined,
+    resultTimeSeconds: undefined,
+    resultPace: undefined,
     createdAt: '2026-03-02T00:00:00Z',
     updatedAt: '2026-03-02T00:00:00Z',
     ...overrides,
@@ -150,5 +154,25 @@ describe('computeWeekStats', () => {
       makeSession({ id: 's2', plannedDistanceKm: 10 }),
     ];
     expect(computeWeekStats(sessions).totalPlannedKm).toBe(10);
+  });
+
+  it('excludes sessions with goalId from totals and counts', () => {
+    const sessions = [
+      makeSession({ id: 's1', trainingType: 'run', plannedDistanceKm: 10, isCompleted: true }),
+      makeSession({ id: 's2', trainingType: 'run', plannedDistanceKm: 5, goalId: 'goal-1' }),
+      makeSession({
+        id: 's3',
+        trainingType: 'cycling',
+        plannedDistanceKm: 20,
+        goalId: 'goal-2',
+        isCompleted: true,
+      }),
+    ];
+    const stats = computeWeekStats(sessions);
+    // Only s1 counts — s2 and s3 have goalId and are excluded
+    expect(stats.totalSessions).toBe(1);
+    expect(stats.completedSessions).toBe(1);
+    expect(stats.totalPlannedKm).toBe(10);
+    expect(stats.completionPercentage).toBe(100);
   });
 });

--- a/supabase/migrations/20260329160000_fix_analytics_search_path.sql
+++ b/supabase/migrations/20260329160000_fix_analytics_search_path.sql
@@ -1,0 +1,3 @@
+-- Fix: add search_path to SECURITY DEFINER function to prevent search_path injection.
+ALTER FUNCTION public.get_analytics_summary(UUID, TEXT, UUID, TEXT, DATE)
+  SET search_path = public, auth;


### PR DESCRIPTION
P0 Bugs:
- Fix totalCompletedKm to use actualDistanceKm with planned fallback
- Add missing is_strava_confirmed column to fetchSessionByGoalId
- Add SET search_path on SECURITY DEFINER analytics function
- Fix stale goalId state in AnalyticsView with useEffect sync
- Fix GoalDialog useEffect deps (goal object, not just id)
- Remove unused parseWeekId import
- Remove dead spy in useGoals test

P1 DRY/i18n/Feature:
- Extract formatTime/formatDuration/formatDurationCompact to shared format.ts
- Extract useGoalDialogState hook from GoalList/GoalListView
- Replace hardcoded English strings with i18n keys (EN + PL)
- Add Analytics nav item to BottomNav for mobile users

P2 Performance/Conventions:
- Add useMemo to VolumeChart data and axis props
- Use module-level noop instead of inline handlers
- Use date-fns isPast instead of raw new Date() comparison
- Type analytics query key as AnalyticsParams

P3 Polish:
- Add console.warn to silent catch blocks
- Implement mock for fetchSessionByGoalId
- Add aria-expanded, aria-label, role attributes for accessibility
- Add 5 new tests (isCompetitionWeek, goalId filtering, rest_day)