### PR TITLE
fix: prevent PWA week navigation bouncing back to current week

### DIFF
--- a/app/lib/utils/pwa.ts
+++ b/app/lib/utils/pwa.ts
@@ -2,3 +2,17 @@ export function isStandaloneMode(): boolean {
   if (typeof window === 'undefined') return false;
   return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
 }
+
+let sessionStarted = false;
+
+/**
+ * Returns true only on the very first render of the PWA session (i.e. app
+ * launched from home screen bookmark). Returns false for all subsequent
+ * in-app navigations so redirect guards don't fire on every route change.
+ */
+export function isStaleBookmarkLoad(): boolean {
+  if (!isStandaloneMode()) return false;
+  if (sessionStarted) return false;
+  sessionStarted = true;
+  return true;
+}

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -27,7 +27,7 @@ import { computeSportBreakdown } from '~/lib/utils/analytics';
 import { StravaActionsBar } from '~/components/calendar/StravaActionsBar';
 import { useWeekView } from '~/lib/hooks/useWeekView';
 import { cn } from '~/lib/utils';
-import { isStandaloneMode } from '~/lib/utils/pwa';
+import { isStaleBookmarkLoad } from '~/lib/utils/pwa';
 import type { DayOfWeek } from '~/types/training';
 import { Navigate, useParams, useLocation } from 'react-router';
 
@@ -38,7 +38,7 @@ export default function AthleteWeekView() {
   // When launched from the home screen bookmark (standalone PWA), the saved URL
   // may contain a stale week ID. Redirect to the current week automatically.
   const todayWeekId = getCurrentWeekId();
-  if (isStandaloneMode() && weekId && weekId !== todayWeekId) {
+  if (isStaleBookmarkLoad() && weekId && weekId !== todayWeekId) {
     return <Navigate to={`/${locale ?? 'pl'}/athlete/week/${todayWeekId}`} replace />;
   }
   const { t } = useTranslation('athlete');

--- a/app/routes/coach/week.$weekId.tsx
+++ b/app/routes/coach/week.$weekId.tsx
@@ -16,7 +16,7 @@ import { isCompetitionWeek } from '~/lib/utils/goals';
 import { Navigate, useParams } from 'react-router';
 import { useWeekView } from '~/lib/hooks/useWeekView';
 import { cn } from '~/lib/utils';
-import { isStandaloneMode } from '~/lib/utils/pwa';
+import { isStaleBookmarkLoad } from '~/lib/utils/pwa';
 import type { WeekPlan, SessionsByDay } from '~/types/training';
 
 export default function CoachWeekView() {
@@ -26,7 +26,7 @@ export default function CoachWeekView() {
 
   // Redirect stale bookmarked week to current week when opened from home screen
   const todayWeekId = getCurrentWeekId();
-  if (isStandaloneMode() && weekId && weekId !== todayWeekId) {
+  if (isStaleBookmarkLoad() && weekId && weekId !== todayWeekId) {
     return <Navigate to={`/${locale ?? 'pl'}/coach/week/${todayWeekId}`} replace />;
   }
   const updateWeek = useUpdateWeekPlan();


### PR DESCRIPTION
## Problem

In standalone PWA mode, tapping prev/next week immediately redirected back to the current week. The `isStandaloneMode()` check fired on every render — so navigating to a different week triggered the redirect guard again.

## Fix

Replaced `isStandaloneMode()` with `isStaleBookmarkLoad()` — backed by a module-level boolean that flips `true` on first render (the initial page load from the home screen bookmark) and stays `true` for all subsequent in-app navigations within the same session.

Page reload (opening PWA from home screen) → module re-evaluates → redirect fires once if week is stale. Client-side nav → module stays loaded → redirect skipped.

No DOM APIs, no `sessionStorage`.

## Test plan

- [ ] Open PWA from home screen on a stale week → redirects to current week
- [ ] Navigate to prev/next week → stays on that week (no bounce)
- [ ] Close PWA fully, reopen on stale week → redirects again
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)