### PR TITLE
feat: add support page with Turnstile, Resend email, and DB persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@ VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
 # Local dev: supabase secrets set APP_URL=http://localhost:5173
 # Production: supabase secrets set APP_URL=https://<your-domain>
 APP_URL=http://localhost:5173
+
+# Resend (transactional email — used by submit-support Edge Function)
+#   supabase secrets set RESEND_API_KEY=...
+# Optional sender/recipient overrides (defaults: support@synek.app → hello@synek.app):
+#   supabase secrets set SUPPORT_FROM="SYNEK Support <support@synek.app>"
+#   supabase secrets set SUPPORT_TO="hello@synek.app"

--- a/app/components/landing/LandingFooter.tsx
+++ b/app/components/landing/LandingFooter.tsx
@@ -10,9 +10,18 @@ export function LandingFooter() {
       <div className="mx-auto max-w-6xl px-6 py-8">
         <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
           <p className="text-xs font-medium tracking-widest text-muted-foreground/50 uppercase">
-            © {new Date().getFullYear()} Synek
+            © {new Date().getFullYear()} SYNEK
           </p>
           <nav className="flex items-center gap-6">
+            <Link
+              to={`/${locale}/support`}
+              className="text-xs font-medium tracking-wider text-muted-foreground/60 uppercase transition-colors hover:text-foreground"
+            >
+              {t('footer.support')}
+            </Link>
+            <span className="text-border" aria-hidden>
+              ·
+            </span>
             <Link
               to={`/${locale}/privacy-policy`}
               className="text-xs font-medium tracking-wider text-muted-foreground/60 uppercase transition-colors hover:text-foreground"

--- a/app/components/landing/SupportSection.tsx
+++ b/app/components/landing/SupportSection.tsx
@@ -1,0 +1,303 @@
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CheckCircle2, HelpCircle, Bug, Zap, UserRound } from 'lucide-react';
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile';
+import { useAuth } from '~/lib/context/AuthContext';
+import { useSubmitSupport } from '~/lib/hooks/useSupport';
+import { SupportSubmissionError } from '~/lib/queries/support';
+import { SUPPORT_CATEGORIES, supportSchema, type SupportCategory } from '~/lib/schemas/support';
+import { Button } from '~/components/ui/button';
+import { Input } from '~/components/ui/input';
+import { cn } from '~/lib/utils';
+
+const CATEGORY_ICONS: Record<SupportCategory, React.ElementType> = {
+  general: HelpCircle,
+  bug: Bug,
+  strava: Zap,
+  account: UserRound,
+};
+
+const MAX_MESSAGE = 5000;
+
+interface SupportSectionProps {
+  className?: string;
+}
+
+export function SupportSection({ className }: SupportSectionProps) {
+  const { t } = useTranslation('landing');
+  const { user } = useAuth();
+  const { mutate, status, reset } = useSubmitSupport();
+  const turnstileRef = useRef<TurnstileInstance>(null);
+
+  const [name, setName] = useState(user?.name ?? '');
+  const [email, setEmail] = useState(user?.email ?? '');
+  const [category, setCategory] = useState<SupportCategory>('general');
+  const [message, setMessage] = useState('');
+  const [honeypot, setHoneypot] = useState('');
+  const [cfToken, setCfToken] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const isSuccess = status === 'success';
+  const isPending = status === 'pending';
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (honeypot) return;
+
+    const result = supportSchema.safeParse({
+      name: name.trim(),
+      email: email.trim(),
+      message: message.trim(),
+      category,
+      cfToken,
+    });
+
+    if (!result.success) {
+      const errs: Record<string, string> = {};
+      for (const issue of result.error.issues) {
+        errs[String(issue.path[0])] = issue.message;
+      }
+      setFieldErrors(errs);
+      return;
+    }
+
+    setFieldErrors({});
+    setErrorMsg(null);
+
+    mutate(
+      { ...result.data, userId: user?.id ?? null, honeypot },
+      {
+        onSuccess: () => {
+          setMessage('');
+        },
+        onError: (err) => {
+          if (err instanceof SupportSubmissionError) {
+            if (err.code === 'turnstile_failed') {
+              setErrorMsg(t('errors.turnstileFailed', { ns: 'common' }));
+              setCfToken('');
+              turnstileRef.current?.reset();
+            } else if (err.code === 'rate_limited') {
+              setErrorMsg(t('errors.rateLimited', { ns: 'common' }));
+            } else if (err.code === 'invalid_email') {
+              setFieldErrors({ email: t('support.invalidEmail') });
+            } else {
+              setErrorMsg(t('support.submitError'));
+            }
+          } else {
+            setErrorMsg(t('support.submitError'));
+          }
+        },
+      },
+    );
+  }
+
+  return (
+    <section
+      id="support"
+      className={cn(
+        'border-t border-border/40 bg-surface-2/50 px-4 pt-28 pb-24 sm:pt-36 sm:pb-32',
+        className,
+      )}
+    >
+      <div className="mx-auto max-w-md">
+        {!isSuccess && (
+          <div className="mb-12 text-center">
+            <h1 className="text-3xl font-black tracking-tighter uppercase italic sm:text-5xl">
+              {t('support.title')}
+            </h1>
+            <p className="mt-4 font-medium text-muted-foreground">{t('support.subtitle')}</p>
+            <p className="mt-3 inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/8 px-3 py-1 text-[10px] font-bold tracking-[0.2em] text-primary uppercase">
+              {t('support.responseNote')}
+            </p>
+          </div>
+        )}
+
+        {isSuccess ? (
+          <div className="flex flex-col items-center gap-5 rounded-xl border border-border/50 bg-surface-1 p-12 text-center shadow-sm">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-green-500/10 text-green-600">
+              <CheckCircle2 className="h-7 w-7" />
+            </div>
+            <div className="space-y-1">
+              <p className="font-bold tracking-tight uppercase">{t('support.submitSuccess')}</p>
+              <p className="text-xs text-muted-foreground">{t('support.subtitle')}</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-2 text-xs text-muted-foreground"
+              onClick={() => {
+                reset();
+                setCfToken('');
+                turnstileRef.current?.reset();
+              }}
+            >
+              {t('support.submitAnother')}
+            </Button>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            noValidate
+            aria-label="Support request form"
+            className="space-y-5 rounded-xl border border-border/50 bg-surface-1 p-8 shadow-sm"
+          >
+            {/* Category */}
+            <fieldset>
+              <legend className="mb-3 block text-[10px] font-bold tracking-wider text-muted-foreground/80 uppercase">
+                {t('support.categoryLabel')}
+              </legend>
+              <div className="grid grid-cols-2 gap-2">
+                {SUPPORT_CATEGORIES.map((c) => {
+                  const Icon = CATEGORY_ICONS[c];
+                  return (
+                    <button
+                      key={c}
+                      type="button"
+                      onClick={() => setCategory(c)}
+                      aria-pressed={category === c}
+                      className={cn(
+                        'flex items-center gap-2 rounded-md border px-3 py-2.5 text-xs font-semibold tracking-wide transition-colors',
+                        category === c
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-border bg-background text-foreground hover:bg-muted',
+                      )}
+                    >
+                      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      {t(`support.category.${c}`)}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+
+            {/* Name */}
+            <div className="space-y-2">
+              <label
+                htmlFor="support-name"
+                className="block text-[10px] font-bold tracking-wider text-muted-foreground/80 uppercase"
+              >
+                {t('support.name')}
+              </label>
+              <Input
+                id="support-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="name"
+                required
+                aria-required="true"
+                className="h-11 bg-background/50 transition-colors focus:bg-background"
+              />
+              {fieldErrors.name && (
+                <p className="text-xs font-medium text-destructive" role="alert">
+                  {fieldErrors.name}
+                </p>
+              )}
+            </div>
+
+            {/* Email */}
+            <div className="space-y-2">
+              <label
+                htmlFor="support-email"
+                className="block text-[10px] font-bold tracking-wider text-muted-foreground/80 uppercase"
+              >
+                {t('support.email')}
+              </label>
+              <Input
+                id="support-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+                aria-required="true"
+                className="h-11 bg-background/50 transition-colors focus:bg-background"
+              />
+              {fieldErrors.email && (
+                <p className="text-xs font-medium text-destructive" role="alert">
+                  {fieldErrors.email}
+                </p>
+              )}
+            </div>
+
+            {/* Message */}
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between">
+                <label
+                  htmlFor="support-message"
+                  className="block text-[10px] font-bold tracking-wider text-muted-foreground/80 uppercase"
+                >
+                  {t('support.message')}
+                </label>
+                <span
+                  className={cn(
+                    'text-[10px] tabular-nums',
+                    message.length > MAX_MESSAGE * 0.9
+                      ? 'text-destructive'
+                      : 'text-muted-foreground/40',
+                  )}
+                >
+                  {message.length}/{MAX_MESSAGE}
+                </span>
+              </div>
+              <textarea
+                id="support-message"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder={t('support.messagePlaceholder')}
+                required
+                aria-required="true"
+                maxLength={MAX_MESSAGE}
+                rows={6}
+                className="w-full resize-none rounded-md border border-input bg-background/50 px-3 py-2 text-sm ring-offset-background transition-colors placeholder:text-muted-foreground/50 focus:bg-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              />
+              {fieldErrors.message && (
+                <p className="text-xs font-medium text-destructive" role="alert">
+                  {fieldErrors.message}
+                </p>
+              )}
+            </div>
+
+            {/* Honeypot */}
+            <input
+              name="website"
+              tabIndex={-1}
+              aria-hidden="true"
+              className="sr-only"
+              value={honeypot}
+              onChange={(e) => setHoneypot(e.target.value)}
+            />
+
+            <Turnstile
+              ref={turnstileRef}
+              siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY ?? ''}
+              onSuccess={setCfToken}
+              onError={() => setErrorMsg(t('errors.turnstileFailed', { ns: 'common' }))}
+              onExpire={() => setCfToken('')}
+            />
+
+            {errorMsg && (
+              <p className="text-xs font-medium text-destructive" role="alert" aria-live="polite">
+                {errorMsg}
+              </p>
+            )}
+
+            {!cfToken && !errorMsg && (
+              <p className="text-center text-xs text-muted-foreground">
+                {t('errors.turnstileVerifying', { ns: 'common' })}
+              </p>
+            )}
+
+            <Button
+              type="submit"
+              className="h-12 w-full text-sm font-bold tracking-widest uppercase italic"
+              disabled={isPending || !cfToken}
+            >
+              {isPending ? '…' : t('support.submit')}
+            </Button>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/i18n/resources/en/landing.json
+++ b/app/i18n/resources/en/landing.json
@@ -112,7 +112,8 @@
   },
   "footer": {
     "privacyPolicy": "Privacy Policy",
-    "terms": "Terms & Conditions"
+    "terms": "Terms & Conditions",
+    "support": "Support"
   },
   "contact": {
     "title": "Write to us",
@@ -125,5 +126,26 @@
     "submit": "Send message",
     "submitSuccess": "Message sent — thank you! We'll get back to you soon.",
     "submitError": "Something went wrong. Please try again."
+  },
+  "support": {
+    "title": "Need help?",
+    "subtitle": "Tell us what's going wrong and we'll get you back on track.",
+    "responseNote": "We aim to reply within one business day",
+    "categoryLabel": "What's this about?",
+    "category": {
+      "general": "General",
+      "bug": "Bug",
+      "strava": "Strava sync",
+      "account": "Account"
+    },
+    "name": "Your name",
+    "email": "Your email",
+    "message": "Describe your issue",
+    "messagePlaceholder": "What happened, what you expected, and any steps to reproduce...",
+    "submit": "Send to support",
+    "submitAnother": "Send another request",
+    "submitSuccess": "We got it — thank you! Our team will get back to you soon.",
+    "submitError": "Something went wrong. Please try again.",
+    "invalidEmail": "Invalid email address"
   }
 }

--- a/app/i18n/resources/pl/landing.json
+++ b/app/i18n/resources/pl/landing.json
@@ -112,7 +112,8 @@
   },
   "footer": {
     "privacyPolicy": "Polityka prywatności",
-    "terms": "Regulamin"
+    "terms": "Regulamin",
+    "support": "Pomoc"
   },
   "contact": {
     "title": "Napisz do nas",
@@ -125,5 +126,26 @@
     "submit": "Wyślij wiadomość",
     "submitSuccess": "Wiadomość wysłana — dziękujemy! Odezwiemy się wkrótce.",
     "submitError": "Coś poszło nie tak. Spróbuj ponownie."
+  },
+  "support": {
+    "title": "Potrzebujesz pomocy?",
+    "subtitle": "Opisz problem, a pomożemy Ci wrócić na właściwe tory.",
+    "responseNote": "Odpowiadamy w ciągu jednego dnia roboczego",
+    "categoryLabel": "Czego dotyczy zgłoszenie?",
+    "category": {
+      "general": "Ogólne",
+      "bug": "Błąd",
+      "strava": "Synchronizacja Strava",
+      "account": "Konto"
+    },
+    "name": "Imię i nazwisko",
+    "email": "Twój e-mail",
+    "message": "Opisz problem",
+    "messagePlaceholder": "Co się stało, czego oczekiwałeś i kroki do odtworzenia...",
+    "submit": "Wyślij do wsparcia",
+    "submitAnother": "Wyślij kolejne zgłoszenie",
+    "submitSuccess": "Mamy Twoje zgłoszenie — dziękujemy! Wrócimy do Ciebie wkrótce.",
+    "submitError": "Coś poszło nie tak. Spróbuj ponownie.",
+    "invalidEmail": "Nieprawidłowy adres email"
   }
 }

--- a/app/lib/hooks/useSupport.ts
+++ b/app/lib/hooks/useSupport.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { submitSupport } from '~/lib/queries/support';
+
+export function useSubmitSupport() {
+  return useMutation({
+    mutationFn: submitSupport,
+  });
+}

--- a/app/lib/hooks/useSupport.ts
+++ b/app/lib/hooks/useSupport.ts
@@ -1,8 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '~/lib/queries/keys';
 import { submitSupport } from '~/lib/queries/support';
 
 export function useSubmitSupport() {
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: submitSupport,
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.support.all });
+    },
   });
 }

--- a/app/lib/queries/keys.ts
+++ b/app/lib/queries/keys.ts
@@ -29,6 +29,9 @@ export const queryKeys = {
   feedback: {
     all: ['feedback'] as const,
   },
+  support: {
+    all: ['support'] as const,
+  },
   sessionLaps: {
     all: ['sessionLaps'] as const,
     bySession: (sessionId: string) => ['sessionLaps', sessionId] as const,

--- a/app/lib/queries/support.ts
+++ b/app/lib/queries/support.ts
@@ -1,0 +1,58 @@
+import { isMockMode } from '~/lib/supabase';
+import type { SupportCategory } from '~/lib/schemas/support';
+
+export interface SubmitSupportInput {
+  name: string;
+  email: string;
+  message: string;
+  category: SupportCategory;
+  userId?: string | null;
+  cfToken: string;
+  honeypot: string;
+}
+
+export type SupportError =
+  | 'turnstile_failed'
+  | 'rate_limited'
+  | 'invalid_email'
+  | 'invalid_category'
+  | 'invalid_params'
+  | 'missing_params'
+  | 'internal_error';
+
+export class SupportSubmissionError extends Error {
+  code: SupportError;
+  constructor(code: SupportError) {
+    super(code);
+    this.code = code;
+  }
+}
+
+export async function submitSupport(input: SubmitSupportInput): Promise<void> {
+  if (isMockMode) {
+    return;
+  }
+
+  const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/submit-support`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({
+      name: input.name,
+      email: input.email,
+      message: input.message,
+      category: input.category,
+      userId: input.userId ?? null,
+      website: input.honeypot,
+      cfToken: input.cfToken,
+    }),
+  });
+
+  const payload = (await res.json().catch(() => ({}))) as { success?: boolean; error?: string };
+
+  if (!res.ok || !payload.success) {
+    throw new SupportSubmissionError((payload.error as SupportError) ?? 'internal_error');
+  }
+}

--- a/app/lib/schemas/support.ts
+++ b/app/lib/schemas/support.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const SUPPORT_CATEGORIES = ['general', 'bug', 'strava', 'account'] as const;
+export type SupportCategory = (typeof SUPPORT_CATEGORIES)[number];
+
+export const supportSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  email: z.string().email('Invalid email').max(254),
+  message: z.string().min(1, 'Message is required').max(5000),
+  category: z.enum(SUPPORT_CATEGORIES),
+  cfToken: z.string().min(1, 'Bot check token is required'),
+});
+
+export type SupportFormData = z.infer<typeof supportSchema>;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -20,6 +20,7 @@ export default [
     route('forgot-password', 'routes/forgot-password.tsx'),
     route('reset-password', 'routes/reset-password.tsx'),
     route('select-role', 'routes/select-role.tsx'),
+    route('support', 'routes/support.tsx'),
 
     // App pages — wrapped with Header + BottomNav
     layout('routes/locale-layout.tsx', [

--- a/app/routes/support.tsx
+++ b/app/routes/support.tsx
@@ -1,0 +1,19 @@
+import { LandingNav } from '~/components/landing/LandingNav';
+import { LandingFooter } from '~/components/landing/LandingFooter';
+import { SupportSection } from '~/components/landing/SupportSection';
+
+export function meta() {
+  return [{ title: 'Support — SYNEK' }];
+}
+
+export default function SupportPage() {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <LandingNav />
+      <main className="flex-1">
+        <SupportSection />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/deno.lock
+++ b/deno.lock
@@ -15,6 +15,12 @@
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     }
   },
+  "redirects": {
+    "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2.104.1"
+  },
+  "remote": {
+    "https://esm.sh/@supabase/supabase-js@2.104.1": "bad73bfa9aac8a6d896e7a1d4449c7c2ece9a01bccca9e9569f1ed0fc76b5222"
+  },
   "workspace": {
     "packageJson": {
       "dependencies": [
@@ -60,6 +66,7 @@
         "npm:release-it@^19.2.4",
         "npm:shadcn@^3.8.5",
         "npm:sonner@^2.0.7",
+        "npm:supabase@^2.89.1",
         "npm:tailwind-merge@^3.5.0",
         "npm:tailwindcss@^4.1.13",
         "npm:tsx@^4.19.3",

--- a/supabase/functions/submit-support/index.ts
+++ b/supabase/functions/submit-support/index.ts
@@ -1,0 +1,248 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { checkAndIncrementRateLimit } from '../register-user/rate-limit.ts';
+
+// Required env vars:
+//   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY — injected by Supabase runtime
+//   TURNSTILE_SECRET_KEY — bot check
+//   RESEND_API_KEY — email delivery
+//   SUPPORT_FROM (optional) — defaults to support@synek.app
+//   SUPPORT_TO (optional) — defaults to hello@synek.app
+
+const RATE_LIMIT_WINDOW_MINUTES = 10;
+const RATE_LIMIT_MAX_ATTEMPTS = 5;
+
+const MAX_NAME_LENGTH = 100;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_MESSAGE_LENGTH = 5000;
+
+const VALID_CATEGORIES = ['general', 'bug', 'strava', 'account'] as const;
+type Category = (typeof VALID_CATEGORIES)[number];
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-client-info, apikey',
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+}
+
+async function verifyTurnstile(token: string, ip: string): Promise<boolean> {
+  const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      secret: Deno.env.get('TURNSTILE_SECRET_KEY'),
+      response: token,
+      remoteip: ip,
+    }),
+  });
+  const data = (await res.json()) as { success: boolean };
+  return data.success;
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+async function sendSupportEmail(payload: {
+  name: string;
+  email: string;
+  message: string;
+  category: Category | null;
+  userId: string | null;
+}): Promise<boolean> {
+  const apiKey = Deno.env.get('RESEND_API_KEY');
+  if (!apiKey) {
+    console.log('[submit-support] RESEND_API_KEY missing — skipping email');
+    return false;
+  }
+
+  const from = Deno.env.get('SUPPORT_FROM') ?? 'SYNEK Support <support@synek.app>';
+  const to = Deno.env.get('SUPPORT_TO') ?? 'hello@synek.app';
+  const categoryLabel = payload.category ?? 'general';
+  const subject = `[Support / ${categoryLabel}] ${payload.name}`;
+
+  const text =
+    `New support request\n\n` +
+    `Name: ${payload.name}\n` +
+    `Email: ${payload.email}\n` +
+    `Category: ${categoryLabel}\n` +
+    `User ID: ${payload.userId ?? 'anonymous'}\n\n` +
+    `Message:\n${payload.message}\n`;
+
+  const html =
+    `<h2>New support request</h2>` +
+    `<p><strong>Name:</strong> ${escapeHtml(payload.name)}</p>` +
+    `<p><strong>Email:</strong> ${escapeHtml(payload.email)}</p>` +
+    `<p><strong>Category:</strong> ${escapeHtml(categoryLabel)}</p>` +
+    `<p><strong>User ID:</strong> ${escapeHtml(payload.userId ?? 'anonymous')}</p>` +
+    `<hr/>` +
+    `<pre style="white-space:pre-wrap;font-family:inherit">${escapeHtml(payload.message)}</pre>`;
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        reply_to: payload.email,
+        subject,
+        text,
+        html,
+      }),
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      console.log('[submit-support] resend send failed', { status: res.status, body: errText });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.log('[submit-support] resend exception', { error: String(err) });
+    return false;
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS });
+  }
+
+  try {
+    const body = (await req.json()) as {
+      name?: string;
+      email?: string;
+      message?: string;
+      category?: string;
+      userId?: string;
+      website?: string;
+      cfToken?: string;
+    };
+
+    const { name, email, message, category, userId, website, cfToken } = body;
+
+    // 1. Honeypot
+    if (website) {
+      console.log('[submit-support] honeypot triggered');
+      return json({ success: true });
+    }
+
+    // 2. Turnstile
+    const ip = (req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip') ?? 'unknown')
+      .split(',')[0]
+      .trim();
+    if (!cfToken) {
+      console.log('[submit-support] turnstile_failed: missing cfToken', { ip });
+      return json({ error: 'turnstile_failed' }, 400);
+    }
+    const turnstileOk = await verifyTurnstile(cfToken, ip);
+    if (!turnstileOk) {
+      console.log('[submit-support] turnstile_failed: verification failed', { ip });
+      return json({ error: 'turnstile_failed' }, 400);
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    // 3. IP rate limit
+    const allowed = await checkAndIncrementRateLimit(
+      supabase,
+      ip,
+      'support',
+      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_MAX_ATTEMPTS,
+    );
+    if (!allowed) {
+      console.log('[submit-support] rate_limited', { ip });
+      return json({ error: 'rate_limited' }, 429);
+    }
+
+    // 4. Validation
+    if (!name || !email || !message) {
+      return json({ error: 'missing_params' }, 400);
+    }
+
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+    const trimmedMessage = message.trim();
+
+    if (
+      trimmedName.length === 0 ||
+      trimmedName.length > MAX_NAME_LENGTH ||
+      trimmedEmail.length === 0 ||
+      trimmedEmail.length > MAX_EMAIL_LENGTH ||
+      trimmedMessage.length === 0 ||
+      trimmedMessage.length > MAX_MESSAGE_LENGTH
+    ) {
+      return json({ error: 'invalid_params' }, 400);
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      return json({ error: 'invalid_email' }, 400);
+    }
+
+    let resolvedCategory: Category | null = null;
+    if (category) {
+      if (!(VALID_CATEGORIES as readonly string[]).includes(category)) {
+        return json({ error: 'invalid_category' }, 400);
+      }
+      resolvedCategory = category as Category;
+    }
+
+    const resolvedUserId = userId && userId.length > 0 ? userId : null;
+
+    // 5. Insert into DB (source of truth — even if email later fails)
+    const { error: insertError } = await supabase.from('feedback_submissions').insert({
+      kind: 'support',
+      name: trimmedName,
+      email: trimmedEmail,
+      message: trimmedMessage,
+      category: resolvedCategory,
+      user_id: resolvedUserId,
+    });
+
+    if (insertError) {
+      console.log('[submit-support] insert failed', {
+        error: insertError.message,
+        code: insertError.code,
+      });
+      return json({ error: 'internal_error' }, 500);
+    }
+
+    // 6. Send email (fire-and-forget — DB row already persisted)
+    const emailSent = await sendSupportEmail({
+      name: trimmedName,
+      email: trimmedEmail,
+      message: trimmedMessage,
+      category: resolvedCategory,
+      userId: resolvedUserId,
+    });
+
+    console.log('[submit-support] received', {
+      emailSent,
+      category: resolvedCategory,
+      userId: resolvedUserId,
+    });
+
+    return json({ success: true });
+  } catch (err) {
+    console.log('[submit-support] unhandled exception', { error: String(err) });
+    return json({ error: 'internal_error' }, 500);
+  }
+});

--- a/supabase/migrations/027_support_submissions.sql
+++ b/supabase/migrations/027_support_submissions.sql
@@ -1,0 +1,14 @@
+-- Extend feedback_submissions to also hold support requests.
+-- Reuses table: same shape, same RLS, distinguished by `kind`.
+-- `category` is optional and only meaningful for kind = 'support' (general | bug | strava | account).
+
+alter table feedback_submissions
+  add column if not exists kind text not null default 'feedback'
+    check (kind in ('feedback', 'support'));
+
+alter table feedback_submissions
+  add column if not exists category text
+    check (category is null or category in ('general', 'bug', 'strava', 'account'));
+
+create index if not exists feedback_submissions_kind_idx
+  on feedback_submissions (kind, created_at desc);


### PR DESCRIPTION
- New /en/support and /pl/support route with dedicated SupportSection component
- Category picker (General/Bug/Strava/Account) with Lucide icons
- submit-support edge function: honeypot + Turnstile verify + IP rate limit + DB insert + Resend email to hello@synek.app
- Migration 027: kind + category columns on feedback_submissions table
- LandingFooter: Support link added, SYNEK capitalisation fixes
- Auth-prefill for logged-in users, char counter on message field
- aria-live errors, fieldset/legend for category, aria-pressed states