### PR TITLE
fix: PKCE email templates, recovery flow, and auth-callback UX

### DIFF
--- a/app/lib/queries/auth-callbacks.ts
+++ b/app/lib/queries/auth-callbacks.ts
@@ -1,6 +1,17 @@
 import { supabase, isMockMode } from '~/lib/supabase';
 import type { UserRole } from '~/lib/auth';
 
+/**
+ * Checks whether the current browser has an active authenticated session.
+ * Used to distinguish "link expired" from "already confirmed" when an
+ * OTP token has been consumed (e.g. mobile preview consumed it first).
+ */
+export async function hasActiveSession(): Promise<boolean> {
+  if (isMockMode) return false;
+  const { data } = await supabase.auth.getSession();
+  return !!data.session;
+}
+
 // ============================================================
 // Mock implementations
 // ============================================================

--- a/app/routes/auth-callback.tsx
+++ b/app/routes/auth-callback.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useNavigate, useSearchParams, useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { Loader2 } from 'lucide-react';
 import { useAuth } from '~/lib/context/AuthContext';
 import {
   verifyEmailToken,
@@ -221,7 +222,7 @@ export default function AuthCallbackPage() {
       className="flex min-h-screen items-center justify-center px-4"
       data-testid="completing-signin-spinner"
     >
-      <p className="text-sm text-muted-foreground">{t('auth.completingSignIn')}</p>
+      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
     </main>
   );
 }

--- a/app/routes/auth-callback.tsx
+++ b/app/routes/auth-callback.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useNavigate, useSearchParams, useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '~/lib/context/AuthContext';
-import { verifyEmailToken, resendConfirmationEmail } from '~/lib/queries/auth-callbacks';
+import {
+  verifyEmailToken,
+  resendConfirmationEmail,
+  hasActiveSession,
+} from '~/lib/queries/auth-callbacks';
 import { Button } from '~/components/ui/button';
 
 type CardState = 'loading' | 'expired' | 'already-confirmed' | 'error' | 'oauth-timeout';
@@ -66,7 +70,11 @@ export default function AuthCallbackPage() {
     if (hashParams) {
       const errorCode = hashParams.get('error_code');
       if (errorCode === 'otp_expired') {
-        setCard('expired');
+        // Token consumed — check if the account was already confirmed
+        // (e.g. mobile preview consumed the link before desktop opened it)
+        hasActiveSession().then((active) => {
+          setCard(active ? 'already-confirmed' : 'expired');
+        });
         return;
       }
       if (hashParams.get('error')) {
@@ -101,10 +109,11 @@ export default function AuthCallbackPage() {
           const target = role === 'coach' ? `/${locale}/coach` : `/${locale}/athlete`;
           navigate(target, { replace: true });
         })
-        .catch((err: { code?: string; message?: string } | Error) => {
+        .catch(async (err: { code?: string; message?: string } | Error) => {
           const code = (err as { code?: string }).code ?? '';
           if (code === 'otp_expired') {
-            setCard('expired');
+            const active = await hasActiveSession();
+            setCard(active ? 'already-confirmed' : 'expired');
           } else if (
             code === 'otp_disabled' ||
             (err as Error).message?.includes('already confirmed')

--- a/app/test/integration/auth-callback.test.tsx
+++ b/app/test/integration/auth-callback.test.tsx
@@ -13,10 +13,12 @@ vi.mock('~/components/landing/LandingNav', () => ({
 // ---------------------------------------------------------------------------
 
 const mockVerifyEmailTokenFn = vi.fn();
+const mockHasActiveSessionFn = vi.fn().mockResolvedValue(false);
 
 vi.mock('~/lib/queries/auth-callbacks', () => ({
   verifyEmailToken: (...args: unknown[]) => mockVerifyEmailTokenFn(...args),
   resendConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+  hasActiveSession: () => mockHasActiveSessionFn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -86,6 +88,7 @@ beforeAll(async () => {
 describe('AuthCallbackPage', () => {
   beforeEach(() => {
     mockVerifyEmailTokenFn.mockReset();
+    mockHasActiveSessionFn.mockReset().mockResolvedValue(false);
     mockNavigate.mockReset();
     sessionStorage.clear();
     mockUser = { role: 'coach' };
@@ -117,6 +120,17 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('expired-link-card')).toBeInTheDocument();
+      });
+    });
+
+    it('shows already-confirmed card when otp_expired but session exists', async () => {
+      const error = { code: 'otp_expired', message: 'OTP expired' };
+      mockVerifyEmailTokenFn.mockRejectedValueOnce(error);
+      mockHasActiveSessionFn.mockResolvedValueOnce(true);
+      renderWithParams('?type=email&token_hash=used');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('already-confirmed-card')).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## Changes

### PKCE email templates (link-scanner safe)
- Email templates now use `{{ .RedirectTo }}?token_hash={{ .TokenHash }}` instead of `{{ .ConfirmationURL }}`
- Prevents link scanners (Cloudflare, etc.) from consuming single-use OTP tokens before users click them
- Updated branding: Synek → SYNEK in email templates

### Recovery flow fix
- `type=recovery` is now detected from hash fragment (implicit flow) in addition to query params (PKCE)
- PKCE recovery exchanges `token_hash` via `verifyOtp` before redirecting to reset-password
- Second effect guards against redirecting recovery sessions to dashboard

### UX improvements
- Shows 'already confirmed' instead of 'link expired' when session already exists (e.g. mobile preview consumed the link)
- Generic `Loader2` spinner replaces 'Completing sign-in...' text (flow-agnostic)
- Added `hasActiveSession()` helper in auth-callbacks

### Docs & tooling
- `scripts/supabase-deploy-email-templates.sh` for CI/CD deployment via Management API
- Updated `docs/how-to/auth-callback-pattern.md` with PKCE flow, signup type, and deployment docs

### Tests
- Updated recovery test: verifyEmailToken is now called with `recovery` type
- Added test: otp_expired + active session → already-confirmed card
- All 8 auth-callback tests pass