### PR TITLE
fix: stabilize PWA bottom navigation height

### DIFF
--- a/app/components/goals/GoalListView.tsx
+++ b/app/components/goals/GoalListView.tsx
@@ -35,7 +35,7 @@ export function GoalListView({ athleteId, createdBy, canManage, className }: Goa
   if (isLoading) return <AppLoader />;
 
   return (
-    <div className={cn('mx-auto max-w-2xl space-y-6 px-4 py-6', className)}>
+    <div className={cn('mx-auto max-w-2xl space-y-6', className)}>
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">{t('goal.library')}</h1>
         {canManage && (

--- a/app/components/strength/StrengthLibraryView.tsx
+++ b/app/components/strength/StrengthLibraryView.tsx
@@ -61,7 +61,7 @@ export function StrengthLibraryView({ userId, canManage, baseRoute }: StrengthLi
   if (isLoading) return <AppLoader />;
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 px-4 py-6">
+    <div className="mx-auto max-w-2xl space-y-6">
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">{t('strength.variant.library')}</h1>
         {canManage && (

--- a/app/routes/athlete/analytics.tsx
+++ b/app/routes/athlete/analytics.tsx
@@ -8,7 +8,7 @@ export default function AthleteAnalytics() {
   const { data: goals = [] } = useGoals(athleteId);
 
   return (
-    <div className="space-y-6 p-4 md:p-6">
+    <div className="space-y-6">
       <AnalyticsView namespace="athlete" athleteId={athleteId} goals={goals} />
     </div>
   );

--- a/app/routes/coach/analytics.tsx
+++ b/app/routes/coach/analytics.tsx
@@ -8,7 +8,7 @@ export default function CoachAnalytics() {
   const { data: goals = [] } = useGoals(athleteId);
 
   return (
-    <div className="space-y-6 p-4 md:p-6">
+    <div className="space-y-6">
       <AnalyticsView namespace="coach" athleteId={athleteId} goals={goals} />
     </div>
   );

--- a/app/routes/locale-layout.tsx
+++ b/app/routes/locale-layout.tsx
@@ -8,14 +8,14 @@ export default function LocaleLayout() {
   const navigation = useNavigation();
 
   return (
-    <>
+    <div className="flex min-h-dvh flex-col bg-background">
       <Header />
-      <main className="container mx-auto px-4 py-6 pb-24 md:pb-6">
+      <main className="container mx-auto flex-1 px-4 py-6 pb-[calc(5.5rem+env(safe-area-inset-bottom,0px))] md:pb-6">
         <Outlet />
       </main>
       <BottomNav />
       <InstallPrompt />
       {navigation.state === 'loading' && <AppLoader />}
-    </>
+    </div>
   );
 }

--- a/app/routes/root-redirect.tsx
+++ b/app/routes/root-redirect.tsx
@@ -1,6 +1,9 @@
 import { Navigate } from 'react-router';
+import { isStandaloneMode } from '~/lib/utils/pwa';
 
 export default function RootRedirect() {
   const locale = localStorage.getItem('locale') ?? 'pl';
-  return <Navigate to={`/${locale}`} replace />;
+  const target = isStandaloneMode() ? `/${locale}/home` : `/${locale}`;
+
+  return <Navigate to={target} replace />;
 }


### PR DESCRIPTION
## Summary
- stabilize locale app shell with min-height and flex layout
- account for bottom nav plus safe-area padding in main content
- remove duplicate outer padding from strength, goals, and analytics pages

## Verification
- pnpm verify:app