### PR TITLE
feat: iOS PWA install prompt, stale week redirect, safe area fixes

### DIFF
--- a/app/components/landing/LandingNav.tsx
+++ b/app/components/landing/LandingNav.tsx
@@ -113,7 +113,7 @@ export function LandingNav({ className }: LandingNavProps) {
   return (
     <header
       className={cn(
-        'fixed inset-x-0 top-0 z-50 border-b border-[color:var(--separator)] bg-surface-1/80 backdrop-blur-md',
+        'pt-safe fixed inset-x-0 top-0 z-50 border-b border-[color:var(--separator)] bg-surface-1/80 backdrop-blur-md',
         className,
       )}
     >

--- a/app/components/layout/InstallPrompt.tsx
+++ b/app/components/layout/InstallPrompt.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react';
+import { X, Share } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Logo } from './Logo';
+import { cn } from '~/lib/utils';
+import { isStandaloneMode } from '~/lib/utils/pwa';
+
+const STORAGE_KEY = 'pwa-install-dismissed';
+
+function isIOSSafari(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  const isIOS = /iPad|iPhone|iPod/.test(ua);
+  const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|OPiOS|mercury/.test(ua);
+  return isIOS && isSafari;
+}
+
+export function InstallPrompt() {
+  const { t } = useTranslation('common');
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isIOSSafari() || isStandaloneMode()) return;
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    const timer = setTimeout(() => setVisible(true), 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Auto-dismiss when user returns from share sheet / home screen
+  // (visibilitychange fires when they leave to add the icon and come back).
+  // Also auto-dismiss after 30s as a fallback.
+  useEffect(() => {
+    if (!visible) return;
+
+    let wasHidden = false;
+
+    function onVisibilityChange() {
+      if (document.hidden) {
+        wasHidden = true;
+      } else if (wasHidden) {
+        dismiss();
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    const fallback = setTimeout(dismiss, 30_000);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      clearTimeout(fallback);
+    };
+  }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!visible) return null;
+
+  function dismiss() {
+    setVisible(false);
+    localStorage.setItem(STORAGE_KEY, 'true');
+  }
+
+  return (
+    <div
+      role="complementary"
+      aria-label={t('install.ariaLabel')}
+      className={cn(
+        'fixed inset-x-4 z-50 md:hidden',
+        // position above BottomNav (h-14 = 3.5rem) + safe area + 8px gap
+        'bottom-[calc(3.5rem+env(safe-area-inset-bottom,0px)+0.5rem)]',
+        'flex items-center gap-3 rounded-xl px-4 py-3',
+        'border border-[color:var(--separator)]',
+        'bg-surface-2/95 shadow-lg backdrop-blur-md',
+        'animate-in duration-300 ease-out fade-in slide-in-from-bottom-3',
+      )}
+    >
+      <Logo size="sm" showWordmark={false} className="shrink-0" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm leading-tight font-semibold text-foreground">{t('install.title')}</p>
+        <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+          {t('install.instructionPre')}{' '}
+          <Share className="inline h-3 w-3 align-[-1px]" aria-hidden="true" />{' '}
+          {t('install.instructionPost')}
+        </p>
+      </div>
+      <button
+        onClick={dismiss}
+        aria-label={t('actions.close')}
+        className="-mr-1 flex h-8 w-8 shrink-0 touch-manipulation items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/app/i18n/resources/en/common.json
+++ b/app/i18n/resources/en/common.json
@@ -215,6 +215,12 @@
       "noData": "No Garmin data for this session"
     }
   },
+  "install": {
+    "ariaLabel": "Install app prompt",
+    "title": "Add Synek to Home Screen",
+    "instructionPre": "Tap",
+    "instructionPost": "then \"Add to Home Screen\""
+  },
   "strava": {
     "connect": "Connect with Strava",
     "connected": "Connected",

--- a/app/i18n/resources/pl/common.json
+++ b/app/i18n/resources/pl/common.json
@@ -215,6 +215,12 @@
       "noData": "Brak danych Garmin dla tego treningu"
     }
   },
+  "install": {
+    "ariaLabel": "Monit instalacji aplikacji",
+    "title": "Dodaj Synek do ekranu głównego",
+    "instructionPre": "Stuknij",
+    "instructionPost": "a następnie \"Dodaj do ekranu początkowego\""
+  },
   "strava": {
     "connect": "Połącz ze Stravą",
     "connected": "Połączono",

--- a/app/lib/utils/pwa.ts
+++ b/app/lib/utils/pwa.ts
@@ -1,0 +1,4 @@
+export function isStandaloneMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+}

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -19,7 +19,7 @@ import { useSelfPlanPermission } from '~/lib/hooks/useProfile';
 import { useGoals } from '~/lib/hooks/useGoals';
 import { useAuth } from '~/lib/context/AuthContext';
 import { queryKeys } from '~/lib/queries/keys';
-import { weekIdToMonday, getTodayDayOfWeek } from '~/lib/utils/date';
+import { weekIdToMonday, getTodayDayOfWeek, getCurrentWeekId } from '~/lib/utils/date';
 import { isCompetitionWeek } from '~/lib/utils/goals';
 import { computeWeekStats, groupSessionsByDay } from '~/lib/utils/week-view';
 import { augmentSessionsWithGarmin } from '~/lib/utils/junction-poc';
@@ -27,12 +27,20 @@ import { computeSportBreakdown } from '~/lib/utils/analytics';
 import { StravaActionsBar } from '~/components/calendar/StravaActionsBar';
 import { useWeekView } from '~/lib/hooks/useWeekView';
 import { cn } from '~/lib/utils';
+import { isStandaloneMode } from '~/lib/utils/pwa';
 import type { DayOfWeek } from '~/types/training';
-import { useParams, useLocation } from 'react-router';
+import { Navigate, useParams, useLocation } from 'react-router';
 
 export default function AthleteWeekView() {
-  const { weekId } = useParams();
+  const { weekId, locale } = useParams<{ weekId?: string; locale?: string }>();
   const location = useLocation();
+
+  // When launched from the home screen bookmark (standalone PWA), the saved URL
+  // may contain a stale week ID. Redirect to the current week automatically.
+  const todayWeekId = getCurrentWeekId();
+  if (isStandaloneMode() && weekId && weekId !== todayWeekId) {
+    return <Navigate to={`/${locale ?? 'pl'}/athlete/week/${todayWeekId}`} replace />;
+  }
   const { t } = useTranslation('athlete');
   const { user } = useAuth();
   const qc = useQueryClient();

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -11,15 +11,24 @@ import { DeleteConfirmationDialog } from '~/components/training/DeleteConfirmati
 import { useUpdateWeekPlan } from '~/lib/hooks/useWeekPlan';
 import { useGoals } from '~/lib/hooks/useGoals';
 import { useAuth } from '~/lib/context/AuthContext';
-import { getTodayDayOfWeek } from '~/lib/utils/date';
+import { getTodayDayOfWeek, getCurrentWeekId } from '~/lib/utils/date';
 import { isCompetitionWeek } from '~/lib/utils/goals';
+import { Navigate, useParams } from 'react-router';
 import { useWeekView } from '~/lib/hooks/useWeekView';
 import { cn } from '~/lib/utils';
+import { isStandaloneMode } from '~/lib/utils/pwa';
 import type { WeekPlan, SessionsByDay } from '~/types/training';
 
 export default function CoachWeekView() {
   const { t } = useTranslation('coach');
+  const { weekId, locale } = useParams<{ weekId?: string; locale?: string }>();
   const { user, effectiveAthleteId } = useAuth();
+
+  // Redirect stale bookmarked week to current week when opened from home screen
+  const todayWeekId = getCurrentWeekId();
+  if (isStandaloneMode() && weekId && weekId !== todayWeekId) {
+    return <Navigate to={`/${locale ?? 'pl'}/coach/week/${todayWeekId}`} replace />;
+  }
   const updateWeek = useUpdateWeekPlan();
 
   const weekView = useWeekView({ canAutoCreate: true });
@@ -48,7 +57,7 @@ export default function CoachWeekView() {
   if (!weekView) return null;
 
   const {
-    weekId,
+    weekId: currentWeekId,
     weekStart,
     weekPlan,
     sessions,
@@ -101,7 +110,7 @@ export default function CoachWeekView() {
   return (
     <>
       {showSkeleton && <AppLoader />}
-      <div key={weekId} className="animate-in space-y-6 duration-200 fade-in">
+      <div key={currentWeekId} className="animate-in space-y-6 duration-200 fade-in">
         {!showSkeleton && weekPlan && (
           <>
             {/* Header with navigation */}
@@ -111,7 +120,7 @@ export default function CoachWeekView() {
                   {t('title')}
                 </h1>
                 <WeekNavigation
-                  weekId={weekId}
+                  weekId={currentWeekId}
                   basePath="coach"
                   selectedDay={selectedDay}
                   isLoading={weekFetching}
@@ -145,7 +154,7 @@ export default function CoachWeekView() {
                 className={cn('transition-opacity duration-300', showStaleContent && 'opacity-0')}
               >
                 <MultiWeekView
-                  currentWeekId={weekId}
+                  currentWeekId={currentWeekId}
                   currentWeekPlan={showStaleContent ? null : weekPlan}
                   currentSessions={showStaleContent ? [] : sessions}
                   currentSessionsByDay={showStaleContent ? ({} as SessionsByDay) : sessionsByDay}

--- a/app/routes/locale-layout.tsx
+++ b/app/routes/locale-layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router';
 import { Header } from '~/components/layout/Header';
 import { BottomNav } from '~/components/layout/BottomNav';
+import { InstallPrompt } from '~/components/layout/InstallPrompt';
 
 export default function LocaleLayout() {
   return (
@@ -10,6 +11,7 @@ export default function LocaleLayout() {
         <Outlet />
       </main>
       <BottomNav />
+      <InstallPrompt />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- **Install prompt**: shows iOS Safari users a banner instructing them to tap Share → "Add to Home Screen"; auto-dismisses when they return from the share sheet (or after 30s); one-time only via `localStorage`
- **Stale bookmark redirect**: iOS saves the exact URL when bookmarking — opening it days later lands on an old week; standalone PWA mode now redirects to current week automatically (athlete + coach routes)
- **Landing nav safe area**: `LandingNav` was missing `pt-safe`, causing header overlap with the iOS notch
- **Shared util**: extracted `isStandaloneMode()` into `app/lib/utils/pwa.ts` (was duplicated inline in 3 places)

## Test plan

- [ ] Open app in iOS Safari → install banner appears after ~3s
- [ ] Tap X → banner gone, does not reappear on reload
- [ ] Tap Share → Add to Home Screen → return to Safari → banner auto-dismisses
- [ ] Open from home screen next week → redirects to current week
- [ ] Landing page header sits below notch on notched iPhone
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)