### PR TITLE
feat: Privacy Policy and Terms & Conditions (#44)

### DIFF
--- a/app/components/landing/LandingFooter.tsx
+++ b/app/components/landing/LandingFooter.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+
+export function LandingFooter() {
+  const { t } = useTranslation('landing');
+  const { locale = 'pl' } = useParams<{ locale: string }>();
+
+  return (
+    <footer className="border-t border-border bg-background">
+      <div className="mx-auto max-w-6xl px-6 py-8">
+        <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
+          <p className="text-xs font-medium tracking-widest text-muted-foreground/50 uppercase">
+            © {new Date().getFullYear()} Synek
+          </p>
+          <nav className="flex items-center gap-6">
+            <Link
+              to={`/${locale}/privacy-policy`}
+              className="text-xs font-medium tracking-wider text-muted-foreground/60 uppercase transition-colors hover:text-foreground"
+            >
+              {t('footer.privacyPolicy')}
+            </Link>
+            <span className="text-border" aria-hidden>
+              ·
+            </span>
+            <Link
+              to={`/${locale}/terms`}
+              className="text-xs font-medium tracking-wider text-muted-foreground/60 uppercase transition-colors hover:text-foreground"
+            >
+              {t('footer.terms')}
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/app/components/landing/LandingNav.tsx
+++ b/app/components/landing/LandingNav.tsx
@@ -120,11 +120,13 @@ export function LandingNav({ className }: LandingNavProps) {
         {/* Logo */}
         <Logo size="sm" />
 
-        {/* Desktop: marketing links centred, auth links + controls on far right */}
+        {/* Desktop: marketing links centred (landing only), auth links + controls on far right */}
         <div className="hidden flex-1 items-center md:flex">
-          <nav className="ml-8 flex items-center gap-6">
-            {MARKETING_LINKS.map((link) => renderMarketingLink(link))}
-          </nav>
+          {isLanding && (
+            <nav className="ml-8 flex items-center gap-6">
+              {MARKETING_LINKS.map((link) => renderMarketingLink(link))}
+            </nav>
+          )}
 
           {/* Pushes auth group to the far right */}
           <div className="ml-auto flex items-center gap-2">
@@ -157,7 +159,7 @@ export function LandingNav({ className }: LandingNavProps) {
       {menuOpen && (
         <div className="border-t border-[color:var(--separator)] bg-surface-1 px-4 pb-4 md:hidden">
           <nav className="flex flex-col divide-y divide-[color:var(--separator)]">
-            {MARKETING_LINKS.map((link) => renderMarketingLink(link, true))}
+            {isLanding && MARKETING_LINKS.map((link) => renderMarketingLink(link, true))}
             {/* Auth links in their own group with a heavier divider */}
             <div className="flex flex-col gap-0 pt-2">
               {AUTH_LINKS.map((link) => renderAuthLink(link as RouteLink, true))}

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -6,11 +6,13 @@ import enCoach from './resources/en/coach.json';
 import enAthlete from './resources/en/athlete.json';
 import enTraining from './resources/en/training.json';
 import enLanding from './resources/en/landing.json';
+import enLegal from './resources/en/legal.json';
 import plCommon from './resources/pl/common.json';
 import plCoach from './resources/pl/coach.json';
 import plAthlete from './resources/pl/athlete.json';
 import plTraining from './resources/pl/training.json';
 import plLanding from './resources/pl/landing.json';
+import plLegal from './resources/pl/legal.json';
 
 const resources = {
   en: {
@@ -19,6 +21,7 @@ const resources = {
     athlete: enAthlete,
     training: enTraining,
     landing: enLanding,
+    legal: enLegal,
   },
   pl: {
     common: plCommon,
@@ -26,6 +29,7 @@ const resources = {
     athlete: plAthlete,
     training: plTraining,
     landing: plLanding,
+    legal: plLegal,
   },
 };
 
@@ -34,7 +38,7 @@ i18n.use(initReactI18next).init({
   lng: 'pl',
   fallbackLng: 'en',
   defaultNS: 'common',
-  ns: ['common', 'coach', 'athlete', 'training', 'landing'],
+  ns: ['common', 'coach', 'athlete', 'training', 'landing', 'legal'],
   interpolation: {
     escapeValue: false,
   },

--- a/app/i18n/i18next.d.ts
+++ b/app/i18n/i18next.d.ts
@@ -4,6 +4,7 @@ import type coach from './resources/en/coach.json';
 import type athlete from './resources/en/athlete.json';
 import type training from './resources/en/training.json';
 import type landing from './resources/en/landing.json';
+import type legal from './resources/en/legal.json';
 
 declare module 'i18next' {
   interface CustomTypeOptions {
@@ -14,6 +15,7 @@ declare module 'i18next' {
       athlete: typeof athlete;
       training: typeof training;
       landing: typeof landing;
+      legal: typeof legal;
     };
   }
 }

--- a/app/i18n/resources/en/landing.json
+++ b/app/i18n/resources/en/landing.json
@@ -93,7 +93,17 @@
     "registrationError": "Something went wrong. Please try again.",
     "alreadyHaveAccount": "Already have an account?",
     "alreadyHaveAccountCta": "Log in →",
-    "cta": "Join the beta"
+    "cta": "Join the beta",
+    "consent": {
+      "prefix": "By registering you agree to our",
+      "terms": "Terms & Conditions",
+      "and": "and",
+      "privacy": "Privacy Policy"
+    }
+  },
+  "footer": {
+    "privacyPolicy": "Privacy Policy",
+    "terms": "Terms & Conditions"
   },
   "contact": {
     "title": "Write to us",

--- a/app/i18n/resources/en/legal.json
+++ b/app/i18n/resources/en/legal.json
@@ -1,0 +1,114 @@
+{
+  "backToHome": "Back to home",
+  "lastUpdated": "Last updated: April 9, 2026",
+
+  "privacy": {
+    "title": "Privacy Policy",
+    "intro": "Synek (the app, \"we\", \"our\", \"us\") is a training management platform that connects coaches and athletes. This Privacy Policy explains what personal data we collect, how we use it, and the rights you have over it. By creating an account or connecting your Strava profile, you agree to this policy.",
+
+    "section1": {
+      "title": "1. Who We Are",
+      "body": "Synek is operated during a public beta phase. For any privacy-related inquiries, please contact us at the address provided at the bottom of this page."
+    },
+
+    "section2": {
+      "title": "2. Data We Collect",
+      "body": "We collect the following categories of personal data:\n\n- Account data: your full name, email address, password (hashed), and role (coach or athlete).\n- Training plan data: sessions, performance notes, and goals you or your coach enter within the app.\n- Strava activity data: when you connect your Strava account, we fetch performance metrics (distance, duration, pace, heart rate, elevation, power) for activities that fall within a planned training week. We also store the OAuth access token and refresh token needed to maintain the connection."
+    },
+
+    "section3": {
+      "title": "3. How We Use Your Data",
+      "body": "We use the data we collect exclusively to provide the Synek service:\n\n- To display your weekly training plan and logged sessions.\n- To sync workout data from Strava so your coach can compare planned versus executed training.\n- To refresh your Strava access token automatically via a background job so the integration remains active.\n- To send administrative emails (e.g. invite links).\n\nWe do not sell your data, use it for advertising, or share it with any third party except as described in section 4."
+    },
+
+    "section4": {
+      "title": "4. Strava Integration and Data Privacy",
+      "body": "When you authorise Synek to connect to your Strava account:\n\n- We fetch your activity data solely to display it within your training plan.\n- Data is stored in our database associated with your user account.\n- We do not use Strava data to train, fine-tune, or test any Artificial Intelligence, Machine Learning, or Large Language Models.\n- We do not share your Strava activity data with any third party.\n- We display Strava attribution (\"Powered by Strava\") and include a \"View on Strava\" link on every synced activity, as required by Strava's brand guidelines."
+    },
+
+    "section5": {
+      "title": "5. Athlete Consent and Data Masking",
+      "body": "Strava workouts synced into Synek are private by default. When a workout is synced, its performance metrics are hidden from your coach until you explicitly choose to share them.\n\nYou share a workout by tapping \"Confirm & Share with Coach\" in the app. This action updates the activity status so your coach can see the full performance data. You remain in control — only the activities you confirm are visible to your coach."
+    },
+
+    "section6": {
+      "title": "6. Data Retention and Deletion",
+      "body": "We retain your data for as long as your account is active. You may delete your account at any time from the Settings page — this permanently removes all your data from our systems.\n\nIf you revoke Synek's access to your Strava account, we receive a webhook notification from Strava and automatically delete all Strava activity data and OAuth tokens associated with your account. This deletion is permanent and immediate."
+    },
+
+    "section7": {
+      "title": "7. Your Rights",
+      "body": "You have the right to:\n\n- Access the personal data we hold about you.\n- Correct inaccurate data.\n- Delete your account and all associated data directly from the Settings page.\n- Revoke Strava authorisation at any time via your Strava account settings.\n\nFor any other privacy requests, contact us using the details below."
+    },
+
+    "section8": {
+      "title": "8. Security",
+      "body": "Passwords are hashed before storage. Strava tokens are stored encrypted at rest. All data in transit is protected by TLS. Access to the database is restricted to authenticated services."
+    },
+
+    "section9": {
+      "title": "9. Changes to This Policy",
+      "body": "We may update this Privacy Policy from time to time. The date at the top of this page reflects the latest revision. Continued use of the service after changes constitutes acceptance of the revised policy."
+    },
+
+    "contact": {
+      "title": "Contact",
+      "body": "For any privacy-related questions, requests, or concerns, please email us at: hello@synek.app"
+    }
+  },
+
+  "terms": {
+    "title": "Terms & Conditions",
+    "intro": "These Terms & Conditions (\"Terms\") govern your access to and use of Synek (\"the Service\"). By creating an account you agree to be bound by these Terms.",
+
+    "section1": {
+      "title": "1. Beta Service",
+      "body": "Synek is currently in a public beta phase. The Service is provided free of charge during this period. Features may change, be removed, or be interrupted without prior notice. We make no guarantees regarding uptime, data retention, or feature availability during the beta."
+    },
+
+    "section2": {
+      "title": "2. Accounts",
+      "body": "You must provide accurate information when creating your account. You are responsible for maintaining the security of your password. You may not share your account with others. We reserve the right to suspend or terminate accounts that violate these Terms."
+    },
+
+    "section3": {
+      "title": "3. Coaches and Athletes",
+      "body": "Coaches may invite athletes to their group. By accepting an invitation, an athlete grants their coach visibility into their confirmed training data within Synek. Athletes retain control over which Strava workouts are shared with their coach (see our Privacy Policy, section 5)."
+    },
+
+    "section4": {
+      "title": "4. Strava Integration",
+      "body": "Connecting your Strava account is optional. By connecting Strava, you authorise Synek to access your activity data in accordance with Strava's API Agreement and our Privacy Policy. You can revoke this authorisation at any time through your Strava account settings, which will also trigger deletion of your Strava data from Synek."
+    },
+
+    "section5": {
+      "title": "5. Prohibited Uses",
+      "body": "You may not:\n\n- Use the Service for any unlawful purpose.\n- Attempt to gain unauthorised access to other users' data.\n- Interfere with the integrity or performance of the Service.\n- Scrape, reverse-engineer, or reproduce any part of the Service without permission."
+    },
+
+    "section6": {
+      "title": "6. Intellectual Property",
+      "body": "All content, design, and code in Synek are the property of the Synek team. You may not copy, reproduce, or distribute any part of the Service without our written permission."
+    },
+
+    "section7": {
+      "title": "7. Disclaimers",
+      "body": "The Service is provided on an as-is basis without warranties of any kind, express or implied. We do not warrant that the Service will be error-free, uninterrupted, or suitable for any particular purpose. Use the Service at your own risk."
+    },
+
+    "section8": {
+      "title": "8. Limitation of Liability",
+      "body": "To the maximum extent permitted by applicable law, Synek shall not be liable for any indirect, incidental, special, or consequential damages arising from your use of the Service, even if we have been advised of the possibility of such damages."
+    },
+
+    "section9": {
+      "title": "9. Changes to These Terms",
+      "body": "We may revise these Terms at any time. The updated date at the top of this page indicates the latest revision. Continued use of the Service after changes constitutes your acceptance of the revised Terms."
+    },
+
+    "contact": {
+      "title": "Contact",
+      "body": "If you have any questions about these Terms, please contact us at: hello@synek.app"
+    }
+  }
+}

--- a/app/i18n/resources/pl/landing.json
+++ b/app/i18n/resources/pl/landing.json
@@ -93,7 +93,17 @@
     "registrationError": "Coś poszło nie tak. Spróbuj ponownie.",
     "alreadyHaveAccount": "Masz już konto?",
     "alreadyHaveAccountCta": "Zaloguj się →",
-    "cta": "Dołącz do bety"
+    "cta": "Dołącz do bety",
+    "consent": {
+      "prefix": "Rejestrując się, akceptujesz nasz",
+      "terms": "Regulamin",
+      "and": "i",
+      "privacy": "Politykę prywatności"
+    }
+  },
+  "footer": {
+    "privacyPolicy": "Polityka prywatności",
+    "terms": "Regulamin"
   },
   "contact": {
     "title": "Napisz do nas",

--- a/app/i18n/resources/pl/legal.json
+++ b/app/i18n/resources/pl/legal.json
@@ -1,0 +1,114 @@
+{
+  "backToHome": "Wróć do strony głównej",
+  "lastUpdated": "Ostatnia aktualizacja: 9 kwietnia 2026",
+
+  "privacy": {
+    "title": "Polityka prywatności",
+    "intro": "Synek (\"my\", \"nasze\") to platforma do zarządzania treningiem, łącząca trenerów i zawodników. Niniejsza Polityka prywatności wyjaśnia, jakie dane osobowe zbieramy, jak je wykorzystujemy i jakie prawa Ci przysługują. Tworząc konto lub łącząc profil Strava, wyrażasz zgodę na niniejszą politykę.",
+
+    "section1": {
+      "title": "1. Kim jesteśmy",
+      "body": "Synek jest eksploatowany w fazie publicznej bety. W sprawie wszelkich kwestii związanych z prywatnością prosimy o kontakt pod adresem podanym na dole tej strony."
+    },
+
+    "section2": {
+      "title": "2. Dane, które zbieramy",
+      "body": "Zbieramy następujące kategorie danych osobowych:\n\n- Dane konta: imię i nazwisko, adres e-mail, hasło (zahaszowane) oraz rola (trener lub zawodnik).\n- Dane planu treningowego: sesje, notatki dotyczące wydajności i cele wpisane przez Ciebie lub Twojego trenera.\n- Dane o aktywności Strava: gdy połączysz konto Strava, pobieramy dane o wydajności (dystans, czas, tempo, tętno, przewyższenie, moc) dla aktywności w zaplanowanym tygodniu treningowym. Przechowujemy również token dostępowy OAuth i token odświeżania potrzebny do utrzymania połączenia."
+    },
+
+    "section3": {
+      "title": "3. Jak wykorzystujemy Twoje dane",
+      "body": "Zebrane dane wykorzystujemy wyłącznie w celu świadczenia usługi Synek:\n\n- Wyświetlania Twojego tygodniowego planu treningowego i zarejestrowanych sesji.\n- Synchronizowania danych treningowych ze Strava, aby Twój trener mógł porównać planowane i wykonane treningi.\n- Automatycznego odświeżania tokenu dostępowego Strava za pomocą zadania działającego w tle.\n- Wysyłania e-maili administracyjnych (np. linków z zaproszeniami).\n\nNie sprzedajemy Twoich danych, nie używamy ich do celów reklamowych ani nie udostępniamy ich stronom trzecim poza przypadkami opisanymi w sekcji 4."
+    },
+
+    "section4": {
+      "title": "4. Integracja ze Strava i prywatność danych",
+      "body": "Po upoważnieniu Synek do połączenia z Twoim kontem Strava:\n\n- Pobieramy dane o Twojej aktywności wyłącznie w celu ich wyświetlenia w Twoim planie treningowym.\n- Dane są przechowywane w naszej bazie danych powiązanej z Twoim kontem użytkownika.\n- Nie używamy danych Strava do trenowania, dostrajania ani testowania jakichkolwiek modeli sztucznej inteligencji, uczenia maszynowego ani dużych modeli językowych.\n- Nie udostępniamy danych o Twojej aktywności Strava żadnym stronom trzecim.\n- Na każdej zsynchronizowanej aktywności wyświetlamy atrybucję Strava (\"Powered by Strava\") i link \"View on Strava\", zgodnie z wytycznymi marki Strava."
+    },
+
+    "section5": {
+      "title": "5. Zgoda zawodnika i maskowanie danych",
+      "body": "Treningi Strava zsynchronizowane z Synek są domyślnie prywatne. Po synchronizacji treningu jego dane wydajnościowe są ukryte przed trenerem, dopóki nie zdecydujesz się ich udostępnić.\n\nUdostępniasz trening, klikając \"Potwierdź i udostępnij trenerowi\" w aplikacji. Ta czynność aktualizuje status aktywności, umożliwiając trenerowi wgląd w pełne dane. Masz pełną kontrolę — trener widzi tylko te aktywności, które potwierdzisz."
+    },
+
+    "section6": {
+      "title": "6. Przechowywanie i usuwanie danych",
+      "body": "Przechowujemy Twoje dane przez cały czas aktywności konta. Możesz usunąć konto w dowolnym momencie bezpośrednio z poziomu Ustawień — spowoduje to trwałe usunięcie wszystkich Twoich danych z naszych systemów.\n\nJeśli cofniesz dostęp Synek do Twojego konta Strava, otrzymamy powiadomienie webhook od Strava i automatycznie usuniemy wszystkie dane o aktywności Strava oraz tokeny OAuth powiązane z Twoim kontem. Usunięcie jest trwałe i natychmiastowe."
+    },
+
+    "section7": {
+      "title": "7. Twoje prawa",
+      "body": "Przysługuje Ci prawo do:\n\n- Dostępu do przechowywanych przez nas danych osobowych.\n- Poprawienia błędnych danych.\n- Usunięcia konta i wszystkich powiązanych danych bezpośrednio z poziomu Ustawień.\n- Cofnięcia autoryzacji Strava w dowolnym momencie za pośrednictwem ustawień konta Strava.\n\nW przypadku innych żądań dotyczących prywatności skontaktuj się z nami pod adresem podanym poniżej."
+    },
+
+    "section8": {
+      "title": "8. Bezpieczeństwo",
+      "body": "Hasła są hashowane przed zapisem. Tokeny Strava są przechowywane w postaci zaszyfrowanej. Wszystkie dane przesyłane są chronione przez TLS. Dostęp do bazy danych mają wyłącznie uwierzytelnione usługi."
+    },
+
+    "section9": {
+      "title": "9. Zmiany w tej polityce",
+      "body": "Możemy aktualizować niniejszą Politykę prywatności. Data na górze strony wskazuje ostatnią wersję. Dalsze korzystanie z usługi po wprowadzeniu zmian oznacza akceptację zaktualizowanej polityki."
+    },
+
+    "contact": {
+      "title": "Kontakt",
+      "body": "W sprawie pytań, próśb lub zastrzeżeń dotyczących prywatności napisz do nas: hello@synek.app"
+    }
+  },
+
+  "terms": {
+    "title": "Regulamin",
+    "intro": "Niniejszy Regulamin (\"Regulamin\") określa zasady dostępu do usługi Synek (\"Usługa\") i korzystania z niej. Tworząc konto, akceptujesz niniejszy Regulamin.",
+
+    "section1": {
+      "title": "1. Faza beta",
+      "body": "Synek jest obecnie w fazie publicznej bety. Usługa jest w tym czasie bezpłatna. Funkcje mogą ulec zmianie, zostać usunięte lub niedostępne bez wcześniejszego powiadomienia. Nie gwarantujemy dostępności, przechowywania danych ani stabilności funkcji w trakcie bety."
+    },
+
+    "section2": {
+      "title": "2. Konta",
+      "body": "Podczas tworzenia konta musisz podać rzetelne informacje. Jesteś odpowiedzialny za bezpieczeństwo swojego hasła. Nie możesz udostępniać konta innym osobom. Zastrzegamy sobie prawo do zawieszenia lub usunięcia kont naruszających niniejszy Regulamin."
+    },
+
+    "section3": {
+      "title": "3. Trenerzy i zawodnicy",
+      "body": "Trenerzy mogą zapraszać zawodników do swojej grupy. Akceptując zaproszenie, zawodnik przyznaje trenerowi wgląd w swoje potwierdzone dane treningowe w Synek. Zawodnik zachowuje kontrolę nad tym, które treningi ze Strava są udostępniane trenerowi (zob. Politykę prywatności, sekcja 5)."
+    },
+
+    "section4": {
+      "title": "4. Integracja ze Strava",
+      "body": "Połączenie konta Strava jest opcjonalne. Łącząc Strava, upoważniasz Synek do dostępu do danych o Twojej aktywności zgodnie z Umową API Strava i naszą Polityką prywatności. Możesz cofnąć tę autoryzację w dowolnym momencie w ustawieniach konta Strava, co spowoduje również usunięcie Twoich danych Strava z Synek."
+    },
+
+    "section5": {
+      "title": "5. Zakazane użycie",
+      "body": "Nie możesz:\n\n- Korzystać z Usługi w celach niezgodnych z prawem.\n- Próbować uzyskać nieautoryzowanego dostępu do danych innych użytkowników.\n- Zakłócać integralności lub wydajności Usługi.\n- Pobierać, inżynierować wstecznie ani reprodukować żadnej części Usługi bez zgody."
+    },
+
+    "section6": {
+      "title": "6. Własność intelektualna",
+      "body": "Wszelkie treści, projekt i kod w Synek stanowią własność zespołu Synek. Nie możesz kopiować, reprodukować ani dystrybuować żadnej części Usługi bez naszej pisemnej zgody."
+    },
+
+    "section7": {
+      "title": "7. Wyłączenia odpowiedzialności",
+      "body": "Usługa jest świadczona w stanie, w jakim jest, bez żadnych gwarancji, wyraźnych ani dorozumianych. Nie gwarantujemy, że Usługa będzie wolna od błędów, nieprzerwana ani odpowiednia do jakiegokolwiek konkretnego celu. Korzystasz z Usługi na własne ryzyko."
+    },
+
+    "section8": {
+      "title": "8. Ograniczenie odpowiedzialności",
+      "body": "W maksymalnym zakresie dopuszczonym przez obowiązujące prawo, Synek nie ponosi odpowiedzialności za żadne pośrednie, przypadkowe, szczególne ani wynikowe szkody wynikające z korzystania z Usługi, nawet jeśli zostaliśmy poinformowani o możliwości wystąpienia takich szkód."
+    },
+
+    "section9": {
+      "title": "9. Zmiany w Regulaminie",
+      "body": "Możemy zmieniać niniejszy Regulamin w dowolnym momencie. Data na górze strony wskazuje ostatnią wersję. Dalsze korzystanie z Usługi po wprowadzeniu zmian oznacza akceptację zaktualizowanego Regulaminu."
+    },
+
+    "contact": {
+      "title": "Kontakt",
+      "body": "W razie pytań dotyczących Regulaminu napisz do nas: hello@synek.app"
+    }
+  }
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,6 +13,8 @@ export default [
     index('routes/landing.tsx'),
     route('login', 'routes/login.tsx'),
     route('register', 'routes/register.tsx'),
+    route('privacy-policy', 'routes/privacy-policy.tsx'),
+    route('terms', 'routes/terms.tsx'),
 
     // App pages — wrapped with Header + BottomNav
     layout('routes/locale-layout.tsx', [

--- a/app/routes/landing.tsx
+++ b/app/routes/landing.tsx
@@ -7,6 +7,7 @@ import { WhySynekSection } from '~/components/landing/WhySynekSection';
 import { FeaturesSection } from '~/components/landing/FeaturesSection';
 import { JoinBetaSection } from '~/components/landing/JoinBetaSection';
 import { ContactSection } from '~/components/landing/ContactSection';
+import { LandingFooter } from '~/components/landing/LandingFooter';
 import { AppLoader } from '~/components/ui/app-loader';
 
 export function meta() {
@@ -45,6 +46,7 @@ export default function LandingPage() {
         <JoinBetaSection />
         <ContactSection />
       </main>
+      <LandingFooter />
     </div>
   );
 }

--- a/app/routes/privacy-policy.tsx
+++ b/app/routes/privacy-policy.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+import { ArrowLeft } from 'lucide-react';
+import { LandingNav } from '~/components/landing/LandingNav';
+
+export function meta() {
+  return [{ title: 'Privacy Policy — Synek' }];
+}
+
+const SECTIONS = [
+  'section1',
+  'section2',
+  'section3',
+  'section4',
+  'section5',
+  'section6',
+  'section7',
+  'section8',
+  'section9',
+] as const;
+
+export default function PrivacyPolicyPage() {
+  const { t } = useTranslation('legal');
+  const { locale = 'pl' } = useParams<{ locale: string }>();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <LandingNav />
+      <main className="mx-auto max-w-2xl px-6 pt-28 pb-24">
+        {/* Back link */}
+        <Link
+          to={`/${locale}`}
+          className="mb-10 inline-flex items-center gap-1.5 text-xs font-medium tracking-wider text-muted-foreground uppercase transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          {t('backToHome')}
+        </Link>
+
+        {/* Header */}
+        <header className="mb-12 border-b border-border pb-8">
+          <p className="mb-3 text-xs font-semibold tracking-widest text-muted-foreground/60 uppercase">
+            {t('lastUpdated')}
+          </p>
+          <h1 className="text-3xl font-black tracking-tight uppercase italic">
+            {t('privacy.title')}
+          </h1>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">{t('privacy.intro')}</p>
+        </header>
+
+        {/* Sections */}
+        <div className="space-y-10">
+          {SECTIONS.map((key) => (
+            <section key={key}>
+              <h2 className="mb-3 text-xs font-bold tracking-widest text-foreground/50 uppercase">
+                {t(`privacy.${key}.title`)}
+              </h2>
+              <p className="text-sm leading-7 whitespace-pre-line text-muted-foreground">
+                {t(`privacy.${key}.body`)}
+              </p>
+            </section>
+          ))}
+
+          <div className="border-t border-border pt-10">
+            <h2 className="mb-3 text-xs font-bold tracking-widest text-foreground/50 uppercase">
+              {t('privacy.contact.title')}
+            </h2>
+            <p className="text-sm leading-7 text-muted-foreground">{t('privacy.contact.body')}</p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -108,7 +108,10 @@ export default function RegisterPage() {
             setIsPending(false);
             return;
           }
-          if (payload.error === 'coach_limit_reached' || payload.error === 'athlete_limit_reached') {
+          if (
+            payload.error === 'coach_limit_reached' ||
+            payload.error === 'athlete_limit_reached'
+          ) {
             setError(t('beta.registrationLimitReached'));
             setIsPending(false);
             return;
@@ -246,6 +249,26 @@ export default function RegisterPage() {
             <Button type="submit" className="w-full" disabled={isPending || !role}>
               {isPending ? '…' : t('beta.submit')}
             </Button>
+
+            <p className="text-center text-xs text-muted-foreground">
+              {t('beta.consent.prefix')}{' '}
+              <Link
+                to={`/${locale}/terms`}
+                className="underline hover:text-foreground"
+                target="_blank"
+              >
+                {t('beta.consent.terms')}
+              </Link>{' '}
+              {t('beta.consent.and')}{' '}
+              <Link
+                to={`/${locale}/privacy-policy`}
+                className="underline hover:text-foreground"
+                target="_blank"
+              >
+                {t('beta.consent.privacy')}
+              </Link>
+              .
+            </p>
 
             <p className="text-center text-sm text-muted-foreground">
               {t('beta.alreadyHaveAccount')}{' '}

--- a/app/routes/terms.tsx
+++ b/app/routes/terms.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+import { ArrowLeft } from 'lucide-react';
+import { LandingNav } from '~/components/landing/LandingNav';
+
+export function meta() {
+  return [{ title: 'Terms & Conditions — Synek' }];
+}
+
+const SECTIONS = [
+  'section1',
+  'section2',
+  'section3',
+  'section4',
+  'section5',
+  'section6',
+  'section7',
+  'section8',
+  'section9',
+] as const;
+
+export default function TermsPage() {
+  const { t } = useTranslation('legal');
+  const { locale = 'pl' } = useParams<{ locale: string }>();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <LandingNav />
+      <main className="mx-auto max-w-2xl px-6 pt-28 pb-24">
+        {/* Back link */}
+        <Link
+          to={`/${locale}`}
+          className="mb-10 inline-flex items-center gap-1.5 text-xs font-medium tracking-wider text-muted-foreground uppercase transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          {t('backToHome')}
+        </Link>
+
+        {/* Header */}
+        <header className="mb-12 border-b border-border pb-8">
+          <p className="mb-3 text-xs font-semibold tracking-widest text-muted-foreground/60 uppercase">
+            {t('lastUpdated')}
+          </p>
+          <h1 className="text-3xl font-black tracking-tight uppercase italic">
+            {t('terms.title')}
+          </h1>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">{t('terms.intro')}</p>
+        </header>
+
+        {/* Sections */}
+        <div className="space-y-10">
+          {SECTIONS.map((key) => (
+            <section key={key}>
+              <h2 className="mb-3 text-xs font-bold tracking-widest text-foreground/50 uppercase">
+                {t(`terms.${key}.title`)}
+              </h2>
+              <p className="text-sm leading-7 whitespace-pre-line text-muted-foreground">
+                {t(`terms.${key}.body`)}
+              </p>
+            </section>
+          ))}
+
+          <div className="border-t border-border pt-10">
+            <h2 className="mb-3 text-xs font-bold tracking-widest text-foreground/50 uppercase">
+              {t('terms.contact.title')}
+            </h2>
+            <p className="text-sm leading-7 text-muted-foreground">{t('terms.contact.body')}</p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/[locale]/privacy-policy` and `/[locale]/terms` routes with full EN + PL content
- Privacy Policy covers Strava data handling, athlete consent/masking, and deletion on revocation — aligned with the Strava API limit extension submission requirements
- Adds `LandingFooter` with links to both legal pages (visible on the landing page)
- Adds a consent disclaimer on the register form linking to both docs
- Fixes `LandingNav`: marketing anchor links (`#why-synek`, `#features`, etc.) are now hidden on non-landing pages, preventing broken redirects through `root-redirect`

## Test plan

- [ ] Visit `/pl/privacy-policy` and `/en/privacy-policy` — content renders, back link navigates to landing
- [ ] Visit `/pl/terms` and `/en/terms` — same
- [ ] Confirm footer links appear on the landing page and navigate correctly
- [ ] Confirm register form shows consent line with working links (open in new tab)
- [ ] Confirm `LandingNav` on legal pages shows only logo + Log In + Join Beta (no anchor links)
- [ ] Toggle language on legal pages — content switches locale correctly
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)