### PR TITLE
fix: exclude scripts/ from typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,6 @@
 {
-  "include": [
-    "**/*",
-    "**/.server/**/*",
-    "**/.client/**/*",
-    ".react-router/types/**/*"
-  ],
-  "exclude": [
-    "supabase/functions/**/*"
-  ],
+  "include": ["**/*", "**/.server/**/*", "**/.client/**/*", ".react-router/types/**/*"],
+  "exclude": ["scripts/**/*", "supabase/functions/**/*"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["node", "vite/client", "vitest/globals"],


### PR DESCRIPTION
scripts/generate-icons.ts imports sharp (not a runtime dependency), which breaks CI typecheck.