### PR TITLE
fix: add safe-area top padding to Header for iOS notch

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -18,7 +18,7 @@ export function Header() {
   const logoHref = user ? `/${resolvedLocale}/${user.role}` : '/';
 
   return (
-    <header className="sticky top-0 z-40 border-b border-[color:var(--separator)] bg-surface-1/80 backdrop-blur-md">
+    <header className="pt-safe sticky top-0 z-40 border-b border-[color:var(--separator)] bg-surface-1/80 backdrop-blur-md">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <div className="flex items-center gap-6">
           <Link to={logoHref} className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- `viewport-fit=cover` + `black-translucent` status bar causes the sticky header to render behind the iOS status bar
- Adds `pt-safe` (`env(safe-area-inset-top)`) to the `<header>` element, pushing content below the status bar

## Test plan
- [ ] Open app on iPhone (notched device) as home screen standalone app
- [ ] Verify header Logo and buttons are not obscured by status bar
- [ ] Verify layout looks correct on non-notched devices (safe-area inset = 0, no visible change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)