### PR TITLE
feat: athlete day-swap — DnD + day navigator in session modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ supabase/seed.sql
 
 #DB Backups
 supabase/backup_before_strava_refactor
+/backups/
 
 /screenshots/
 /.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ supabase/seed.sql
 # Logs
 *.log
 
+# pnpm
+.pnpm-store/
+
 # Agent-specific
 .claude/
 .gemini/

--- a/app/components/calendar/MultiWeekView.tsx
+++ b/app/components/calendar/MultiWeekView.tsx
@@ -113,6 +113,10 @@ export function MultiWeekView({
 
   const reversedHistory = useMemo(() => [...history].reverse(), [history]);
 
+  function handleMoveToDay(sessionId: string, day: DayOfWeek) {
+    updateSessionMutation.mutate({ id: sessionId, dayOfWeek: day });
+  }
+
   function handleReorderSession(input: ReorderSessionInput) {
     updateSessionMutation.mutate({
       id: input.sessionId,
@@ -175,6 +179,7 @@ export function MultiWeekView({
           onUpdateNotes={onUpdateNotes}
           onUpdatePerformance={onUpdatePerformance}
           onReorderSession={handleReorderSession}
+          onMoveToDay={handleMoveToDay}
           userRole={userRole}
           showAthleteControls={showAthleteControls}
           selectedDay={selectedDay}

--- a/app/components/calendar/WeekGrid.tsx
+++ b/app/components/calendar/WeekGrid.tsx
@@ -47,6 +47,8 @@ interface WeekGridProps {
   onCopySession?: (session: TrainingSession) => void;
   /** When provided (and readonly is false), enables drag-and-drop reordering */
   onReorderSession?: (input: ReorderSessionInput) => void;
+  /** When provided, the day navigator in SessionDetailModal becomes interactive */
+  onMoveToDay?: (sessionId: string, day: import('~/types/training').DayOfWeek) => void;
 }
 
 function getDefaultSelectedDay(weekStart: string | undefined): DayOfWeek {
@@ -141,6 +143,7 @@ export function WeekGrid({
   onCopyDay,
   onCopySession,
   onReorderSession,
+  onMoveToDay,
 }: WeekGridProps) {
   const location = useLocation();
   const [internalSelectedDay, setInternalSelectedDay] = useState<DayOfWeek>(() =>
@@ -216,6 +219,7 @@ export function WeekGrid({
       onUpdateCoachPostFeedback,
       onSyncStrava,
       onConfirmStrava,
+      onMoveToDay,
     }),
     [
       readonly,
@@ -232,6 +236,7 @@ export function WeekGrid({
       onUpdateCoachPostFeedback,
       onSyncStrava,
       onConfirmStrava,
+      onMoveToDay,
     ],
   );
 

--- a/app/components/settings/HealthKitSection.tsx
+++ b/app/components/settings/HealthKitSection.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { format, parseISO } from 'date-fns';
+import { useAuth } from '~/lib/context/AuthContext';
+import {
+  useHealthKitAvailable,
+  useHealthKitSync,
+  useHealthKitSyncStatus,
+} from '~/lib/hooks/useHealthKitConnection';
+import { Button } from '~/components/ui/button';
+import { Badge } from '~/components/ui/badge';
+import { cn } from '~/lib/utils';
+
+interface HealthKitSectionProps {
+  className?: string;
+}
+
+export function HealthKitSection({ className }: HealthKitSectionProps) {
+  const { t } = useTranslation('common');
+  const { user } = useAuth();
+  const available = useHealthKitAvailable();
+  const { data: status } = useHealthKitSyncStatus(user?.id ?? '');
+  const sync = useHealthKitSync();
+  const [resultMsg, setResultMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  function handleSync() {
+    if (!user) return;
+    setResultMsg(null);
+    setErrorMsg(null);
+    sync.mutate(
+      { userId: user.id },
+      {
+        onSuccess: (data) => {
+          if (data.upserted === 0) {
+            setResultMsg(t('healthkit.noWorkouts'));
+            return;
+          }
+          setResultMsg(
+            `${t('healthkit.synced', { count: data.upserted })} · ${t('healthkit.matched', { count: data.matched })}`,
+          );
+        },
+        onError: (err) => {
+          setErrorMsg(
+            t('healthkit.errorSync', { message: err instanceof Error ? err.message : String(err) }),
+          );
+        },
+      },
+    );
+  }
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="flex items-center gap-3">
+        <svg viewBox="0 0 40 40" className="h-8 w-8" aria-hidden>
+          <rect width="40" height="40" rx="6" fill="#000" />
+          <path d="M20 30c-4-3-8-6-8-11a4 4 0 017-2.6A4 4 0 0128 19c0 5-4 8-8 11z" fill="#FF2D55" />
+        </svg>
+        <span className="font-semibold">{t('healthkit.title')}</span>
+        {status?.lastSyncAt && <Badge variant="secondary">{t('healthkit.syncedBadge')}</Badge>}
+      </div>
+
+      {!available ? (
+        <p className="text-sm text-muted-foreground">{t('healthkit.iosOnlyNotice')}</p>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">{t('healthkit.description')}</p>
+          {status?.lastSyncAt && (
+            <p className="text-xs text-muted-foreground">
+              {t('healthkit.lastSynced', { time: format(parseISO(status.lastSyncAt), 'PPp') })}
+            </p>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSync}
+            disabled={sync.isPending || !user}
+          >
+            {sync.isPending ? t('healthkit.syncing') : t('healthkit.syncButton')}
+          </Button>
+          {resultMsg && <p className="text-xs text-muted-foreground">{resultMsg}</p>}
+          {errorMsg && <p className="text-xs text-destructive">{errorMsg}</p>}
+          {status?.lastError && !errorMsg && (
+            <p className="text-xs text-destructive">
+              {t('healthkit.errorSync', { message: status.lastError })}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/settings/IntegrationsTab.tsx
+++ b/app/components/settings/IntegrationsTab.tsx
@@ -12,6 +12,7 @@ import { Separator } from '~/components/ui/separator';
 import { stravaAssets } from '~/assets/strava';
 import { cn } from '~/lib/utils';
 import { JunctionGarminSection } from '~/components/settings/JunctionGarminSection';
+import { HealthKitSection } from '~/components/settings/HealthKitSection';
 import {
   mondayToWeekId,
   getPrevWeekId,
@@ -159,6 +160,10 @@ export function IntegrationsTab({
           </div>
         )}
       </div>
+
+      <Separator />
+
+      <HealthKitSection className="mt-2" />
 
       <Separator />
 

--- a/app/components/training/SessionDetailModal.tsx
+++ b/app/components/training/SessionDetailModal.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { format, parseISO } from 'date-fns';
+import { format, parseISO, addDays } from 'date-fns';
 import { getSessionCalendarDate } from '~/lib/utils/date';
-import { Pencil, Trash2, X, Zap } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Pencil, Trash2, X, Zap } from 'lucide-react';
 import { Button } from '~/components/ui/button';
 import { Textarea } from '~/components/ui/textarea';
 import { Separator } from '~/components/ui/separator';
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover';
 import { Dialog, DialogContent, DialogTitle, DialogClose } from '~/components/ui/dialog';
 import { Sheet, SheetContent, SheetTitle, SheetClose } from '~/components/ui/sheet';
 import { useIsMobile } from '~/lib/hooks/useIsMobile';
@@ -23,6 +24,7 @@ import { PerformanceChipGroup } from './PerformanceChipGroup';
 import { trainingTypeConfig, iconMap, isDistanceBased } from '~/lib/utils/training-types';
 import { sessionHasActualPerformance } from '~/lib/utils/week-view';
 import { cn } from '~/lib/utils';
+import { DAYS_OF_WEEK } from '~/types/training';
 import {
   SessionExerciseLogger,
   StrengthLoggerSkeleton,
@@ -109,10 +111,28 @@ export function SessionDetailModal({
     onUpdateNotes,
     onUpdatePerformance,
     onUpdateCoachPostFeedback,
+    onMoveToDay,
   } = useSessionActions();
+
+  // Day navigation — tracks pending day; fires onMoveToDay on close if changed
+  const [pendingDay, setPendingDay] = useState(session.dayOfWeek);
+  const [calendarOpen, setCalendarOpen] = useState(false);
 
   const [coachFeedback, setCoachFeedback] = useState(session.coachPostFeedback ?? '');
   const coachFeedbackRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setPendingDay(session.dayOfWeek);
+    setCalendarOpen(false);
+  }, [session.id, session.dayOfWeek]);
+
+  // Fire move mutation when modal closes with a pending day change
+  const handleOpenChange = (open: boolean) => {
+    if (!open && pendingDay !== session.dayOfWeek) {
+      onMoveToDay?.(session.id, pendingDay);
+    }
+    onOpenChange(open);
+  };
 
   useEffect(() => {
     // Don't reset while the coach is actively typing — the blur handler will save and
@@ -133,8 +153,16 @@ export function SessionDetailModal({
   const shouldShowMaskedPlaceholders = session.isCompleted && isMasked;
 
   const calendarDate = getSessionCalendarDate(weekStart, session.dayOfWeek);
-  const dayDate = calendarDate ? parseISO(calendarDate) : null;
-  const dateStr = dayDate ? format(dayDate, 'EEEE · MMM d') : null;
+
+  // Day navigator
+  const dayIdx = DAYS_OF_WEEK.indexOf(pendingDay);
+  const isDirty = !!onMoveToDay && pendingDay !== session.dayOfWeek;
+  const pendingDayDate = weekStart ? addDays(parseISO(weekStart), dayIdx) : null;
+  const dateStr = pendingDayDate
+    ? format(pendingDayDate, 'MMM d')
+    : calendarDate
+      ? format(parseISO(calendarDate), 'MMM d')
+      : null;
 
   // Strength variant logging
   const strengthData =
@@ -382,6 +410,83 @@ export function SessionDetailModal({
     }
   }
 
+  /** Day navigator strip — very top of modal */
+  const dayNavigator = (
+    <div className="flex shrink-0 items-center justify-between border-b px-3 py-1.5">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        disabled={!onMoveToDay || dayIdx === 0}
+        onClick={() => setPendingDay(DAYS_OF_WEEK[dayIdx - 1])}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={!onMoveToDay}
+            className={cn(
+              'flex flex-col items-center rounded-md px-4 py-1 text-center transition-colors',
+              onMoveToDay && 'hover:bg-muted',
+              isDirty ? 'text-primary' : 'text-foreground',
+            )}
+          >
+            <span className="text-sm font-semibold">{t(`common:days.${pendingDay}` as never)}</span>
+            {dateStr && (
+              <span
+                className={cn('text-[11px]', isDirty ? 'text-primary/80' : 'text-muted-foreground')}
+              >
+                {dateStr}
+              </span>
+            )}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-2" align="center">
+          <div className="flex gap-0.5">
+            {DAYS_OF_WEEK.map((d, i) => {
+              const dd = weekStart ? addDays(parseISO(weekStart), i) : null;
+              const isSel = d === pendingDay;
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => {
+                    setPendingDay(d);
+                    setCalendarOpen(false);
+                  }}
+                  className={cn(
+                    'flex min-w-[38px] flex-col items-center gap-0.5 rounded-lg px-1.5 py-2 transition-colors',
+                    isSel ? 'bg-foreground text-background' : 'hover:bg-muted',
+                  )}
+                >
+                  <span className="text-[10px] leading-none font-semibold uppercase">
+                    {t(`common:daysShort.${d}` as never)}
+                  </span>
+                  {dd && (
+                    <span className="text-xs leading-none tabular-nums">{format(dd, 'd')}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        disabled={!onMoveToDay || dayIdx === 6}
+        onClick={() => setPendingDay(DAYS_OF_WEEK[dayIdx + 1])}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+
   /** Top action bar shared by desktop header and mobile sheet header */
   const actionBar = (closeButton: React.ReactNode) => (
     <div className="flex items-center gap-1">
@@ -622,7 +727,7 @@ export function SessionDetailModal({
 
   if (isMobile) {
     return (
-      <Sheet open={open} onOpenChange={onOpenChange}>
+      <Sheet open={open} onOpenChange={handleOpenChange}>
         <SheetContent
           side="bottom"
           showCloseButton={false}
@@ -632,12 +737,12 @@ export function SessionDetailModal({
           <div className="flex shrink-0 justify-center pt-3 pb-1">
             <div className="h-1 w-10 rounded-full bg-border" />
           </div>
+          {dayNavigator}
           <div className="shrink-0 border-b px-6 pt-3 pb-4">
             {actionBar(null)}
             <SheetTitle className="mt-2 text-lg leading-tight font-semibold">
               {titleText}
             </SheetTitle>
-            {dateStr && <p className="mt-0.5 text-sm text-muted-foreground">{dateStr}</p>}
           </div>
           {bodyContent}
           <div className="flex shrink-0 justify-end border-t px-6 py-4">
@@ -651,13 +756,14 @@ export function SessionDetailModal({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
         className="flex max-h-[90vh] max-w-2xl flex-col gap-0 p-0"
       >
-        <div className="shrink-0 border-b px-6 pt-5 pb-4">
+        {dayNavigator}
+        <div className="shrink-0 border-b px-6 pt-4 pb-4">
           {actionBar(
             <DialogClose asChild>
               <Button variant="ghost" size="icon" className="h-7 w-7">
@@ -668,7 +774,6 @@ export function SessionDetailModal({
           <DialogTitle className="mt-2 text-lg leading-tight font-semibold">
             {titleText}
           </DialogTitle>
-          {dateStr && <p className="mt-0.5 text-sm text-muted-foreground">{dateStr}</p>}
         </div>
         {bodyContent}
         <div className="flex shrink-0 justify-end border-t px-6 py-4">

--- a/app/components/training/SessionDetailModal.tsx
+++ b/app/components/training/SessionDetailModal.tsx
@@ -419,6 +419,7 @@ export function SessionDetailModal({
         className="h-8 w-8"
         disabled={!onMoveToDay || dayIdx === 0}
         onClick={() => setPendingDay(DAYS_OF_WEEK[dayIdx - 1])}
+        aria-label={t('training:sessionDetail.prevDay' as never)}
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
@@ -481,6 +482,7 @@ export function SessionDetailModal({
         className="h-8 w-8"
         disabled={!onMoveToDay || dayIdx === 6}
         onClick={() => setPendingDay(DAYS_OF_WEEK[dayIdx + 1])}
+        aria-label={t('training:sessionDetail.nextDay' as never)}
       >
         <ChevronRight className="h-4 w-4" />
       </Button>

--- a/app/components/ui/popover.tsx
+++ b/app/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Popover as PopoverPrimitive } from 'radix-ui';
+
+import { cn } from '~/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-[100] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/app/i18n/resources/en/common.json
+++ b/app/i18n/resources/en/common.json
@@ -200,6 +200,22 @@
     "stravaAllShared": "All sessions data shared with coach",
     "stravaAllShareFailed": "Failed to share sessions data"
   },
+  "healthkit": {
+    "title": "Apple Watch",
+    "iosOnlyNotice": "Open Synek in the iOS app to sync workouts from your Apple Watch.",
+    "description": "Sync workouts from your Apple Watch via HealthKit. Reads workouts from the last 30 days.",
+    "permissionTitle": "HealthKit permission",
+    "permissionBody": "Synek needs read access to Workouts, Heart Rate, Distance and Active Energy.",
+    "syncButton": "Sync now",
+    "syncing": "Syncing…",
+    "syncedBadge": "Synced via Apple Watch",
+    "lastSynced": "Last synced {{time}}",
+    "synced": "Synced {{count}} workouts",
+    "matched": "Linked {{count}} to planned sessions",
+    "errorPermission": "HealthKit permission was not granted.",
+    "errorSync": "Sync failed: {{message}}",
+    "noWorkouts": "No new workouts found in the last 30 days."
+  },
   "junction": {
     "connectButton": "Connect Garmin",
     "connectedBadge": "Garmin connected",

--- a/app/i18n/resources/en/training.json
+++ b/app/i18n/resources/en/training.json
@@ -243,7 +243,9 @@
     "actual": "Actual",
     "noActualData": "No performance data recorded yet.",
     "plannedIntervals": "Planned Intervals",
-    "rest": "Rest"
+    "rest": "Rest",
+    "prevDay": "Previous day",
+    "nextDay": "Next day"
   },
   "intervals": {
     "viewButton": "Intervals",

--- a/app/i18n/resources/pl/common.json
+++ b/app/i18n/resources/pl/common.json
@@ -200,6 +200,22 @@
     "stravaAllShared": "Wszystkie dane udostępnione trenerowi",
     "stravaAllShareFailed": "Nie udało się udostępnić danych"
   },
+  "healthkit": {
+    "title": "Apple Watch",
+    "iosOnlyNotice": "Otwórz Synek w aplikacji iOS, aby synchronizować treningi z Apple Watch.",
+    "description": "Synchronizuj treningi z Apple Watch przez HealthKit. Czyta treningi z ostatnich 30 dni.",
+    "permissionTitle": "Uprawnienia HealthKit",
+    "permissionBody": "Synek potrzebuje dostępu do odczytu Treningów, Tętna, Dystansu i Aktywnej energii.",
+    "syncButton": "Synchronizuj",
+    "syncing": "Synchronizowanie…",
+    "syncedBadge": "Zsynchronizowano z Apple Watch",
+    "lastSynced": "Ostatnia synchronizacja {{time}}",
+    "synced": "Zsynchronizowano {{count}} treningów",
+    "matched": "Powiązano {{count}} z zaplanowanymi sesjami",
+    "errorPermission": "Nie udzielono uprawnień HealthKit.",
+    "errorSync": "Synchronizacja nie powiodła się: {{message}}",
+    "noWorkouts": "Brak nowych treningów z ostatnich 30 dni."
+  },
   "junction": {
     "connectButton": "Połącz z Garmin",
     "connectedBadge": "Garmin połączony",

--- a/app/i18n/resources/pl/training.json
+++ b/app/i18n/resources/pl/training.json
@@ -243,7 +243,9 @@
     "actual": "Wykonanie",
     "noActualData": "Brak danych o wykonaniu.",
     "plannedIntervals": "Zaplanowane interwały",
-    "rest": "Odpoczynek"
+    "rest": "Odpoczynek",
+    "prevDay": "Poprzedni dzień",
+    "nextDay": "Następny dzień"
   },
   "intervals": {
     "viewButton": "Interwały",

--- a/app/lib/context/SessionActionsContext.tsx
+++ b/app/lib/context/SessionActionsContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
-import type { TrainingSession, AthleteSessionUpdate } from '~/types/training';
+import type { TrainingSession, AthleteSessionUpdate, DayOfWeek } from '~/types/training';
 import type { UserRole } from '~/lib/auth';
 
 export interface SessionActionsContextValue {
@@ -18,6 +18,7 @@ export interface SessionActionsContextValue {
   onUpdateCoachPostFeedback?: (sessionId: string, feedback: string | null) => void;
   onSyncStrava?: (sessionId: string) => Promise<void>;
   onConfirmStrava?: (sessionId: string) => Promise<void>;
+  onMoveToDay?: (sessionId: string, day: DayOfWeek) => void;
 }
 
 const SESSION_ACTIONS_DEFAULTS: SessionActionsContextValue = {

--- a/app/lib/hooks/useHealthKitConnection.ts
+++ b/app/lib/hooks/useHealthKitConnection.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '~/lib/queries/keys';
+import { getHealthKitSyncStatus, syncHealthKitWorkouts } from '~/lib/queries/healthkit-sync';
+import {
+  fetchHealthKitWorkouts,
+  isHealthKitBridgeAvailable,
+  requestHealthKitAuth,
+} from '~/lib/integrations/healthkit-bridge';
+
+const DEFAULT_LOOKBACK_DAYS = 30;
+
+export function useHealthKitAvailable(): boolean {
+  return isHealthKitBridgeAvailable();
+}
+
+export function useHealthKitSyncStatus(userId: string) {
+  return useQuery({
+    queryKey: queryKeys.healthkitSync.status(userId),
+    queryFn: () => getHealthKitSyncStatus(userId),
+    enabled: !!userId,
+  });
+}
+
+interface SyncVars {
+  userId: string;
+  /** Override the default 30-day lookback (in days). */
+  lookbackDays?: number;
+}
+
+/**
+ * Asks iOS for HealthKit permission, fetches workouts since lookback window,
+ * upserts them to Supabase and links to planned sessions where possible.
+ */
+export function useHealthKitSync() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ userId, lookbackDays = DEFAULT_LOOKBACK_DAYS }: SyncVars) => {
+      const auth = await requestHealthKitAuth();
+      if (!auth.granted) {
+        throw new Error('HealthKit permission required');
+      }
+      const sinceMs = Date.now() - lookbackDays * 24 * 60 * 60 * 1000;
+      const workouts = await fetchHealthKitWorkouts(sinceMs);
+      return syncHealthKitWorkouts({ userId, workouts });
+    },
+    onSettled: (_data, _err, { userId }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.healthkitSync.status(userId) });
+      qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
+    },
+  });
+}

--- a/app/lib/hooks/useWeekView.ts
+++ b/app/lib/hooks/useWeekView.ts
@@ -20,6 +20,7 @@ import type {
   WeekPlan,
   SessionsByDay,
   DayOfWeek,
+  ReorderSessionInput,
 } from '~/types/training';
 
 export interface UseWeekViewOptions {
@@ -70,6 +71,8 @@ export interface UseWeekViewResult {
   handleToggleComplete: (sessionId: string, completed: boolean) => void;
   handleUpdateNotes: (sessionId: string, notes: string | null) => void;
   handleUpdatePerformance: (sessionId: string, update: Omit<AthleteSessionUpdate, 'id'>) => void;
+  handleReorderSession: (input: ReorderSessionInput) => void;
+  handleMoveToDay: (sessionId: string, day: DayOfWeek) => void;
 }
 
 export function useWeekView({
@@ -177,6 +180,24 @@ export function useWeekView({
     [updateAthlete],
   );
 
+  const handleReorderSession = useCallback(
+    (input: ReorderSessionInput) => {
+      updateSession.mutate({
+        id: input.sessionId,
+        dayOfWeek: input.dayOfWeek,
+        sortOrder: input.sortOrder,
+      });
+    },
+    [updateSession],
+  );
+
+  const handleMoveToDay = useCallback(
+    (sessionId: string, day: DayOfWeek) => {
+      updateSession.mutate({ id: sessionId, dayOfWeek: day });
+    },
+    [updateSession],
+  );
+
   // All hooks have been called — safe to return null for missing weekId
   if (!weekId) return null;
 
@@ -227,5 +248,7 @@ export function useWeekView({
     handleToggleComplete,
     handleUpdateNotes,
     handleUpdatePerformance,
+    handleReorderSession,
+    handleMoveToDay,
   };
 }

--- a/app/lib/integrations/healthkit-bridge.ts
+++ b/app/lib/integrations/healthkit-bridge.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import type { HealthKitWorkoutPayload } from '~/types/healthkit';
+
+// ============================================================
+// Bridge type wiring (window.__healthkit)
+// ============================================================
+
+interface BridgeError {
+  code:
+    | 'permission_denied'
+    | 'permission_not_determined'
+    | 'hk_unavailable'
+    | 'invalid_args'
+    | 'internal';
+  message: string;
+}
+
+interface HealthKitBridge {
+  call(action: string, args?: Record<string, unknown>): Promise<unknown>;
+  _resolve(requestId: string, ok: unknown | null, err: BridgeError | null): void;
+}
+
+declare global {
+  interface Window {
+    __healthkit?: HealthKitBridge;
+  }
+}
+
+export class HealthKitBridgeUnavailableError extends Error {
+  constructor() {
+    super('HealthKit bridge unavailable (not running inside iOS app)');
+    this.name = 'HealthKitBridgeUnavailableError';
+  }
+}
+
+export class HealthKitBridgeError extends Error {
+  constructor(
+    public readonly code: BridgeError['code'],
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HealthKitBridgeError';
+  }
+}
+
+export function isHealthKitBridgeAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.__healthkit !== 'undefined';
+}
+
+function getBridge(): HealthKitBridge {
+  if (!isHealthKitBridgeAvailable()) throw new HealthKitBridgeUnavailableError();
+  return window.__healthkit!;
+}
+
+async function call<T>(
+  action: string,
+  schema: z.ZodType<T>,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  try {
+    const raw = await getBridge().call(action, args);
+    return schema.parse(raw);
+  } catch (err) {
+    if (err instanceof HealthKitBridgeUnavailableError) throw err;
+    if (err instanceof Error && 'code' in err) {
+      const code = (err as { code?: unknown }).code;
+      if (typeof code === 'string') {
+        throw new HealthKitBridgeError(code as BridgeError['code'], err.message);
+      }
+    }
+    throw err;
+  }
+}
+
+// ============================================================
+// Schemas (mirror contracts/healthkit-bridge.md)
+// ============================================================
+
+const RequestAuthResult = z.object({ granted: z.boolean() });
+
+const Workout = z.object({
+  hkUuid: z.string().min(1),
+  activityId: z.string().min(1),
+  hkActivityType: z.number().int(),
+  sourceName: z.string().nullable(),
+  sourceBundleId: z.string().nullable(),
+  startDate: z.string().min(1),
+  endDate: z.string().min(1),
+  durationSeconds: z.number().nullable(),
+  distanceMeters: z.number().nullable(),
+  activeEnergyKcal: z.number().nullable(),
+  averageHeartrate: z.number().nullable(),
+  maxHeartrate: z.number().nullable(),
+  raw: z.record(z.string(), z.unknown()).nullable(),
+}) satisfies z.ZodType<HealthKitWorkoutPayload>;
+
+const FetchWorkoutsResult = z.object({ workouts: z.array(Workout) });
+
+const StatusResult = z.object({
+  available: z.boolean(),
+  permission: z.enum(['granted', 'denied', 'not_determined']),
+});
+
+const AppInfoResult = z.object({
+  version: z.string(),
+  build: z.string(),
+  os: z.string(),
+});
+
+// ============================================================
+// Public API
+// ============================================================
+
+export async function requestHealthKitAuth(): Promise<{ granted: boolean }> {
+  return call('requestAuth', RequestAuthResult);
+}
+
+export async function fetchHealthKitWorkouts(sinceMs: number): Promise<HealthKitWorkoutPayload[]> {
+  const result = await call('fetchWorkouts', FetchWorkoutsResult, { sinceMs });
+  return result.workouts;
+}
+
+export async function getHealthKitDeviceStatus(): Promise<{
+  available: boolean;
+  permission: 'granted' | 'denied' | 'not_determined';
+}> {
+  return call('getStatus', StatusResult);
+}
+
+export async function getHealthKitAppInfo(): Promise<{
+  version: string;
+  build: string;
+  os: string;
+}> {
+  return call('getAppInfo', AppInfoResult);
+}

--- a/app/lib/queries/healthkit-sync.ts
+++ b/app/lib/queries/healthkit-sync.ts
@@ -1,0 +1,252 @@
+import { supabase, isMockMode } from '~/lib/supabase';
+import type {
+  HealthKitSyncResult,
+  HealthKitSyncStatus,
+  HealthKitWorkoutPayload,
+} from '~/types/healthkit';
+import { trainingTypeMatchesHk } from '~/lib/utils/healthkit-activity-map';
+import type { TrainingType } from '~/types/training';
+
+// ============================================================
+// Mock state
+// ============================================================
+
+let mockStatus: HealthKitSyncStatus = {
+  connected: false,
+  lastSyncAt: null,
+  lastError: null,
+  workoutsSynced: 0,
+};
+
+// ============================================================
+// Status
+// ============================================================
+
+export async function mockGetHealthKitSyncStatus(): Promise<HealthKitSyncStatus> {
+  await new Promise((r) => setTimeout(r, 100));
+  return mockStatus;
+}
+
+export async function getHealthKitSyncStatus(userId: string): Promise<HealthKitSyncStatus> {
+  if (isMockMode) return mockGetHealthKitSyncStatus();
+
+  const { data, error } = await supabase
+    .from('healthkit_sync_status')
+    .select('last_sync_at, last_error, workouts_synced')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) {
+    return { connected: false, lastSyncAt: null, lastError: null, workoutsSynced: 0 };
+  }
+
+  return {
+    connected: true,
+    lastSyncAt: data.last_sync_at as string | null,
+    lastError: data.last_error as string | null,
+    workoutsSynced: (data.workouts_synced as number | null) ?? 0,
+  };
+}
+
+// ============================================================
+// Sync: upsert HK workouts + match to planned sessions
+// ============================================================
+
+interface SyncInput {
+  userId: string;
+  workouts: HealthKitWorkoutPayload[];
+}
+
+export async function mockSyncHealthKitWorkouts(input: SyncInput): Promise<HealthKitSyncResult> {
+  await new Promise((r) => setTimeout(r, 400));
+  const now = new Date().toISOString();
+  mockStatus = {
+    connected: true,
+    lastSyncAt: now,
+    lastError: null,
+    workoutsSynced: mockStatus.workoutsSynced + input.workouts.length,
+  };
+  return { upserted: input.workouts.length, matched: 0, lastSyncAt: now };
+}
+
+export async function syncHealthKitWorkouts(input: SyncInput): Promise<HealthKitSyncResult> {
+  if (isMockMode) return mockSyncHealthKitWorkouts(input);
+
+  const { userId, workouts } = input;
+  const now = new Date().toISOString();
+
+  if (workouts.length === 0) {
+    await upsertSyncStatus(userId, now, null, 0);
+    return { upserted: 0, matched: 0, lastSyncAt: now };
+  }
+
+  const rows = workouts.map((w) => ({
+    hk_uuid: w.hkUuid,
+    user_id: userId,
+    activity_type: w.activityId,
+    hk_activity_type: w.hkActivityType,
+    source_name: w.sourceName,
+    source_bundle_id: w.sourceBundleId,
+    start_date: w.startDate,
+    end_date: w.endDate,
+    duration_seconds: w.durationSeconds,
+    distance_meters: w.distanceMeters,
+    active_energy_kcal: w.activeEnergyKcal,
+    average_heartrate: w.averageHeartrate,
+    max_heartrate: w.maxHeartrate,
+    raw_data: w.raw,
+  }));
+
+  const { data: upserted, error: upsertError } = await supabase
+    .from('healthkit_workouts')
+    .upsert(rows, { onConflict: 'hk_uuid' })
+    .select('id, hk_uuid, activity_type, start_date, training_session_id');
+
+  if (upsertError) {
+    await upsertSyncStatus(userId, now, upsertError.message, 0);
+    throw upsertError;
+  }
+
+  const unmatched = (upserted ?? []).filter((row) => row.training_session_id === null);
+  const matched = await matchWorkoutsToSessions(userId, unmatched);
+
+  await upsertSyncStatus(userId, now, null, rows.length);
+
+  return { upserted: rows.length, matched, lastSyncAt: now };
+}
+
+// ============================================================
+// Internal: match HK workouts to planned training_sessions
+// ============================================================
+
+interface UnmatchedRow {
+  id: string;
+  hk_uuid: string;
+  activity_type: string | null;
+  start_date: string | null;
+  training_session_id: string | null;
+}
+
+/**
+ * For each unmatched HK workout, find a same-day planned session of compatible training_type
+ * for this athlete and link them (one-to-one; first compatible wins).
+ */
+async function matchWorkoutsToSessions(userId: string, unmatched: UnmatchedRow[]): Promise<number> {
+  if (unmatched.length === 0) return 0;
+
+  const dates = Array.from(
+    new Set(
+      unmatched.map((w) => w.start_date?.slice(0, 10)).filter((d): d is string => d !== undefined),
+    ),
+  );
+  if (dates.length === 0) return 0;
+
+  const weekStarts = Array.from(new Set(dates.map((d) => weekStartFor(d))));
+
+  // Sessions for this athlete in the relevant weeks, not yet linked to a HK workout.
+  const { data: sessions, error: sessionsError } = await supabase
+    .from('training_sessions')
+    .select('id, training_type, day_of_week, week_plans!inner(athlete_id, week_start)')
+    .is('healthkit_workout_id', null)
+    .in('week_plans.week_start', weekStarts)
+    .eq('week_plans.athlete_id', userId);
+
+  if (sessionsError) throw sessionsError;
+
+  type SessionRow = { id: string; training_type: TrainingType; date: string };
+  const sessionsByDate = new Map<string, SessionRow[]>();
+  for (const s of sessions ?? []) {
+    const wp = s.week_plans as { week_start: string } | { week_start: string }[] | null;
+    const weekStart = Array.isArray(wp) ? wp[0]?.week_start : wp?.week_start;
+    if (!weekStart) continue;
+    const date = addDaysIso(weekStart, dayOffset(s.day_of_week as string));
+    const arr = sessionsByDate.get(date) ?? [];
+    arr.push({
+      id: s.id as string,
+      training_type: s.training_type as TrainingType,
+      date,
+    });
+    sessionsByDate.set(date, arr);
+  }
+
+  let matched = 0;
+  for (const workout of unmatched) {
+    const date = workout.start_date?.slice(0, 10);
+    if (!date || !workout.activity_type) continue;
+
+    const candidates = sessionsByDate.get(date) ?? [];
+    const session = candidates.find((s) =>
+      trainingTypeMatchesHk(s.training_type, workout.activity_type!),
+    );
+    if (!session) continue;
+
+    const { error: linkError } = await supabase
+      .from('training_sessions')
+      .update({ healthkit_workout_id: workout.id, healthkit_synced_at: new Date().toISOString() })
+      .eq('id', session.id);
+    if (linkError) continue;
+
+    const { error: backlinkError } = await supabase
+      .from('healthkit_workouts')
+      .update({ training_session_id: session.id })
+      .eq('id', workout.id);
+    if (backlinkError) continue;
+
+    // Consume this session so we don't double-match in this batch.
+    sessionsByDate.set(
+      date,
+      candidates.filter((s) => s.id !== session.id),
+    );
+    matched += 1;
+  }
+
+  return matched;
+}
+
+/** ISO weekday-aware Monday-of-week, used to filter week_plans.week_start. */
+function weekStartFor(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  const dow = d.getUTCDay(); // 0=Sun..6=Sat
+  const diff = (dow + 6) % 7; // days since Monday
+  d.setUTCDate(d.getUTCDate() - diff);
+  return d.toISOString().slice(0, 10);
+}
+
+const DAY_OFFSETS: Record<string, number> = {
+  monday: 0,
+  tuesday: 1,
+  wednesday: 2,
+  thursday: 3,
+  friday: 4,
+  saturday: 5,
+  sunday: 6,
+};
+
+function dayOffset(day: string): number {
+  return DAY_OFFSETS[day] ?? 0;
+}
+
+function addDaysIso(isoDate: string, days: number): string {
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+async function upsertSyncStatus(
+  userId: string,
+  syncedAt: string,
+  error: string | null,
+  workoutsSynced: number,
+): Promise<void> {
+  const { error: upsertError } = await supabase.from('healthkit_sync_status').upsert(
+    {
+      user_id: userId,
+      last_sync_at: syncedAt,
+      last_error: error,
+      workouts_synced: workoutsSynced,
+    },
+    { onConflict: 'user_id' },
+  );
+  if (upsertError) throw upsertError;
+}

--- a/app/lib/queries/keys.ts
+++ b/app/lib/queries/keys.ts
@@ -18,6 +18,10 @@ export const queryKeys = {
     all: ['stravaConnection'] as const,
     byUser: (userId: string) => ['stravaConnection', userId] as const,
   },
+  healthkitSync: {
+    all: ['healthkitSync'] as const,
+    status: (userId: string) => ['healthkitSync', 'status', userId] as const,
+  },
   invites: {
     all: ['invites'] as const,
     byCoach: (coachId: string) => ['invites', coachId] as const,

--- a/app/lib/queries/sessions.ts
+++ b/app/lib/queries/sessions.ts
@@ -22,7 +22,7 @@ import type {
 } from '~/types/training';
 
 const SESSION_COLUMNS_BEFORE_STRAVA_CONFIRMATION =
-  'id, week_plan_id, day_of_week, sort_order, training_type, description, coach_comments, planned_duration_minutes, planned_distance_km, type_specific_data, is_completed, completed_at, actual_duration_minutes, actual_distance_km, actual_pace, avg_heart_rate, max_heart_rate, rpe, calories, coach_post_feedback, trainee_notes, strava_activity_id, strava_synced_at, goal_id, result_distance_km, result_time_seconds, result_pace';
+  'id, week_plan_id, day_of_week, sort_order, training_type, description, coach_comments, planned_duration_minutes, planned_distance_km, type_specific_data, is_completed, completed_at, actual_duration_minutes, actual_distance_km, actual_pace, avg_heart_rate, max_heart_rate, rpe, calories, coach_post_feedback, trainee_notes, strava_activity_id, strava_synced_at, healthkit_workout_id, healthkit_synced_at, healthkit_source_name, goal_id, result_distance_km, result_time_seconds, result_pace';
 
 const SESSION_COLUMNS = `${SESSION_COLUMNS_BEFORE_STRAVA_CONFIRMATION}, is_strava_confirmed, created_at, updated_at`;
 
@@ -53,6 +53,9 @@ export function toSession(row: Record<string, unknown>): TrainingSession {
     athleteNotes: row.trainee_notes as string | null,
     stravaActivityId: row.strava_activity_id as number | null,
     stravaSyncedAt: row.strava_synced_at as string | null,
+    healthkitWorkoutId: (row.healthkit_workout_id as string | null) ?? null,
+    healthkitSyncedAt: (row.healthkit_synced_at as string | null) ?? null,
+    healthkitSourceName: (row.healthkit_source_name as string | null) ?? null,
     goalId: (row.goal_id as string | null) ?? null,
     resultDistanceKm: row.result_distance_km != null ? Number(row.result_distance_km) : null,
     resultTimeSeconds: row.result_time_seconds != null ? (row.result_time_seconds as number) : null,

--- a/app/lib/utils/healthkit-activity-map.ts
+++ b/app/lib/utils/healthkit-activity-map.ts
@@ -1,0 +1,49 @@
+import type { TrainingType } from '~/types/training';
+
+/**
+ * iOS bridge emits these activity IDs (see synek-ios HealthKitActivityMap.swift).
+ * They are HealthKit-side identifiers — NOT the same vocabulary as synek's TrainingType.
+ */
+export type HealthKitActivityId =
+  | 'run'
+  | 'walk'
+  | 'hike'
+  | 'bike'
+  | 'swim'
+  | 'row'
+  | 'elliptical'
+  | 'strength'
+  | 'yoga'
+  | 'mixed-cardio'
+  | 'hiit'
+  | 'other';
+
+const HK_TO_TRAINING_TYPE: Record<HealthKitActivityId, TrainingType> = {
+  run: 'run',
+  walk: 'walk',
+  hike: 'hike',
+  bike: 'cycling',
+  swim: 'swimming',
+  row: 'other',
+  elliptical: 'elliptical',
+  strength: 'strength',
+  yoga: 'yoga',
+  'mixed-cardio': 'other',
+  hiit: 'other',
+  other: 'other',
+};
+
+export function hkActivityToTrainingType(activityId: string): TrainingType {
+  return HK_TO_TRAINING_TYPE[activityId as HealthKitActivityId] ?? 'other';
+}
+
+/**
+ * Whether a synek training_type accepts a HK workout activity for auto-linking.
+ * Used when matching a HKWorkout to a planned training_session on the same day.
+ */
+export function trainingTypeMatchesHk(sessionType: TrainingType, hkActivityId: string): boolean {
+  if (sessionType === 'other') return false;
+  const mapped = hkActivityToTrainingType(hkActivityId);
+  if (mapped === 'other') return false;
+  return mapped === sessionType;
+}

--- a/app/routes/athlete/week.$weekId.tsx
+++ b/app/routes/athlete/week.$weekId.tsx
@@ -169,6 +169,8 @@ export default function AthleteWeekView() {
     handleToggleComplete,
     handleUpdateNotes,
     handleUpdatePerformance,
+    handleReorderSession,
+    handleMoveToDay,
     deleteSessionMut,
   } = weekView;
 
@@ -256,6 +258,8 @@ export default function AthleteWeekView() {
                     userRole={user?.role ?? undefined}
                     selectedDay={selectedDay}
                     onSelectDay={setSelectedDay}
+                    onReorderSession={handleReorderSession}
+                    onMoveToDay={handleMoveToDay}
                     {...(canSelfPlan && {
                       onAddSession: handleAddSession,
                       onEditSession: handleEditSession,

--- a/app/test/integration/LandingNav.test.tsx
+++ b/app/test/integration/LandingNav.test.tsx
@@ -37,7 +37,7 @@ describe('LandingNav (v2)', () => {
     renderAt('/pl');
     expect(screen.getByText('SYNEK')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /zaloguj/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /zacznij/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /rozpocznij/i })).toBeInTheDocument();
   });
 
   it('routes Sign in to /<locale>/login', () => {

--- a/app/test/integration/SessionDetailModal.day-navigator.test.tsx
+++ b/app/test/integration/SessionDetailModal.day-navigator.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * Day navigator in SessionDetailModal.
+ *
+ * Tests user-observable behaviour — what the user sees and what happens
+ * when they interact — not internal state or implementation details.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import type { ReactNode } from 'react';
+import i18n from '~/i18n/config';
+import { SessionDetailModal } from '~/components/training/SessionDetailModal';
+
+// ─── i18n ────────────────────────────────────────────────────────────────────
+// The config singleton defaults to Polish. Switch to English so tests can
+// query by readable English labels ("Previous day", "Wednesday", "Close").
+beforeAll(async () => {
+  await i18n.changeLanguage('en');
+});
+afterAll(async () => {
+  await i18n.changeLanguage('pl'); // restore default for other files in the same worker
+});
+import { SessionActionsProvider } from '~/lib/context/SessionActionsContext';
+import type { SessionActionsContextValue } from '~/lib/context/SessionActionsContext';
+import type { TrainingSession, DayOfWeek } from '~/types/training';
+import { createTestQueryClient } from '~/test/utils/query-client';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('~/lib/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1', role: 'athlete' }, effectiveAthleteId: 'user-1' }),
+}));
+
+vi.mock('~/lib/hooks/useIsMobile', () => ({
+  useIsMobile: () => false, // always render the desktop Dialog variant
+}));
+
+vi.mock('~/lib/hooks/useStrengthVariants', () => ({
+  useStrengthVariant: () => ({ data: undefined }),
+  useStrengthSessionExercises: () => ({ data: [] }),
+  useLastSessionExercises: () => ({ data: undefined }),
+  useUpsertSessionExercises: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('~/lib/hooks/useJunctionConnection', () => ({
+  useJunctionWorkout: () => ({ data: undefined }),
+  useJunctionConnectionStatus: () => ({ data: null }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// Week of Mon 16 Mar – Sun 22 Mar 2026
+const weekStart = '2026-03-16';
+
+function makeSession(overrides: Partial<TrainingSession> = {}): TrainingSession {
+  return {
+    id: 'sess-1',
+    weekPlanId: 'wp-1',
+    dayOfWeek: 'wednesday',
+    sortOrder: 0,
+    trainingType: 'run',
+    description: 'Easy run',
+    coachComments: null,
+    plannedDurationMinutes: 45,
+    plannedDistanceKm: 8,
+    typeSpecificData: { type: 'run' },
+    isCompleted: false,
+    completedAt: null,
+    actualDurationMinutes: null,
+    actualDistanceKm: null,
+    actualPace: null,
+    avgHeartRate: null,
+    maxHeartRate: null,
+    rpe: null,
+    calories: null,
+    coachPostFeedback: null,
+    athleteNotes: null,
+    stravaActivityId: null,
+    stravaSyncedAt: null,
+    createdAt: '2026-03-01T00:00:00Z',
+    updatedAt: '2026-03-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderModal({
+  session = makeSession(),
+  onMoveToDay,
+}: {
+  session?: TrainingSession;
+  onMoveToDay?: (sessionId: string, day: DayOfWeek) => void;
+} = {}) {
+  const onOpenChange = vi.fn();
+  const queryClient = createTestQueryClient();
+
+  const contextValue: SessionActionsContextValue = {
+    readonly: false,
+    athleteMode: true,
+    showAthleteControls: false,
+    stravaConnected: false,
+    junctionConnected: false,
+    onMoveToDay,
+  };
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <I18nextProvider i18n={i18n}>
+          <SessionActionsProvider value={contextValue}>{children}</SessionActionsProvider>
+        </I18nextProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  render(
+    <SessionDetailModal
+      open={true}
+      onOpenChange={onOpenChange}
+      session={session}
+      weekStart={weekStart}
+    />,
+    { wrapper: Wrapper },
+  );
+
+  return { onOpenChange };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SessionDetailModal — day navigator', () => {
+  it("shows the session's current day in the navigator", () => {
+    renderModal({ session: makeSession({ dayOfWeek: 'wednesday' }) });
+
+    // The day trigger button contains the day name
+    expect(screen.getByRole('button', { name: /wednesday/i })).toBeInTheDocument();
+  });
+
+  it('right arrow advances the displayed day by one', async () => {
+    renderModal({ session: makeSession({ dayOfWeek: 'wednesday' }), onMoveToDay: vi.fn() });
+
+    await userEvent.click(screen.getByRole('button', { name: /next day/i }));
+
+    expect(screen.getByRole('button', { name: /thursday/i })).toBeInTheDocument();
+  });
+
+  it('left arrow moves the displayed day back by one', async () => {
+    renderModal({ session: makeSession({ dayOfWeek: 'wednesday' }), onMoveToDay: vi.fn() });
+
+    await userEvent.click(screen.getByRole('button', { name: /previous day/i }));
+
+    expect(screen.getByRole('button', { name: /tuesday/i })).toBeInTheDocument();
+  });
+
+  it('left arrow is disabled on Monday — cannot go before the week start', () => {
+    renderModal({ session: makeSession({ dayOfWeek: 'monday' }), onMoveToDay: vi.fn() });
+
+    expect(screen.getByRole('button', { name: /previous day/i })).toBeDisabled();
+  });
+
+  it('right arrow is disabled on Sunday — cannot go past the week end', () => {
+    renderModal({ session: makeSession({ dayOfWeek: 'sunday' }), onMoveToDay: vi.fn() });
+
+    expect(screen.getByRole('button', { name: /next day/i })).toBeDisabled();
+  });
+
+  it('both arrows are disabled when the modal has no move permission', () => {
+    // No onMoveToDay provided — read-only display
+    renderModal({ session: makeSession({ dayOfWeek: 'wednesday' }) });
+
+    expect(screen.getByRole('button', { name: /previous day/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next day/i })).toBeDisabled();
+  });
+
+  it('calendar picker opens showing all 7 days and lets the user jump to any day', async () => {
+    renderModal({ session: makeSession({ dayOfWeek: 'wednesday' }), onMoveToDay: vi.fn() });
+
+    // Open the picker
+    await userEvent.click(screen.getByRole('button', { name: /wednesday/i }));
+
+    // All 7 day abbreviations are visible in the popover
+    for (const abbr of ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']) {
+      expect(screen.getByText(abbr)).toBeInTheDocument();
+    }
+
+    // Jump to Saturday (non-adjacent)
+    await userEvent.click(screen.getByRole('button', { name: /^sat/i }));
+
+    // Navigator now shows Saturday; popover is gone
+    expect(screen.getByRole('button', { name: /saturday/i })).toBeInTheDocument();
+    expect(screen.queryByText('Mon')).not.toBeInTheDocument();
+  });
+
+  it('fires onMoveToDay with the chosen day when the modal closes after a change', async () => {
+    const onMoveToDay = vi.fn();
+    const { onOpenChange } = renderModal({
+      session: makeSession({ dayOfWeek: 'wednesday' }),
+      onMoveToDay,
+    });
+
+    // Change to Thursday via the right arrow
+    await userEvent.click(screen.getByRole('button', { name: /next day/i }));
+
+    // Close the modal
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(onMoveToDay).toHaveBeenCalledWith('sess-1', 'thursday');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not fire onMoveToDay when the modal closes without any day change', async () => {
+    const onMoveToDay = vi.fn();
+    renderModal({ session: makeSession({ dayOfWeek: 'wednesday' }), onMoveToDay });
+
+    // Close without touching the navigator
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(onMoveToDay).not.toHaveBeenCalled();
+  });
+
+  it('navigator resets to the original day when the session prop changes', async () => {
+    const onMoveToDay = vi.fn();
+    const { rerender } = render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <I18nextProvider i18n={i18n}>
+          <SessionActionsProvider
+            value={{
+              readonly: false,
+              athleteMode: true,
+              showAthleteControls: false,
+              stravaConnected: false,
+              junctionConnected: false,
+              onMoveToDay,
+            }}
+          >
+            <SessionDetailModal
+              open={true}
+              onOpenChange={vi.fn()}
+              session={makeSession({ dayOfWeek: 'wednesday' })}
+              weekStart={weekStart}
+            />
+          </SessionActionsProvider>
+        </I18nextProvider>
+      </QueryClientProvider>,
+    );
+
+    // Advance to Thursday
+    await userEvent.click(screen.getByRole('button', { name: /next day/i }));
+    expect(screen.getByRole('button', { name: /thursday/i })).toBeInTheDocument();
+
+    // Simulate server confirming a different session on Tuesday
+    rerender(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <I18nextProvider i18n={i18n}>
+          <SessionActionsProvider
+            value={{
+              readonly: false,
+              athleteMode: true,
+              showAthleteControls: false,
+              stravaConnected: false,
+              junctionConnected: false,
+              onMoveToDay,
+            }}
+          >
+            <SessionDetailModal
+              open={true}
+              onOpenChange={vi.fn()}
+              session={makeSession({ id: 'sess-2', dayOfWeek: 'tuesday' })}
+              weekStart={weekStart}
+            />
+          </SessionActionsProvider>
+        </I18nextProvider>
+      </QueryClientProvider>,
+    );
+
+    // Navigator snaps to the new session's day, not the stale pending state
+    expect(screen.getByRole('button', { name: /tuesday/i })).toBeInTheDocument();
+  });
+});

--- a/app/test/integration/useSessions.test.tsx
+++ b/app/test/integration/useSessions.test.tsx
@@ -16,6 +16,7 @@ import {
   mockCreateSession,
   mockDeleteSession,
   mockUpdateSession,
+  resetMockSessions,
 } from '~/lib/mock-data';
 import { createTestQueryClient } from '~/test/utils/query-client';
 import { queryKeys } from '~/lib/queries/keys';
@@ -144,6 +145,8 @@ describe('useDeleteSession', () => {
 });
 
 describe('useUpdateSession', () => {
+  beforeEach(() => resetMockSessions());
+
   it('optimistically updates a session description in the cache', async () => {
     const { queryClient, Wrapper } = makeWrapper();
 
@@ -164,6 +167,29 @@ describe('useUpdateSession', () => {
     ]);
     const updated = cached?.find((s) => s.id === target.id);
     expect(updated?.description).toBe('Updated description');
+  });
+
+  it('optimistically moves a session to a different day in the cache', async () => {
+    const { queryClient, Wrapper } = makeWrapper();
+
+    const sessions = await mockFetchSessionsByWeekPlan(ALICE_W10_PLAN_ID);
+    const target = sessions.find((s) => s.dayOfWeek === 'monday');
+    if (!target) throw new Error('Test data: no monday session found in Alice W10');
+
+    queryClient.setQueryData(['sessions', 'week', ALICE_W10_PLAN_ID], sessions);
+
+    const { result } = renderHook(() => useUpdateSession(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ id: target.id, dayOfWeek: 'friday' });
+    });
+
+    const cached = queryClient.getQueryData<typeof sessions>([
+      'sessions',
+      'week',
+      ALICE_W10_PLAN_ID,
+    ]);
+    expect(cached?.find((s) => s.id === target.id)?.dayOfWeek).toBe('friday');
   });
 });
 

--- a/app/test/unit/healthkit-activity-map.test.ts
+++ b/app/test/unit/healthkit-activity-map.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hkActivityToTrainingType,
+  trainingTypeMatchesHk,
+} from '~/lib/utils/healthkit-activity-map';
+
+describe('hkActivityToTrainingType', () => {
+  it.each([
+    ['run', 'run'],
+    ['walk', 'walk'],
+    ['hike', 'hike'],
+    ['bike', 'cycling'],
+    ['swim', 'swimming'],
+    ['elliptical', 'elliptical'],
+    ['strength', 'strength'],
+    ['yoga', 'yoga'],
+  ] as const)('maps HK %s → training_type %s', (hk, expected) => {
+    expect(hkActivityToTrainingType(hk)).toBe(expected);
+  });
+
+  it.each(['row', 'mixed-cardio', 'hiit', 'other', 'unknown-future-id'])(
+    'falls back to "other" for %s',
+    (id) => {
+      expect(hkActivityToTrainingType(id)).toBe('other');
+    },
+  );
+});
+
+describe('trainingTypeMatchesHk', () => {
+  it('matches when mapped training type equals session type', () => {
+    expect(trainingTypeMatchesHk('run', 'run')).toBe(true);
+    expect(trainingTypeMatchesHk('cycling', 'bike')).toBe(true);
+    expect(trainingTypeMatchesHk('swimming', 'swim')).toBe(true);
+  });
+
+  it('does not match incompatible types', () => {
+    expect(trainingTypeMatchesHk('run', 'bike')).toBe(false);
+    expect(trainingTypeMatchesHk('strength', 'yoga')).toBe(false);
+  });
+
+  it('does not auto-link when either side resolves to "other"', () => {
+    expect(trainingTypeMatchesHk('other', 'run')).toBe(false);
+    expect(trainingTypeMatchesHk('run', 'hiit')).toBe(false);
+    expect(trainingTypeMatchesHk('other', 'hiit')).toBe(false);
+  });
+});

--- a/app/types/healthkit.ts
+++ b/app/types/healthkit.ts
@@ -1,0 +1,52 @@
+/**
+ * Payload the iOS bridge returns for each HKWorkout.
+ * Activity IDs use HealthKit-side vocabulary — see `app/lib/utils/healthkit-activity-map.ts`
+ * for the translation to synek's TrainingType.
+ */
+export interface HealthKitWorkoutPayload {
+  hkUuid: string;
+  activityId: string;
+  hkActivityType: number;
+  sourceName: string | null;
+  sourceBundleId: string | null;
+  startDate: string;
+  endDate: string;
+  durationSeconds: number | null;
+  distanceMeters: number | null;
+  activeEnergyKcal: number | null;
+  averageHeartrate: number | null;
+  maxHeartrate: number | null;
+  raw: Record<string, unknown> | null;
+}
+
+/** Row shape persisted in `healthkit_workouts`. */
+export interface HealthKitWorkout {
+  id: string;
+  hkUuid: string;
+  userId: string;
+  trainingSessionId: string | null;
+  activityType: string | null;
+  hkActivityType: number | null;
+  sourceName: string | null;
+  sourceBundleId: string | null;
+  startDate: string;
+  endDate: string;
+  durationSeconds: number | null;
+  distanceMeters: number | null;
+  activeEnergyKcal: number | null;
+  averageHeartrate: number | null;
+  maxHeartrate: number | null;
+}
+
+export interface HealthKitSyncStatus {
+  connected: boolean;
+  lastSyncAt: string | null;
+  lastError: string | null;
+  workoutsSynced: number;
+}
+
+export interface HealthKitSyncResult {
+  upserted: number;
+  matched: number;
+  lastSyncAt: string;
+}

--- a/app/types/training.ts
+++ b/app/types/training.ts
@@ -313,6 +313,9 @@ export interface TrainingSession {
   stravaActivityId: number | null;
   stravaSyncedAt: string | null;
   isStravaConfirmed?: boolean;
+  healthkitWorkoutId?: string | null;
+  healthkitSyncedAt?: string | null;
+  healthkitSourceName?: string | null;
   goalId?: string | null;
   /** True when actual fields were back-filled from Garmin via augmentSessionsWithGarmin (PoC) */
   garminAugmented?: boolean;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "synek",
   "version": "0.10.5",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
   "type": "module",
   "scripts": {
     "build": "react-router build",
@@ -82,14 +82,6 @@
     "vite": "^7.1.7",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.18"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "esbuild",
-      "msw",
-      "supabase"
-    ]
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,cjs,mjs,css,json,md,yml,yaml,html}": "prettier --write"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/inter-tight": "^5.2.7",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -3236,6 +3239,7 @@ packages:
         integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==,
       }
     engines: { node: '>=10.0.0' }
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@4.0.0:
     resolution:
@@ -6397,6 +6401,7 @@ packages:
         integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==,
       }
     engines: { node: '>=14' }
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -7042,6 +7047,7 @@ packages:
         integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
       }
     engines: { node: ^18 || >=20 }
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true
+  msw: true
+  supabase: true

--- a/specs/018-ios-healthkit-wrapper/contracts/healthkit-bridge.md
+++ b/specs/018-ios-healthkit-wrapper/contracts/healthkit-bridge.md
@@ -1,0 +1,248 @@
+# Contract: HealthKit JavaScript ↔ Swift Bridge
+
+**Feature**: 018-ios-healthkit-wrapper
+**Date**: 2026-05-16
+**Consumers**: synek web SPA (`app/lib/queries/healthkit-sync.ts`), synek iOS app (`synek-ios/Synek/Bridge/`)
+
+---
+
+## Overview
+
+The bridge exposes a single global object — `window.__healthkit` — when the web app runs inside the iOS WKWebView. The web app uses bridge detection (`typeof window.__healthkit !== 'undefined'`) to conditionally render Apple Watch UI.
+
+All requests are correlated by `requestId` (UUID v4, web-generated via `crypto.randomUUID()`). The native side never initiates a call — it only responds.
+
+---
+
+## Web API surface
+
+```typescript
+declare global {
+  interface Window {
+    __healthkit?: {
+      call<TAction extends BridgeAction>(
+        action: TAction,
+        args?: BridgeArgs<TAction>,
+      ): Promise<BridgeResult<TAction>>;
+      _resolve(requestId: string, ok: unknown | null, err: BridgeError | null): void;
+    };
+  }
+}
+
+type BridgeAction = 'requestAuth' | 'fetchWorkouts' | 'getStatus' | 'getAppInfo';
+
+interface BridgeError {
+  code:
+    | 'permission_denied'
+    | 'permission_not_determined'
+    | 'hk_unavailable'
+    | 'invalid_args'
+    | 'internal';
+  message: string;
+}
+```
+
+---
+
+## Actions
+
+### `requestAuth()`
+
+Triggers iOS HealthKit permission sheet (only on first call — subsequent calls resolve immediately with the current state).
+
+**Args**: none.
+
+**Result**:
+
+```typescript
+{
+  granted: boolean;
+}
+```
+
+**Error codes**: `internal` (e.g. HK unavailable on device).
+
+**Notes**: `granted: true` does NOT guarantee the user granted read access — HealthKit deliberately does not reveal denial of read access to apps. Treat `granted: true` as "permission sheet was shown and dismissed". Verify by calling `fetchWorkouts` and inspecting the result.
+
+---
+
+### `fetchWorkouts({ sinceMs })`
+
+Fetches all workouts from HealthKit with `startDate >= sinceMs` (Unix epoch milliseconds).
+
+**Args**:
+
+```typescript
+{
+  sinceMs: number;
+}
+```
+
+**Result**:
+
+```typescript
+{ workouts: HealthKitWorkout[] }
+```
+
+Where `HealthKitWorkout` matches the TypeScript shape in `data-model.md`.
+
+**Error codes**:
+
+- `invalid_args` — `sinceMs` missing or not a number
+- `permission_denied` — HK reports access denied (rare, see note above)
+- `internal` — query failure
+
+**Ordering**: Results sorted by `startAt` descending.
+
+**Limit**: No client-side limit. Native may chunk into pages internally but returns flat array.
+
+---
+
+### `getStatus()`
+
+Reports current HealthKit availability and permission state.
+
+**Args**: none.
+
+**Result**:
+
+```typescript
+{
+  available: boolean; // HKHealthStore.isHealthDataAvailable()
+  permission: 'granted' | 'denied' | 'not_determined'; // authorization status for HKWorkoutType
+}
+```
+
+**Error codes**: never errors; if HK unavailable, returns `available: false`.
+
+---
+
+### `getAppInfo()`
+
+Returns iOS app version (for support / debug).
+
+**Args**: none.
+
+**Result**:
+
+```typescript
+{
+  version: string; // CFBundleShortVersionString, e.g. "1.0.0"
+  build: string; // CFBundleVersion, e.g. "42"
+  os: string; // UIDevice.systemVersion, e.g. "17.4.1"
+}
+```
+
+**Error codes**: never errors.
+
+---
+
+## Wire format (web → native)
+
+Web sends one JSON object per call via `window.webkit.messageHandlers.healthkit.postMessage(...)`:
+
+```json
+{
+  "action": "fetchWorkouts",
+  "requestId": "e7c0a4d1-3b9f-4d2e-9a8c-1f2b3a4d5e6f",
+  "sinceMs": 1715683200000
+}
+```
+
+## Wire format (native → web)
+
+Native resolves by calling:
+
+```js
+window.__healthkit._resolve(
+  '<requestId>',
+  /* ok */ {
+    workouts: [
+      /* ... */
+    ],
+  },
+  /* err */ null,
+);
+```
+
+Or rejects by calling:
+
+```js
+window.__healthkit._resolve(
+  '<requestId>',
+  /* ok */ null,
+  /* err */ { code: 'permission_denied', message: 'User denied HealthKit access' },
+);
+```
+
+Exactly one of `ok` and `err` must be non-null.
+
+---
+
+## Web shim (injected by native at `documentStart`)
+
+The native side injects this script before any page script runs:
+
+```js
+(() => {
+  const pending = new Map();
+  window.__healthkit = {
+    async call(action, args = {}) {
+      if (!window.webkit?.messageHandlers?.healthkit) {
+        throw new Error('healthkit bridge unavailable');
+      }
+      const requestId = crypto.randomUUID();
+      return new Promise((resolve, reject) => {
+        pending.set(requestId, { resolve, reject });
+        try {
+          window.webkit.messageHandlers.healthkit.postMessage({
+            action,
+            requestId,
+            ...args,
+          });
+        } catch (e) {
+          pending.delete(requestId);
+          reject(e);
+        }
+      });
+    },
+    _resolve(requestId, ok, err) {
+      const p = pending.get(requestId);
+      if (!p) return;
+      pending.delete(requestId);
+      err ? p.reject(Object.assign(new Error(err.message), { code: err.code })) : p.resolve(ok);
+    },
+  };
+})();
+```
+
+---
+
+## Validation requirements
+
+### Web side
+
+- Wrap every `window.__healthkit.call(...)` result with Zod validation before passing into core logic (Principle III).
+- Schemas live in `app/lib/queries/healthkit-sync.ts` and mirror this contract exactly.
+
+### Native side
+
+- Use `Codable` structs matching the wire formats above.
+- Validate `action` against an exhaustive `enum BridgeAction` — unknown actions reject with `{ code: 'invalid_args' }`.
+- Validate `requestId` is a non-empty string before attempting to reply.
+
+---
+
+## Contract evolution
+
+When adding a new action:
+
+1. Update this document first.
+2. Add the action to both `BridgeAction` (TS) and the Swift `enum BridgeAction`.
+3. Update Zod schemas in `app/lib/queries/healthkit-sync.ts`.
+4. Update `XCTest` cases in `synek-ios` covering the new action.
+5. Bump the iOS app version (any contract change requires a new app build).
+
+When changing an existing action's shape:
+
+- Treat as breaking. Either name a new action (`fetchWorkoutsV2`) and keep the old one as a stub returning `{ code: 'unsupported' }`, or coordinate a synchronized release of web + iOS.

--- a/specs/018-ios-healthkit-wrapper/data-model.md
+++ b/specs/018-ios-healthkit-wrapper/data-model.md
@@ -1,0 +1,180 @@
+# Data Model: iOS App Wrapper with HealthKit Integration
+
+**Feature**: 018-ios-healthkit-wrapper
+**Date**: 2026-05-16
+
+---
+
+## New Tables (via migration `018_healthkit_schema.sql`)
+
+### `healthkit_workouts`
+
+One row per workout pulled from HealthKit. Primary key is the HealthKit-assigned UUID (stable per device) — guarantees idempotent re-sync.
+
+```sql
+CREATE TABLE healthkit_workouts (
+  uuid                   UUID PRIMARY KEY,                                  -- HKWorkout.uuid
+  user_id                UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  hk_activity_type       SMALLINT NOT NULL,                                 -- HKWorkoutActivityType.rawValue
+  synek_activity_id      TEXT NOT NULL,                                     -- mapped synek training-type id
+  start_at               TIMESTAMPTZ NOT NULL,
+  end_at                 TIMESTAMPTZ NOT NULL,
+  duration_seconds       INTEGER NOT NULL,
+  distance_meters        NUMERIC(10,2),                                     -- nullable: not all activities have distance
+  active_energy_kcal     NUMERIC(8,2),
+  avg_heart_rate_bpm     NUMERIC(5,1),
+  source_device_name     TEXT,                                              -- "Artur's Apple Watch", "iPhone", etc.
+  matched_session_id     UUID REFERENCES sessions(id) ON DELETE SET NULL,   -- null if no matching planned session
+  raw_payload            JSONB NOT NULL,                                    -- full normalized HK data for future-proofing
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_healthkit_workouts_user_start ON healthkit_workouts (user_id, start_at DESC);
+CREATE INDEX idx_healthkit_workouts_matched ON healthkit_workouts (matched_session_id) WHERE matched_session_id IS NOT NULL;
+
+ALTER TABLE healthkit_workouts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY healthkit_workouts_owner_select ON healthkit_workouts
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+-- No INSERT/UPDATE policy: writes only via Edge Function with service-role client.
+```
+
+### `healthkit_sync_status`
+
+One row per user; drives the Integrations UI and incremental sync window.
+
+```sql
+CREATE TABLE healthkit_sync_status (
+  user_id              UUID PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  last_synced_at       TIMESTAMPTZ,                                         -- null until first successful sync
+  total_synced_count   INTEGER NOT NULL DEFAULT 0,
+  permission_state     TEXT NOT NULL DEFAULT 'not_determined'
+                       CHECK (permission_state IN ('granted','denied','not_determined')),
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE healthkit_sync_status ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY healthkit_sync_status_owner_select ON healthkit_sync_status
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+-- No INSERT/UPDATE policy: writes only via Edge Function with service-role client.
+```
+
+---
+
+## Extended Tables
+
+### `sessions` (extended)
+
+Add a JSON column tracking which data sources have populated this session's actuals. Mirrors the existing Strava pattern.
+
+```sql
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS data_sources TEXT[] NOT NULL DEFAULT '{}';
+-- Example values: ['manual'], ['strava'], ['healthkit'], ['strava','healthkit']
+```
+
+**Rationale**: When both Strava and HealthKit report data for the same session, Strava wins (current behavior) but the UI should display badges for both sources (FR-008). A simple text array is cheaper than a separate join table for a value that's almost always 0–2 entries.
+
+---
+
+## TypeScript Types
+
+```typescript
+// app/lib/queries/healthkit-sync.ts
+
+export interface HealthKitWorkout {
+  uuid: string; // HKWorkout.uuid (UUID v4 from device)
+  hkActivityType: number; // HKWorkoutActivityType.rawValue
+  synekActivityId: string; // 'run' | 'bike' | 'swim' | ...
+  startAt: string; // ISO 8601
+  endAt: string; // ISO 8601
+  durationSeconds: number;
+  distanceMeters: number | null;
+  activeEnergyKcal: number | null;
+  avgHeartRateBpm: number | null;
+  sourceDeviceName: string | null;
+}
+
+export interface HealthKitSyncStatus {
+  userId: string;
+  lastSyncedAt: string | null; // ISO 8601
+  totalSyncedCount: number;
+  permissionState: 'granted' | 'denied' | 'not_determined';
+}
+
+export interface SyncResult {
+  uploaded: number; // count newly stored (excludes deduped)
+  matched: number; // count matched to a planned session
+  lastSyncedAt: string; // ISO 8601 — server timestamp
+}
+```
+
+All snake_case → camelCase mapping happens in mapper functions inside `app/lib/queries/healthkit-sync.ts` (per Principle III).
+
+---
+
+## Swift Types (synek-ios)
+
+```swift
+// synek-ios/Synek/Models/HealthKitWorkout.swift
+
+struct HealthKitWorkoutDTO: Codable {
+    let uuid: String
+    let hkActivityType: Int
+    let synekActivityId: String
+    let startAt: String           // ISO 8601 in UTC
+    let endAt: String
+    let durationSeconds: Int
+    let distanceMeters: Double?
+    let activeEnergyKcal: Double?
+    let avgHeartRateBpm: Double?
+    let sourceDeviceName: String?
+}
+```
+
+Used both for the bridge response payload (Swift → web) and for the Edge Function POST body (web → server).
+
+---
+
+## Activity Type Mapping
+
+```typescript
+// app/lib/utils/healthkit-activity-map.ts
+
+export const HK_TO_SYNEK_ACTIVITY: Record<number, string> = {
+  37: 'run', // HKWorkoutActivityType.running
+  52: 'walk', // HKWorkoutActivityType.walking
+  35: 'hike', // HKWorkoutActivityType.hiking
+  13: 'bike', // HKWorkoutActivityType.cycling
+  31: 'bike', // HKWorkoutActivityType.indoorCycling
+  46: 'swim', // HKWorkoutActivityType.swimming
+  36: 'row', // HKWorkoutActivityType.rowing
+  18: 'elliptical', // HKWorkoutActivityType.elliptical
+  20: 'strength', // HKWorkoutActivityType.functionalStrengthTraining
+  50: 'strength', // HKWorkoutActivityType.traditionalStrengthTraining
+  57: 'yoga', // HKWorkoutActivityType.yoga
+  34: 'mixed-cardio', // HKWorkoutActivityType.mixedCardio
+  63: 'hiit', // HKWorkoutActivityType.highIntensityIntervalTraining
+};
+
+export const DEFAULT_SYNEK_ACTIVITY = 'other';
+```
+
+Mirrored verbatim in `synek-ios/Synek/HealthKitActivityMap.swift`.
+
+---
+
+## Migration File Location
+
+`supabase/migrations/018_healthkit_schema.sql`
+
+Includes:
+
+- `healthkit_workouts` table + indexes + RLS
+- `healthkit_sync_status` table + RLS
+- `ALTER TABLE sessions ADD COLUMN data_sources`
+- Backfill `data_sources = ARRAY['strava']` for any session with non-null `strava_activity_id` (preserves existing provenance)

--- a/specs/018-ios-healthkit-wrapper/plan.md
+++ b/specs/018-ios-healthkit-wrapper/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: iOS App Wrapper with HealthKit Integration
+
+**Branch**: `018-ios-healthkit-wrapper` | **Date**: 2026-05-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/018-ios-healthkit-wrapper/spec.md`
+
+## Summary
+
+Build a thin native iOS app in Swift that wraps the existing synek web SPA in a `WKWebView`, exposes a JavaScript bridge for HealthKit access, and ships a manual "Sync from Apple Watch" button in the existing Integrations settings tab. V1 is fully user-initiated (no background sync). The iOS app lives in a separate repository (`synek-ios`); changes inside this repository are limited to: (a) a new Supabase Edge Function `healthkit-sync`, (b) the `healthkit_workouts` / `healthkit_sync_status` tables and RLS policies, (c) a small UI addition in `app/components/settings/IntegrationsSection.tsx` to render the Apple Watch section when the bridge is present, (d) a query file `app/lib/queries/healthkit-sync.ts` (mock + real).
+
+This plan covers the synek-side work AND the iOS-side scaffolding plus bridge contract. The bridge contract is the integration seam — both repos must agree.
+
+## Technical Context
+
+**Language/Version (web side)**: TypeScript 5 (strict) + React 19
+**Language/Version (iOS side)**: Swift 6, iOS 16.0 minimum, Xcode 16+
+**Primary Dependencies (web)**: React Router 7 (SPA), TanStack Query 5, Supabase JS 2, shadcn/ui, i18next, Zod 4
+**Primary Dependencies (iOS)**: WebKit, HealthKit, AuthenticationServices — all Apple-provided. Zero third-party Swift packages.
+**Storage**: PostgreSQL via Supabase (new tables `healthkit_workouts`, `healthkit_sync_status`); Supabase Edge Function `healthkit-sync` for upsert
+**Testing (web)**: Mock mode; `pnpm typecheck`; Vitest
+**Testing (iOS)**: XCTest for bridge serialization; manual testing on physical iPhone + Apple Watch for HK flow
+**Target Platform**: iOS 16.0+; iPhone only (no iPad-specific layout in V1); production hosting at synek.app
+**Project Type**: Cross-repo — web SPA + native iOS shell + Supabase Edge Function
+**Performance Goals**: App cold-start to interactive <2s; sync of 10 workouts <5s; bridge round-trip <100ms
+**Constraints**: HealthKit data never leaves user's device except to the `healthkit-sync` Edge Function over HTTPS; HK usage strings must be specific; Google OAuth blocked in WKWebView (email/password only in V1); cookies/localStorage MUST persist via `WKWebsiteDataStore.default()`
+**Scale/Scope**: Per-user data; typical sync window <100 workouts; no team/coach data flows in V1
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                               | Status  | Notes                                                                                                                                                                                                                                                                 |
+| --------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| I. Lean & Purposeful                    | ✅ PASS | V1 strictly scoped: webview + manual sync. No background sync, no Android, no Apple Pay. Sync button reuses existing Integrations tab — no new settings route.                                                                                                        |
+| II. Configuration Over Hardcoding       | ✅ PASS | iOS app reads target URL from `Info.plist` per build configuration (`Debug` → `http://<dev-host>:5173`, `Release` → `https://synek.app`). Activity-type mapping (`HKWorkoutActivityType` → synek training-type) lives in a single config file mirrored on both sides. |
+| III. Type Safety & Boundary Validation  | ✅ PASS | Bridge messages validated with Zod on the web side before crossing into core logic. Edge Function validates `HealthKitWorkout[]` payload with Zod. Swift uses `Codable` types for type-safe JSON.                                                                     |
+| IV. Modularity & Testability            | ✅ PASS | `healthkit-sync` query file ships mock + real implementations. iOS `HealthKitBridge` is a pure class testable with XCTest using a stubbed `HKHealthStore`. Mutation uses standard `onMutate`/`onError`/`onSettled`.                                                   |
+| V. Performance & Operational Discipline | ✅ PASS | Zero new web bundle dependencies (web code is platform-agnostic; bridge detection is one-line `typeof` check). Edge Function uses Zod (already a dep). Native Swift has zero npm/SPM third-party packages.                                                            |
+
+**Post-design re-check**: All principles remain satisfied. The cross-repo split is justified because Apple platform code cannot live in a TypeScript SPA repo. The bridge contract (`contracts/healthkit-bridge.md`) is the single source of truth keeping both repos aligned.
+
+## Complexity Tracking
+
+| Violation                                                      | Why Needed                                                                                                                    | Simpler Alternative Rejected Because                                                                                                                                                                                                                |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New iOS Xcode project (separate repo `synek-ios`)              | Apple platform code cannot ship inside this TS/React repo; HealthKit requires native Swift with signed entitlements           | Capacitor/React Native wrappers were evaluated and rejected: heavier runtime, additional plugin maintenance burden, more dependency rot, larger bundle. For a webview-plus-HK use case the native shell is the simplest path. See `research.md` §1. |
+| New `healthkit-sync` Edge Function                             | Workouts must be authenticated by JWT and validated server-side before write; client SPA must not have service-role access    | Direct Supabase REST upsert from web would require RLS policies on the workouts table; an Edge Function is the same pattern as `strava-auth` and reuses the existing auth verification helper.                                                      |
+| Two new tables (`healthkit_workouts`, `healthkit_sync_status`) | Workout source provenance must be preserved (Strava vs HealthKit) to avoid overwriting Strava data; sync status drives the UI | Extending `sessions` directly was rejected: data shape differs (workouts can exist without a planned session) and provenance metadata would bloat the row.                                                                                          |
+| Google OAuth deferred (email/password only in V1)              | Google blocks OAuth in embedded WKWebViews since 2021 — requires `ASWebAuthenticationSession` integration                     | Implementing ASWebAuth in V1 adds Swift complexity and a deeplink redirect contract; deferring keeps V1 minimal. Documented as a V2 follow-up.                                                                                                      |
+
+## Phase 0: Research
+
+See [research.md](./research.md) for full details. Key decisions:
+
+1. **Wrapper technology**: Native Swift + `WKWebView`. (Rejected: Capacitor, React Native, Tauri, Vital iOS SDK.)
+2. **Bridge mechanism**: `WKScriptMessageHandler` (web→native) + `evaluateJavaScript` (native→web), request/response correlated by UUID.
+3. **Activity-type mapping**: Hardcoded mapping table mirrored in `app/lib/utils/training-types.ts` (web) and `HealthKitActivityMap.swift` (iOS); both reference the same canonical synek training-type IDs.
+4. **Auth approach**: Email/password only in V1 via Supabase auth in WKWebView with `WKWebsiteDataStore.default()`. Google OAuth deferred to V2 via `ASWebAuthenticationSession`.
+5. **Distribution**: V1 PoC = direct install to developer's own iPhone via free Apple ID personal team (7-day cert; reinstall weekly). TestFlight when paid Developer account is obtained. App Store submission deferred until first 5 internal users have validated.
+6. **Dedup strategy**: `HKWorkout.uuid` is stable per-device — used as primary key on `healthkit_workouts`.
+
+## Phase 1: Design
+
+See [data-model.md](./data-model.md) for schema and [contracts/healthkit-bridge.md](./contracts/healthkit-bridge.md) for the JS↔Swift bridge contract.
+
+### Cross-repo split
+
+| Concern                                       | Lives in                                                                   | Notes                                                        |
+| --------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Xcode project, Swift code                     | New repo `synek-ios` (MIT license)                                         | Branch `main` only; CI via GitHub Actions for build + XCTest |
+| HealthKit bridge contract                     | This repo: `specs/018-ios-healthkit-wrapper/contracts/healthkit-bridge.md` | Canonical — iOS repo references back here                    |
+| Supabase migration `018_healthkit_schema.sql` | This repo: `supabase/migrations/`                                          | Standard migration flow                                      |
+| Edge Function `healthkit-sync`                | This repo: `supabase/functions/healthkit-sync/`                            | Mirrors `strava-auth` structure                              |
+| Web UI (Apple Watch section in Integrations)  | This repo: `app/components/settings/`                                      | Conditionally rendered based on bridge detection             |
+| Query file `healthkit-sync.ts` (mock + real)  | This repo: `app/lib/queries/`                                              | Mock-first per Principle IV                                  |
+| i18n keys                                     | This repo: `app/i18n/locales/{en,pl}/`                                     | EN + PL added together per AGENTS.md                         |
+
+### Bridge contract (summary)
+
+Web calls: `window.__healthkit.call(action, args) → Promise<result>`
+
+- `requestAuth() → { granted: boolean }`
+- `fetchWorkouts({ sinceMs: number }) → { workouts: HealthKitWorkout[] }`
+- `getStatus() → { permission: 'granted'|'denied'|'not_determined', available: boolean }`
+- `getAppInfo() → { version: string, build: string }`
+
+Errors return `{ code: string, message: string }` and reject the promise. See contract doc for full schema.
+
+## Phase 2: Tasks
+
+See [tasks.md](./tasks.md) for the full dependency-ordered task list.
+
+High level:
+
+- **Phase 1 Setup**: migration, edge function scaffold, i18n keys, query file (mock+real), `synek-ios` repo bootstrap, bundle ID claim
+- **Phase 2 Foundational**: Edge Function with auth + Zod validation; iOS WKWebView shell with cookie persistence verified; bridge handshake working both directions
+- **Phase 3 US1 (Webview wrapper)**: full auth flow inside app, link interception, external-link routing
+- **Phase 4 US2 (Manual sync)**: HK permission flow, fetchWorkouts implementation, web button, end-to-end sync, dedup & matching
+- **Phase 5 US3 (Status display)**: status query, badges on session details
+- **Phase 6 Polish**: TestFlight upload, App Store metadata draft, telemetry hooks
+
+## Risks & Mitigations
+
+| Risk                                                       | Likelihood | Impact                              | Mitigation                                                                                                                                 |
+| ---------------------------------------------------------- | ---------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Apple rejects HealthKit usage strings as vague             | Medium     | High (blocks distribution)          | Write specific strings up-front (FR-012); review against Apple guidelines before submission                                                |
+| WKWebView loses Supabase session across cold-starts        | Medium     | High (forces re-login every launch) | Use `WKWebsiteDataStore.default()` (not ephemeral); verify in Step 1 validation gate; fallback = persist refresh token via Keychain bridge |
+| Google OAuth users cannot log in to V1                     | Certain    | Medium (some users affected)        | Document clearly in TestFlight notes; V2 ships ASWebAuthenticationSession                                                                  |
+| `HKObserverQuery` skipped in V1 means stale data           | Certain    | Low (sync button is one tap)        | Acceptable per scope decision; track real usage to decide V2 priority                                                                      |
+| iOS 17/18-only HK sample types missing from V1 mapping     | Low        | Low                                 | Mapping table is extensible; new types fall through to "other" bucket                                                                      |
+| Supabase Edge Function rate limits during initial backfill | Low        | Medium                              | Edge Function processes batches of 50 workouts; client paginates                                                                           |
+| Bridge UUID collisions or message ordering bugs            | Low        | Medium                              | XCTest covers serialization; web side uses `crypto.randomUUID()`; reject if no pending request found                                       |
+
+## Out of Scope (V1)
+
+- Background sync via `HKObserverQuery` and `enableBackgroundDelivery` (deferred to V2)
+- Android app (separate future spec)
+- Apple Watch companion app (no native watchOS UI — workouts are recorded by user's preferred AW app)
+- Push notifications
+- Google OAuth login in app (V2)
+- iPad-optimised layout (uses iPhone scaled layout in V1)
+- App Store submission (TestFlight only for V1)
+- Write access to HealthKit (read-only in V1; writing planned workouts back to HK is a V3+ consideration)

--- a/specs/018-ios-healthkit-wrapper/quickstart.md
+++ b/specs/018-ios-healthkit-wrapper/quickstart.md
@@ -1,0 +1,200 @@
+# Quickstart: iOS App Wrapper with HealthKit Integration
+
+**Feature**: 018-ios-healthkit-wrapper
+**Date**: 2026-05-16
+
+---
+
+## Prerequisites
+
+### Web side (this repo)
+
+- Supabase project running OR mock mode active
+- `pnpm dev` starts the web app at `http://localhost:5173`
+- Supabase CLI installed (`pnpm supabase:install`)
+
+### iOS side (separate `synek-ios` repo)
+
+- macOS with Xcode 16+ installed (from App Store)
+- iOS 16+ device for real HealthKit testing (Apple Watch with workout data strongly recommended)
+- Apple Developer account ($99/yr) — required for TestFlight. NOT required for V1 PoC: simulator dev + free Apple ID personal-team installs to your own device work without it. Sign up when ready to invite real testers.
+- Bundle ID: `app.synek.ios` (paid-account-only global claim deferred for V1 PoC; the same ID is still used locally so the Xcode project does not need re-configuration later)
+- **Free-tier reminder**: cert installed via free Apple ID expires after 7 days. Reinstall from Xcode when the app stops launching on device. Max 3 apps signed with a personal team at one time.
+
+---
+
+## Environment Variables
+
+### Web app (`.env.local`)
+
+No new variables needed for V1 — the bridge is auto-detected by the web app at runtime.
+
+### Supabase Edge Functions (`supabase/functions/healthkit-sync/.env`)
+
+No new secrets — uses the standard Supabase service-role client like other Edge Functions.
+
+### iOS app (`Info.plist`, set via Xcode build configurations)
+
+| Key                                                | Debug value                     | Release value                                                                                |
+| -------------------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
+| `SYNEK_WEB_URL`                                    | `http://<your-mac-lan-ip>:5173` | `https://synek.app`                                                                          |
+| `NSHealthShareUsageDescription`                    | (same as release)               | "Synek reads your workouts, heart rate, distance, and energy to populate your training log." |
+| `NSAppTransportSecurity → NSAllowsLocalNetworking` | `true`                          | `false` (default)                                                                            |
+
+---
+
+## First-time setup (web side)
+
+1. Apply the schema migration:
+
+   ```bash
+   pnpm supabase db reset       # local dev
+   # or for hosted: review and apply 018_healthkit_schema.sql via Supabase dashboard
+   ```
+
+2. Deploy the new Edge Function:
+
+   ```bash
+   bash scripts/supabase-deploy-healthkit-sync.sh   # new script created in this feature
+   ```
+
+3. Verify it runs locally:
+
+   ```bash
+   supabase functions serve healthkit-sync --no-verify-jwt
+   curl -X POST http://localhost:54321/functions/v1/healthkit-sync \
+     -H "Content-Type: application/json" \
+     -d '{"workouts":[]}'
+   # expect: 401 (no JWT) — confirms the auth check fires
+   ```
+
+4. Run the web app:
+
+   ```bash
+   pnpm dev
+   ```
+
+5. In a browser console at `http://localhost:5173`, the Apple Watch section should NOT appear (no bridge present). Open Integrations tab to confirm.
+
+---
+
+## First-time setup (iOS side)
+
+1. Clone the new repo:
+
+   ```bash
+   git clone git@github.com:<org>/synek-ios.git
+   cd synek-ios
+   open Synek.xcodeproj
+   ```
+
+2. In Xcode → Project navigator → `Synek` target → Signing & Capabilities:
+   - Team: select your Apple Developer team (free tier OK to start)
+   - Bundle ID: `app.synek.ios`
+   - Capability: HealthKit ✅
+
+3. In Xcode scheme editor, ensure `Debug` config has `SYNEK_WEB_URL = http://<your-mac-lan-ip>:5173` and `Release` has `https://synek.app`.
+
+4. `Cmd+R` to run in simulator. Synek landing page should appear.
+
+5. Run on a physical device (Cmd+R with device selected):
+   - First time: iOS will prompt to trust the developer profile under Settings → General → VPN & Device Management
+   - First HealthKit call: iOS prompts for HK permission
+
+---
+
+## Development loop (typical)
+
+### Web changes
+
+```bash
+pnpm dev   # autoreloads inside iOS app's WKWebView
+```
+
+No iOS rebuild needed. The webview re-fetches `SYNEK_WEB_URL` on app launch and respects hot module reload while running.
+
+### iOS Swift changes
+
+```
+Cmd+R in Xcode   # rebuild & deploy to simulator/device
+```
+
+### Bridge contract changes
+
+Both sides must be updated in lockstep. Update `contracts/healthkit-bridge.md` first, then web Zod schemas, then Swift `Codable` types.
+
+---
+
+## Manual test plan (run before each TestFlight release)
+
+| #   | Step                                                                     | Expected                                              |
+| --- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| 1   | Install fresh build, launch                                              | Synek landing page renders                            |
+| 2   | Log in with email/password                                               | Reaches dashboard                                     |
+| 3   | Force-kill app, relaunch                                                 | Still logged in, lands on dashboard                   |
+| 4   | Navigate to Settings → Integrations                                      | "Apple Watch (HealthKit)" section visible             |
+| 5   | Tap "Sync from Apple Watch" (first time)                                 | iOS HK permission sheet appears                       |
+| 6   | Grant all data types                                                     | Sync proceeds, success state shows count              |
+| 7   | Tap "Sync" again                                                         | Only new workouts since step 6 are uploaded           |
+| 8   | On Apple Watch, record a new workout, end it                             | (Wait 30s for HK to ingest)                           |
+| 9   | Tap "Sync" in app                                                        | New workout appears, count increments by 1            |
+| 10  | View a planned session matching the new workout's date + type            | Actual fields populated, HealthKit badge visible      |
+| 11  | Deny HK permission (Settings → Privacy → Health → Synek → Off), tap Sync | Permission-required state shows with link to settings |
+| 12  | Open browser at synek.app (NOT in app)                                   | Apple Watch section is NOT visible                    |
+
+---
+
+## Troubleshooting
+
+| Symptom                                                    | Likely cause                                      | Fix                                                                                                           |
+| ---------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Apple Watch section missing in app                         | Bridge script not injected at `documentStart`     | Check `WKUserScript` injectionTime in `WebViewContainer.swift`                                                |
+| Permission sheet doesn't appear                            | HealthKit entitlement not enabled                 | Xcode → Signing & Capabilities → confirm HealthKit row exists                                                 |
+| Permission sheet appears but `fetchWorkouts` returns empty | Read access silently denied OR no data on device  | Verify on a device with known Apple Watch workouts; HK never confirms read denial                             |
+| Cookies / login lost on app cold-start                     | Using ephemeral data store                        | Confirm `WKWebViewConfiguration.websiteDataStore = .default()` (the default — check it's not been overridden) |
+| Google login button does nothing in app                    | Google blocks OAuth in webviews                   | Expected in V1 — use email/password. Document in TestFlight notes.                                            |
+| Edge Function returns 401                                  | JWT missing or expired                            | Web client must send `Authorization: Bearer <session.access_token>` header                                    |
+| Sync uploads duplicates                                    | `uuid` primary key collision should prevent this  | Check Edge Function UPSERT is using `ON CONFLICT (uuid) DO UPDATE`                                            |
+| Workouts on Apple Watch not appearing in HK                | Native AW Workout app sometimes delays sync to HK | Open Apple Health app on iPhone, pull-to-refresh, then retry                                                  |
+
+---
+
+## Verification before merge (web side)
+
+Standard synek gates (per AGENTS.md):
+
+```bash
+pnpm typecheck
+pnpm test:run
+pnpm format:check
+pnpm verify:app
+pnpm supabase:functions:check   # required because we added an Edge Function
+pnpm verify                     # full gate including the above
+```
+
+## Verification before TestFlight upload (iOS side)
+
+```bash
+# In synek-ios/
+xcodebuild test -scheme Synek -destination 'platform=iOS Simulator,name=iPhone 15'
+xcodebuild archive -scheme Synek -archivePath build/Synek.xcarchive
+```
+
+Manual checks:
+
+- Bundle version (`CFBundleVersion`) incremented since last upload
+- HK usage strings unchanged (or reviewed by another person if changed)
+- No debug `print()` left in production code paths
+
+---
+
+## V2 follow-ups (not in this spec)
+
+- Background sync via `HKObserverQuery` + `enableBackgroundDelivery`
+- Google OAuth via `ASWebAuthenticationSession`
+- Workout route (GPS polyline) ingestion
+- Per-second HR samples (timeline view, not just average)
+- App Store submission
+- Fastlane / automated TestFlight pipeline
+- iPad layout
+- Push notifications

--- a/specs/018-ios-healthkit-wrapper/research.md
+++ b/specs/018-ios-healthkit-wrapper/research.md
@@ -1,0 +1,204 @@
+# Research: iOS App Wrapper with HealthKit Integration
+
+**Feature**: 018-ios-healthkit-wrapper
+**Date**: 2026-05-16
+
+---
+
+## 1. Wrapper Technology Selection
+
+### Decision
+
+**Native Swift + `WKWebView`**, in a separate repository (`synek-ios`).
+
+### Alternatives evaluated
+
+| Option                                        | Why rejected                                                                                                                                                                                                                                                                            |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Capacitor + `perfood/capacitor-healthkit`** | Plugin last released Feb 2025 (~15 months stale), no LICENSE file, single maintainer. Capacitor adds an npm dep, plugin layer, and `cap sync` build step for what amounts to a one-call native bridge in our case. Forking the plugin is comparable effort to writing ~50 LOC of Swift. |
+| **React Native + `react-native-health`**      | Adds full RN runtime (Hermes + bridge + Metro bundler) — ~25 MB binary baseline — for one native call. Two JS contexts (RN + WebView) complicate the bridge with no payoff when there are no native UI screens planned.                                                                 |
+| **Tauri Mobile 2.0**                          | Mobile support is still maturing as of 2026; no mature HealthKit Rust crate. Forces Rust on a team that doesn't use it. Premature for production.                                                                                                                                       |
+| **Vital iOS SDK**                             | Originally a strong fit because Vital was a paid dep, but Vital is being removed from the stack (decision 2026-05). No remaining reason to introduce a vendor SDK.                                                                                                                      |
+| **PWA + "Health Auto Export"**                | Third-party app the user must install, configure, and pay for separately. Unacceptable UX for a real product.                                                                                                                                                                           |
+| **NativeScript / Flutter**                    | Neither uses webview as primary renderer; would require rebuilding synek's UI. Off-table for "wrapper".                                                                                                                                                                                 |
+
+### Rationale
+
+For a webview + single native bridge (HealthKit), native Swift is the simplest possible stack:
+
+- Zero npm dependencies, zero SPM dependencies — only Apple-provided frameworks (`WebKit`, `HealthKit`, `AuthenticationServices`)
+- Smallest binary (~5 MB vs ~25 MB for RN)
+- No plugin maintenance risk
+- Bridge is one `WKScriptMessageHandler` (web→native) + one `evaluateJavaScript` (native→web)
+- Apple platform code naturally lives in Xcode; nothing about wrapping it in Capacitor adds value
+
+The tradeoff (requires Swift skill) is acceptable: ~150 LOC of Swift is a one-time write, with no ongoing dependency churn.
+
+---
+
+## 2. JavaScript ↔ Native Bridge Design
+
+### Decision
+
+- **Web → Native**: `window.webkit.messageHandlers.healthkit.postMessage({ action, requestId, ...args })`. Native side implements `WKScriptMessageHandler` and routes by `action`.
+- **Native → Web**: After action completes, native calls `webView.evaluateJavaScript("window.__healthkit._resolve('<requestId>', <result>, <err>)")`.
+- **Correlation**: Each request includes a `requestId` (web-generated `crypto.randomUUID()`); native echoes it back in the resolve call.
+- **Injection point**: A `WKUserScript` with `injectionTime: .atDocumentStart` defines `window.__healthkit` before any page script runs, so the web app can detect the bridge during initial render.
+
+### Why not message-channel via `WKWebView.postMessage`
+
+`WKWebView` does not natively expose a `BroadcastChannel`-style two-way API. The official documented path is exactly what's chosen above; trying to invent a richer abstraction (e.g. wrapping each direction in a fake `MessagePort`) buys nothing and obscures debugging.
+
+### Error handling
+
+Native rejects the promise by passing a non-null `err` argument: `{ code: 'permission_denied' | 'hk_unavailable' | 'internal', message: string }`. Web side maps codes to user-friendly i18n strings.
+
+---
+
+## 3. Authentication in WKWebView
+
+### Decision
+
+- **Email/password Supabase login**: works inside WKWebView when `WKWebsiteDataStore.default()` is used (non-ephemeral). Supabase JS persists session to `localStorage`, which survives app cold-starts.
+- **Google OAuth**: deferred to V2. Google explicitly blocks OAuth flows in embedded webviews since 2021. V2 will integrate `ASWebAuthenticationSession` and intercept the redirect deeplink to deliver the auth code back to Supabase.
+
+### Findings during codebase inspection
+
+- `app/lib/supabase.ts` creates a default Supabase client — uses `localStorage` by default for session persistence ✅
+- `app/lib/auth.ts:25` uses `sessionStorage` for a quick `synek_user_id` lookup — this clears on app kill, but the Supabase session (`localStorage`) does NOT. The `AuthContext` re-hydrates user from Supabase session on app launch, so the sessionStorage gap is invisible to the user.
+- `app/lib/queries/auth-callbacks.ts` handles Google OAuth via `supabase.auth.signInWithOAuth({ provider: 'google' })` — uses redirect flow, blocked in WKWebView.
+
+### Validation gate (Step 1)
+
+Manual test: log in with email/password, force-kill app, relaunch — user must remain logged in. If not, debug `WKWebsiteDataStore` configuration before continuing.
+
+---
+
+## 4. HealthKit Data Model & Query API
+
+### Decision
+
+Use `HKSampleQueryDescriptor` (iOS 16+, async/await) to query `HKWorkout` samples. Iterate workouts and fetch associated samples (heart rate, route) per workout as needed.
+
+### Workout fields fetched (V1)
+
+- `workout.uuid` (UUID, primary key)
+- `workout.workoutActivityType` (HKWorkoutActivityType enum → synek training-type via mapping)
+- `workout.startDate`, `workout.endDate`, `workout.duration`
+- `workout.statistics(for: HKQuantityType.distanceWalkingRunning / .distanceCycling)` (meters)
+- `workout.statistics(for: HKQuantityType.activeEnergyBurned)` (kcal)
+- Average HR via separate `HKStatisticsQuery` over the workout's date range (bpm)
+- `workout.sourceRevision.source.name` (device name — "Artur's Apple Watch")
+
+### Deferred to V2
+
+- Workout route (`HKWorkoutRoute` + GPS polyline)
+- Heart rate samples timeline (vs single average)
+- Splits / laps (`HKWorkoutEvent`)
+
+### Rationale
+
+V1 covers the fields synek already supports for Strava (duration, distance, average HR, calories). Anything richer is a UI build-out separate from this spec.
+
+---
+
+## 5. Activity Type Mapping
+
+### Decision
+
+Maintain a hardcoded mapping table from `HKWorkoutActivityType` (Apple enum) to synek's internal training-type IDs (the ones defined in `app/lib/utils/training-types.ts`).
+
+### Why hardcoded vs server-driven
+
+- Mapping is small (~15 entries)
+- New Apple workout types appear once per iOS release (~1/year); a code change per release is acceptable
+- Server-driven would require an additional Edge Function call before every sync — premature
+
+### Coverage (V1)
+
+At minimum, mappings for: running, walking, hiking, cycling (outdoor + indoor), swimming, rowing, elliptical, functionalStrengthTraining, traditionalStrengthTraining, yoga, mixedCardio, highIntensityIntervalTraining. Unknown types fall through to `other`.
+
+### Cross-repo sync
+
+The mapping lives in two places:
+
+- `synek-ios/Synek/HealthKitActivityMap.swift` (HKWorkoutActivityType.rawValue → string ID)
+- `app/lib/utils/healthkit-activity-map.ts` (string ID → synek training-type ID)
+
+The string IDs are the contract. Adding a new type requires updating both files. Documented in the contract.
+
+---
+
+## 6. Storage Schema (Supabase)
+
+### Decision
+
+Two new tables: `healthkit_workouts` (per-workout data, primary key `uuid`) and `healthkit_sync_status` (one row per user, sync metadata). See [data-model.md](./data-model.md).
+
+### Why not extend `sessions`
+
+- Workouts can exist with no matching planned session (e.g. impromptu run)
+- Provenance must be preserved (HealthKit vs Strava vs manual entry)
+- Bloating `sessions` with HK-specific columns violates lean-purposeful principle
+
+### Matching strategy
+
+Mirror Strava: same calendar day (athlete timezone) + matching activity type → populate session's actual fields. If a session already has Strava actuals, HealthKit data is stored but does NOT overwrite (a `data_sources` JSON array on the session records which sources reported it).
+
+---
+
+## 7. Distribution & Signing
+
+### Decision
+
+**V1 PoC**: direct install to developer's own iPhone via free Apple ID personal team (`Cmd+R` from Xcode). 7-day cert; reinstall weekly. Max 3 apps signed at once with a personal team.
+
+**Post-PoC**: TestFlight when paid Apple Developer account is acquired. App Store submission deferred until at least 5 internal users have used the app for 2 weeks without blocking issues.
+
+### Apple Developer account
+
+Required for TestFlight. $99/yr. Not required for simulator-only development or short-lived (7-day) free-tier device installs. **V1 PoC explicitly defers paid account signup** — installs go to developer's own iPhone via free Apple ID. Sign-up triggered when ready to invite real testers (post-PoC).
+
+### Bundle ID
+
+`app.synek.ios` (chosen by user 2026-05-16). Reverse of the `synek.app` domain. Same ID used locally during PoC; globally claimed via developer.apple.com only after paid account is acquired. Switching the ID later is a multi-step pain — picking it correctly now avoids that.
+
+### Provisioning
+
+Automatic signing in Xcode using the developer account team. HealthKit capability is auto-added to provisioning profile when the entitlement is enabled in the project.
+
+---
+
+## 8. Build & CI
+
+### Decision
+
+- **Local builds**: Xcode 16+, manual `Cmd+R` and `Product → Archive`
+- **CI**: GitHub Actions on `synek-ios` repo — runs `xcodebuild test` on every PR. Build for TestFlight is manual via Xcode Organizer in V1 (CI-driven Fastlane setup deferred to V2)
+- **Web build**: synek web stays on Vercel — iOS app loads production URL or dev URL based on build config
+
+### Why manual TestFlight upload
+
+Fastlane / EAS-style automated upload is a real time investment (~half a day) and overkill for a sub-weekly release cadence in the early phase.
+
+---
+
+## 9. Security & Privacy
+
+### Decisions
+
+- HealthKit data is sent only to the `healthkit-sync` Edge Function, authenticated by the user's Supabase JWT
+- No third-party analytics SDKs in the iOS app (V1) — telemetry can be added in V2 if needed, with explicit user consent
+- HK usage strings in `Info.plist` are specific (FR-012) — "Synek reads your workouts, heart rate, distance, and energy to populate your training log"
+- App Transport Security defaults to HTTPS-only; dev mode exception narrowly allows `localhost` and `*.local`
+- No HealthKit write permissions requested in V1 (read-only)
+
+### Apple review compliance
+
+Apple's HealthKit review checks for:
+
+1. Specific usage strings ✅ (FR-012)
+2. Privacy policy URL in App Store listing ✅ (synek.app/privacy)
+3. No selling/sharing HK data ✅ (only ingested into user's own synek account)
+4. No HK data used for advertising ✅ (no ads)
+5. Read-only is preferred over write ✅ (V1 is read-only)

--- a/specs/018-ios-healthkit-wrapper/spec.md
+++ b/specs/018-ios-healthkit-wrapper/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: iOS App Wrapper with HealthKit Integration
+
+**Feature Branch**: `018-ios-healthkit-wrapper`
+**Created**: 2026-05-16
+**Status**: Draft
+**Input**: User description: "Create an iOS app wrapper for synek using native Swift + WKWebView. Main purpose is to integrate with HealthKit to fetch data from Apple Watch trainings. V1 uses a manual sync button. Background sync is deferred to V2."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Open Synek as a Native iOS App (Priority: P1)
+
+An athlete installs the Synek iOS app from TestFlight on their iPhone, opens it, logs in with their email and password, and uses Synek exactly as they would on the web — viewing sessions, planning, charts. The app is a thin native shell around the existing web application.
+
+**Why this priority**: Foundation for every other native capability. Without a working webview that preserves auth and renders the SPA correctly, HealthKit integration has nowhere to display results.
+
+**Independent Test**: Install the iOS app on a physical device, log in with email/password, navigate to the dashboard, kill the app, relaunch — user remains logged in and lands on the same dashboard.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is installed and launched for the first time, **When** the user opens it, **Then** the synek.app landing page renders inside the app exactly as in mobile Safari.
+2. **Given** the login screen is shown, **When** the user enters valid email/password credentials, **Then** they are signed in and reach their dashboard.
+3. **Given** a logged-in user, **When** they fully kill the app (swipe up from app switcher) and relaunch, **Then** they remain logged in and reach the same route they were on (or dashboard fallback).
+4. **Given** any synek page is open, **When** the user taps internal links, **Then** navigation occurs inside the webview (no external Safari handoff).
+5. **Given** the user taps an external link (e.g. Strava OAuth), **When** the link points to a non-synek domain, **Then** it opens in the system browser (`ASWebAuthenticationSession` for OAuth) and returns control to the app after completion.
+
+---
+
+### User Story 2 - Manually Sync Apple Watch Workouts (Priority: P1)
+
+An athlete who has completed runs and other trainings on their Apple Watch opens the Synek iOS app, navigates to Settings → Integrations, and taps "Sync from Apple Watch". The app prompts for HealthKit permission on first use, fetches the user's recent workouts from HealthKit, and uploads them to Synek's backend. The user immediately sees those workouts populate the actual-performance fields of matching planned sessions, identical to how the Strava integration behaves.
+
+**Why this priority**: This is the entire reason the iOS wrapper exists. Without it, the app provides no value beyond the web version.
+
+**Independent Test**: Record a workout on Apple Watch, open Synek iOS, tap "Sync from Apple Watch", grant permission. Workout appears in synek (matched to a planned session if one exists on the same date, or stored as an unattached actual otherwise) within 10 seconds.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the Integrations settings tab inside the iOS app for the first time, **When** the screen renders, **Then** an "Apple Watch (HealthKit)" section appears with a "Sync from Apple Watch" button. The section MUST NOT appear when viewing synek.app outside the iOS app.
+2. **Given** the user taps "Sync from Apple Watch" for the first time, **When** the action runs, **Then** iOS displays the native HealthKit permission sheet listing the requested data types (workouts, heart rate, route, distance, active energy).
+3. **Given** the user grants HealthKit permission, **When** the sync completes, **Then** a success state shows the count of workouts uploaded and the timestamp.
+4. **Given** sync has completed, **When** a planned session exists on the same calendar day with a matching activity type, **Then** the session's actual performance fields (duration, distance, average heart rate, calories) are populated from the HealthKit workout — matching the same matching strategy as the Strava integration.
+5. **Given** the user denies HealthKit permission, **When** they tap "Sync" again, **Then** the app shows guidance to enable permission in iOS Settings → Privacy → Health → Synek.
+6. **Given** sync has run successfully before, **When** the user taps "Sync" again, **Then** only workouts newer than the last successful sync are fetched and uploaded (incremental sync).
+
+---
+
+### User Story 3 - View HealthKit Sync Status (Priority: P2)
+
+A user can see at a glance whether their HealthKit sync is configured and when it last ran. Matches the Strava integration's status display for consistency.
+
+**Why this priority**: Trust and transparency. Lower priority because the core value is delivered by sync itself; the status display is polish.
+
+**Independent Test**: After a successful sync, open Integrations tab on the iOS app — last-synced timestamp and total synced workout count are visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** HealthKit permission has been granted, **When** the user opens Integrations tab, **Then** they see the last-synced timestamp and a count of workouts ever synced from HealthKit.
+2. **Given** a session was populated from HealthKit, **When** the athlete views that session, **Then** a visual indicator (HealthKit badge) confirms the data source — distinct from the Strava badge.
+
+---
+
+### Edge Cases
+
+- **HealthKit unavailable (running outside iOS app)**: The "Apple Watch" section is hidden when `window.__healthkit` bridge is not present. No errors shown.
+- **No HealthKit data on device**: Sync completes successfully with "0 new workouts" message — not treated as an error.
+- **Network failure mid-sync**: Upload fails, partial state is rolled back, user sees error toast with retry option.
+- **Duplicate workout**: Workouts are deduplicated by `HKWorkout.uuid` (HealthKit's stable UUID); re-running sync does not create duplicates.
+- **Workout matched to a session that already has Strava data**: HealthKit data does NOT overwrite existing actuals from Strava (Strava wins). User sees both badges if both sources reported data.
+- **App killed mid-sync**: Sync is not resumable in V1; user re-taps Sync after relaunch. Idempotent by UUID.
+- **HealthKit permission revoked in iOS Settings**: Next sync attempt shows "Permission required" state with re-prompt link.
+- **Email/password login works; Google OAuth in WKWebView blocked**: Google explicitly blocks OAuth flows in embedded webviews. V1 requires email/password — Google OAuth via `ASWebAuthenticationSession` is deferred to V2.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The iOS app MUST wrap the synek.app web application in a `WKWebView` that uses `WKWebsiteDataStore.default()` (non-ephemeral) so that `localStorage` (and therefore the Supabase auth session) persists across app launches.
+- **FR-002**: The iOS app MUST request HealthKit read permission for: `HKObjectType.workoutType()`, `HKQuantityType.heartRate`, `HKQuantityType.distanceWalkingRunning`, `HKQuantityType.distanceCycling`, `HKQuantityType.activeEnergyBurned`, `HKSeriesType.workoutRoute()`. No write permissions are requested.
+- **FR-003**: The iOS app MUST expose a JavaScript bridge on `window.__healthkit` with at least: `requestAuth()`, `fetchWorkouts(since)`, `getStatus()`. Each returns a Promise.
+- **FR-004**: The web application MUST detect `window.__healthkit` and render the "Apple Watch (HealthKit)" section in the Integrations tab only when present.
+- **FR-005**: On "Sync from Apple Watch" tap, the web application MUST: (a) request permission via bridge, (b) fetch workouts since the last-synced timestamp (or last 90 days on first run), (c) POST workouts to a new Supabase Edge Function `healthkit-sync` for storage, (d) display the result count.
+- **FR-006**: Workouts MUST be deduplicated by `HKWorkout.uuid` (stable per device). Re-syncing the same workout MUST be a no-op upsert.
+- **FR-007**: Workouts MUST be matched to planned sessions using the same logic as the Strava integration: same calendar day (athlete timezone) AND matching activity type (HKWorkoutActivityType → synek training-type via a mapping table).
+- **FR-008**: When a session already has actuals populated from Strava, HealthKit MUST NOT overwrite them. The session MUST record that both sources reported data.
+- **FR-009**: The iOS app MUST NOT request, store, or transmit HealthKit data to any destination other than the synek `healthkit-sync` Edge Function.
+- **FR-010**: External links (non-synek hosts) MUST open via `ASWebAuthenticationSession` (for OAuth flows on accounts.google.com) or `SFSafariViewController` (for general external pages) — not in the WKWebView and not via app handoff.
+- **FR-011**: The app MUST display its version in the Settings → User tab footer for support purposes (read from `Bundle.main.infoDictionary["CFBundleShortVersionString"]` via a separate bridge call `getAppInfo()`).
+- **FR-012**: HealthKit usage strings in `Info.plist` MUST clearly describe the purpose: "Synek reads your workouts, heart rate, distance, and energy to populate your training log." Vague strings cause App Store rejection.
+- **FR-013**: The app MUST handle the case where HealthKit access is denied: subsequent calls to `fetchWorkouts` MUST return an error with a code that the web UI can convert into "permission required" guidance.
+- **FR-014**: The minimum supported iOS version MUST be iOS 16.0.
+- **FR-015**: V1 MUST NOT include background sync (`HKObserverQuery`, `enableBackgroundDelivery`, `UIBackgroundModes`). All sync is user-initiated via the button.
+
+### Key Entities _(include if feature involves data)_
+
+- **HealthKitWorkout**: A workout sample retrieved from HealthKit. Identified by `uuid` (UUID, device-stable). Fields: activity type, start/end time, duration, total distance (meters), total energy burned (kcal), average heart rate (bpm), source device name. Stored in a new `healthkit_workouts` table similar to existing Strava workout storage.
+- **HealthKitSyncStatus**: One row per user. Fields: `user_id`, `last_synced_at`, `total_synced_count`, `permission_state` (granted | denied | not_determined), `created_at`. Used to drive the Integrations UI and incremental sync.
+- **HealthKitWorkoutMatch**: Optional row linking a `healthkit_workouts.uuid` to a `sessions.id` when matching succeeded. Mirrors how Strava activities are matched to sessions.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A new user can install the app from TestFlight, log in, grant HealthKit permission, and complete a successful sync in under 3 minutes.
+- **SC-002**: Manual sync of the last 7 days of workouts (typical: 3-10 items) completes in under 5 seconds on a recent iPhone over WiFi.
+- **SC-003**: Re-syncing produces zero duplicates (verified by row count before/after).
+- **SC-004**: When a workout completed on Apple Watch is synced, the matching planned session's actual fields are populated within one full sync cycle (no manual refresh needed beyond the sync itself).
+- **SC-005**: Cold-start of the iOS app to interactive synek dashboard completes in under 2 seconds on iPhone 13 or newer.
+- **SC-006**: The app passes Apple App Store HealthKit review on first submission (verified by absence of usage-string rejection).
+- **SC-007**: Email/password authentication state persists across at least 30 consecutive app cold-starts without forced re-login.

--- a/specs/018-ios-healthkit-wrapper/tasks.md
+++ b/specs/018-ios-healthkit-wrapper/tasks.md
@@ -1,0 +1,214 @@
+# Tasks: iOS App Wrapper with HealthKit Integration
+
+**Input**: Design documents from `/specs/018-ios-healthkit-wrapper/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/ ✅ quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- **[iOS]**: Task is in the `synek-ios` repo (not this one)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Schema migration, Edge Function scaffold, query file, repo bootstrap, bundle ID claim. Establishes the foundation before any user story work.
+
+- [ ] T001 Write `supabase/migrations/018_healthkit_schema.sql` per data-model.md — creates `healthkit_workouts`, `healthkit_sync_status`, adds `sessions.data_sources TEXT[]` with backfill for existing Strava rows, applies RLS policies
+- [ ] T002 [P] Add i18n keys for HealthKit UI to `app/i18n/locales/en/integrations.json` and `app/i18n/locales/pl/integrations.json` simultaneously (per AGENTS.md): section title, sync button label, permission denied state, last-synced label, badge label
+- [ ] T003 [P] Add `healthkitSync` and `healthkitStatus` query key factories to `app/lib/queries/keys.ts`
+- [ ] T004 [P] [iOS] Bootstrap new `synek-ios` GitHub repo with `.gitignore` (Xcode template), `README.md` (links back to this spec), `LICENSE` (MIT), GitHub Actions workflow file `.github/workflows/test.yml` running `xcodebuild test`
+- [ ] T005 [P] [iOS] Create Xcode project `Synek.xcodeproj` — iOS App target, SwiftUI, Swift 6, iOS 16.0 minimum, bundle ID `app.synek.ios`, automatic signing using free Apple ID (personal team). Note: free-tier provisioning expires every 7 days — reinstall via Xcode when cert expires
+- [ ] T006 Claim bundle ID `app.synek.ios` in developer.apple.com (deferred — requires paid Apple Developer account; free Apple ID can still install on personal device without claiming a global bundle ID, but the ID becomes binding once a paid account is created later). For V1 PoC, skip this task; revisit when paying for the account.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Bridge contract implementation, Edge Function with auth + Zod validation, WKWebView shell with cookie persistence verified. Both repos must reach a working state where they can call each other.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### Web side
+
+- [ ] T010 Create `supabase/functions/healthkit-sync/index.ts` — mirror structure of `strava-auth`: verify JWT via `anonClient.auth.getUser(jwt)`, accept `{ workouts: HealthKitWorkout[] }` body, validate with Zod, upsert into `healthkit_workouts` with `ON CONFLICT (uuid) DO UPDATE`, update `healthkit_sync_status` row, run matching against `sessions` (same calendar day + matching activity type), return `{ uploaded, matched, lastSyncedAt }`
+- [ ] T011 [P] Create `scripts/supabase-deploy-healthkit-sync.sh` — mirror `scripts/supabase-deploy-strava.sh` pattern
+- [ ] T012 [P] Create `app/lib/queries/healthkit-sync.ts` with **mock implementation first** (per Principle IV) then real implementation: `syncHealthKitWorkouts(workouts) → SyncResult`, `getHealthKitSyncStatus(userId) → HealthKitSyncStatus`. Include Zod schemas for HealthKitWorkout, HealthKitSyncStatus, SyncResult
+- [ ] T013 [P] Create `app/lib/hooks/useHealthKitBridge.ts` — typed wrapper around `window.__healthkit.call()` with Zod validation on each result; exposes `isAvailable`, `requestAuth()`, `fetchWorkouts(sinceMs)`, `getStatus()`
+- [ ] T014 [P] Create `app/lib/hooks/useHealthKitConnection.ts` mirroring `useStravaConnection.ts` — `useHealthKitSyncStatus`, `useHealthKitSync` mutation (onMutate / onError / onSettled), composed on top of `useHealthKitBridge` for the device call and `app/lib/queries/healthkit-sync.ts` for the server call
+- [ ] T015 [P] Create `app/lib/utils/healthkit-activity-map.ts` per data-model.md (HK rawValue → synek training-type ID)
+- [ ] T016 Add `data_sources` field to session row mapper in `app/lib/queries/sessions.ts` and to the `Session` TypeScript type
+
+### iOS side
+
+- [ ] T020 [iOS] Create `WebViewContainer.swift` (SwiftUI `UIViewRepresentable`) wrapping `WKWebView`, using `WKWebsiteDataStore.default()` (NOT ephemeral). Load URL from `Info.plist` `SYNEK_WEB_URL` key
+- [ ] T021 [iOS] Implement `BridgeMessageHandler.swift` conforming to `WKScriptMessageHandler` — routes by `action`, validates `requestId`, replies via `evaluateJavaScript("window.__healthkit._resolve(...)")`
+- [ ] T022 [iOS] Inject web shim from `contracts/healthkit-bridge.md` as `WKUserScript` at `injectionTime: .atDocumentStart`
+- [ ] T023 [iOS] Implement `HealthKitBridge.swift` — wraps `HKHealthStore`, exposes `requestAuth()`, `fetchWorkouts(since: Date)`, `getStatus()`. Use `HKSampleQueryDescriptor` async API. Returns `Codable` DTOs matching the wire format
+- [ ] T024 [iOS] Implement `HealthKitActivityMap.swift` mirroring the web mapping exactly
+- [ ] T025 [iOS] Create `Info.plist` entries: `NSHealthShareUsageDescription` (specific per FR-012), `SYNEK_WEB_URL`, debug-only ATS exception for `localhost` / `*.local`
+- [ ] T026 [iOS] Enable HealthKit capability in Signing & Capabilities; verify `Synek.entitlements` contains `com.apple.developer.healthkit`
+- [ ] T027 [iOS] Implement `WKNavigationDelegate` to intercept external-link navigation: in-domain navigation stays in webview, external HTTPS opens in `SFSafariViewController`, OAuth flows are caught and rejected with explicit message (V2 will use `ASWebAuthenticationSession`)
+- [ ] T028 [iOS] Add XCTest cases for `BridgeMessageHandler` (action routing, error format) and for `HealthKitActivityMap` (mapping table covers all enum cases listed in spec)
+
+### Validation gate
+
+- [ ] T030 **GATE: Bridge handshake verified end-to-end**. Web side: open Safari Web Inspector connected to simulator, execute `await window.__healthkit.call('getAppInfo')`, must return `{version, build, os}`. Web side: execute `await window.__healthkit.call('getStatus')`, must return `{available, permission}`. If either fails, fix before continuing to Phase 3.
+
+---
+
+## Phase 3: User Story 1 — Open Synek as a Native iOS App (Priority P1)
+
+**Goal**: User can install the app, log in with email/password, and use synek as a native experience.
+
+**Independent Test**: Install, log in, kill app, relaunch — still logged in.
+
+### Implementation
+
+- [ ] T040 [iOS] Add navigation handling: `WKNavigationDelegate` blocks navigation to non-synek hosts; web in-app links stay in webview
+- [ ] T041 [iOS] Add a thin loading state UI (SwiftUI `ProgressView`) shown while WKWebView is loading the initial URL
+- [ ] T042 [iOS] Configure WKWebView with appropriate viewport (no zoom, content-inset for status bar / home indicator)
+- [ ] T043 [iOS] Handle pull-to-refresh: enable on root navigation only, reloads `SYNEK_WEB_URL`
+- [ ] T044 [iOS] Add error state: if initial load fails (no network), show retry UI with "Retry" button
+
+### Validation gate
+
+- [ ] T050 Execute manual test plan from `quickstart.md` steps 1-3. Document each in a brief note.
+- [ ] T051 **GATE: Auth persists across 5 cold-starts** (force-quit + relaunch). If session resets, debug `WKWebsiteDataStore` before continuing.
+
+**Checkpoint**: At this point US1 should be fully functional and independently deliverable. The app is usable as a "synek as a native app" experience without any HealthKit features.
+
+---
+
+## Phase 4: User Story 2 — Manually Sync Apple Watch Workouts (Priority P1)
+
+**Goal**: User can grant HK permission and sync workouts to synek.
+
+**Independent Test**: Record AW workout, tap Sync, see workout appear in synek.
+
+### Web UI
+
+- [ ] T060 Create `app/components/settings/HealthKitSection.tsx` mirroring the pattern of `JunctionGarminSection.tsx` — self-contained section component. Import it into `app/components/settings/IntegrationsTab.tsx` alongside the existing sections. Conditionally render content based on `useHealthKitBridge().isAvailable` (returns null / placeholder when bridge unavailable so the section still slots into the tab gracefully outside the iOS app)
+- [ ] T061 `HealthKitSection` content: "Sync from Apple Watch" button. On click: call `requestAuth()`, then `fetchWorkouts(sinceMs)` where `sinceMs = status.lastSyncedAt ?? Date.now() - 90*86400_000`, then POST to `syncHealthKitWorkouts(workouts)` via the query file. Show optimistic loading state per Principle IV (onMutate → onError → onSettled). Use a new `useHealthKitConnection` hook in `app/lib/hooks/useHealthKitConnection.ts` mirroring `useStravaConnection`.
+- [ ] T062 [P] Add permission-denied state UI: when `getStatus().permission === 'denied'`, show guidance "Enable in iOS Settings → Privacy → Health → Synek" with a button that calls a new bridge action `openSettings()` (defer this bridge action to T065 if it adds scope) OR uses a plain text instruction in V1
+- [ ] T063 [P] Add success state: shows uploaded count, matched count, last-synced timestamp
+- [ ] T064 [P] Add error toast on sync failure
+
+### iOS
+
+- [ ] T065 [iOS] Implement `fetchWorkouts(since:)` in `HealthKitBridge.swift` — `HKSampleQueryDescriptor` + per-workout HR average via `HKStatisticsQuery`, returns DTOs
+- [ ] T066 [iOS] Implement `requestAuth()` — `HKHealthStore.requestAuthorization(toShare: [], read: types)` where types are exactly those listed in FR-002
+
+### Edge Function
+
+- [ ] T070 Implement workout matching logic in `supabase/functions/healthkit-sync/index.ts`: for each workout, find a session on the same calendar day (in athlete timezone — read from `profiles.timezone`) with a matching `training_type`. If found AND that session doesn't already have Strava actuals, populate actuals from the workout; add `'healthkit'` to `data_sources` array regardless.
+- [ ] T071 Edge Function: increment `healthkit_sync_status.total_synced_count` by the count of NEW (non-duplicate) workouts; update `last_synced_at` to NOW().
+- [ ] T072 Edge Function: return `{ uploaded: count, matched: count, lastSyncedAt: iso }`.
+
+### Tests
+
+- [ ] T075 Unit test the matching logic with mock data (same-day, different-day, type-mismatch, Strava-already-present cases)
+- [ ] T076 [iOS] XCTest: `HealthKitBridge.fetchWorkouts(since:)` returns expected DTO shape from a stubbed `HKHealthStore` (use a protocol abstraction over `HKHealthStore` to enable stubbing)
+
+### Validation gate
+
+- [ ] T080 Execute manual test plan from `quickstart.md` steps 4-9 on a physical device with real Apple Watch data
+- [ ] T081 **GATE: Dedup verified**. Run sync twice consecutively; second run uploads 0 new workouts.
+- [ ] T082 **GATE: Matching verified**. Create a planned session for tomorrow, complete a matching AW workout tomorrow, sync — session shows the actuals.
+
+**Checkpoint**: US2 fully functional. App now delivers its core value.
+
+---
+
+## Phase 5: User Story 3 — View HealthKit Sync Status (Priority P2)
+
+**Goal**: User sees sync status in Integrations tab; sessions show HealthKit badge when applicable.
+
+### Implementation
+
+- [ ] T090 In `IntegrationsSection.tsx`, render `lastSyncedAt` and `totalSyncedCount` from `useHealthKitStatus()` hook
+- [ ] T091 [P] Surface `useHealthKitSyncStatus` (created in T014) in the section UI — reads from `healthkit_sync_status` table via the query file
+- [ ] T092 [P] Add HealthKit badge component (`HealthKitBadge.tsx`) — shows alongside existing Strava badge in session detail
+- [ ] T093 [P] Render badge in session detail when `session.data_sources` includes `'healthkit'`
+
+### Tests
+
+- [ ] T095 Mock store for `healthkit_sync_status` exposing seeded data for tests
+- [ ] T096 Unit test: badge renders when source included, hidden when not
+
+### Validation gate
+
+- [ ] T100 Execute manual test plan from `quickstart.md` steps 10-12
+
+**Checkpoint**: US3 complete. Feature is feature-complete for V1.
+
+---
+
+## Phase 6: Polish & Distribution (V1 PoC scope)
+
+V1 PoC ships only to the developer's own device — no TestFlight upload, no App Store submission. Tasks below cover documentation, verification, and local device install.
+
+- [ ] T110 [iOS] Build & install to personal iPhone via Xcode (`Cmd+R` with device selected). Trust developer profile under Settings → General → VPN & Device Management on first install. Reinstall weekly when free-tier cert expires (7-day window).
+- [ ] T111 [P] Update `docs/architecture/overview.md` with a brief HealthKit integration section linking back to this spec
+- [ ] T112 [P] Update `docs/00-start-here.md` documentation map to include the iOS spec
+- [ ] T113 Run `pnpm verify` (full gate including Edge Function check) on the web side
+- [ ] T114 [iOS] Confirm no `print()` left in shipping code paths
+- [ ] T115 Tag a release on the synek main repo: `v0.X.0-ios-v1`
+- [ ] T116 Tag the corresponding `synek-ios` commit: `v1.0.0`
+
+### Deferred to "ready for testers" milestone (post-PoC)
+
+- [ ] D001 Sign up for Apple Developer account ($99/yr)
+- [ ] D002 [iOS] Claim bundle ID `app.synek.ios` globally in developer.apple.com (was T006)
+- [ ] D003 [iOS] Increment `CFBundleVersion` for first TestFlight build
+- [ ] D004 [iOS] Archive and upload to TestFlight via Xcode Organizer
+- [ ] D005 [iOS] Add internal testers in App Store Connect
+- [ ] D006 [iOS] Write TestFlight release notes: V1 scope, email/password only (no Google), manual sync only
+
+---
+
+## Dependency Graph (high level)
+
+```
+Phase 1 (Setup)
+   ↓
+Phase 2 (Foundational) — bridge + edge function must both work end-to-end
+   ↓
+   ├── Phase 3 (US1: Webview wrapper) ──┐
+   └── Phase 4 (US2: Manual sync) ──────┤
+                                         ↓
+                                   Phase 5 (US3: Status display)
+                                         ↓
+                                   Phase 6 (Polish & TestFlight)
+```
+
+US1 and US2 share the bridge but otherwise are independent — could be developed in parallel by two people if available. US3 depends on US2's data being available.
+
+---
+
+## Effort estimate (rough, single developer)
+
+| Phase                  | Effort      |
+| ---------------------- | ----------- |
+| 1. Setup               | 0.5 day     |
+| 2. Foundational        | 1.5 days    |
+| 3. US1                 | 0.5 day     |
+| 4. US2                 | 1.5 days    |
+| 5. US3                 | 0.5 day     |
+| 6. Polish & TestFlight | 0.5 day     |
+| **Total (V1)**         | **~5 days** |
+
+Add ~30-50% buffer for first-time Swift / Xcode quirks (signing, provisioning, simulator weirdness) if the developer is new to iOS.
+
+---
+
+## Notes for implementers
+
+- Cross-repo coordination: when a contract change is needed, update `contracts/healthkit-bridge.md` in this repo FIRST, then PR both repos with the synchronized changes.
+- The web side can run end-to-end against a Zod-validated mock of the bridge (no iOS needed) — use this for fast iteration on the UI.
+- The iOS side can be tested in isolation by pointing `SYNEK_WEB_URL` at a `data:` URL containing a minimal test page that exercises the bridge.
+- HealthKit testing on simulator is NOT representative — workouts are essentially empty. Plan for physical device time.
+- Apple's HealthKit review is strict about usage strings — do NOT change them ad-hoc after first submission.

--- a/supabase/migrations/20260516000000_healthkit_schema.sql
+++ b/supabase/migrations/20260516000000_healthkit_schema.sql
@@ -1,0 +1,111 @@
+-- HealthKit workouts: one row per HKWorkout pulled from the iOS app.
+-- No is_confirmed flag — coach can see athlete's HealthKit data directly
+-- (Apple's permission gate already covers user consent).
+CREATE TABLE healthkit_workouts (
+  id                  UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  hk_uuid             UUID NOT NULL UNIQUE,
+  user_id             UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  training_session_id UUID REFERENCES training_sessions(id) ON DELETE SET NULL,
+  activity_type       TEXT,
+  hk_activity_type    INTEGER,
+  source_name         TEXT,
+  source_bundle_id    TEXT,
+  start_date          TIMESTAMPTZ NOT NULL,
+  end_date            TIMESTAMPTZ NOT NULL,
+  duration_seconds    INTEGER,
+  distance_meters     DECIMAL(10,2),
+  active_energy_kcal  DECIMAL(8,2),
+  average_heartrate   DECIMAL(5,1),
+  max_heartrate       DECIMAL(5,1),
+  raw_data            JSONB,
+  created_at          TIMESTAMPTZ DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Per-user sync state: powers "last synced at" UI and surfaces errors.
+-- iOS keeps its own anchor in UserDefaults; this table is the server-side view.
+CREATE TABLE healthkit_sync_status (
+  user_id           UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  last_sync_at      TIMESTAMPTZ,
+  last_error        TEXT,
+  workouts_synced   INTEGER NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Link column on training_sessions (mirrors strava_activity_id pattern).
+ALTER TABLE training_sessions
+ADD COLUMN IF NOT EXISTS healthkit_workout_id UUID REFERENCES healthkit_workouts(id) ON DELETE SET NULL,
+ADD COLUMN IF NOT EXISTS healthkit_synced_at  TIMESTAMPTZ;
+
+CREATE TRIGGER trg_healthkit_workouts_updated
+  BEFORE UPDATE ON healthkit_workouts
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_healthkit_sync_status_updated
+  BEFORE UPDATE ON healthkit_sync_status
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE INDEX idx_healthkit_workouts_user ON healthkit_workouts(user_id);
+CREATE INDEX idx_healthkit_workouts_session ON healthkit_workouts(training_session_id)
+  WHERE training_session_id IS NOT NULL;
+CREATE INDEX idx_healthkit_workouts_start ON healthkit_workouts(user_id, start_date DESC);
+CREATE INDEX idx_training_sessions_healthkit ON training_sessions(healthkit_workout_id)
+  WHERE healthkit_workout_id IS NOT NULL;
+
+ALTER TABLE healthkit_workouts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE healthkit_sync_status ENABLE ROW LEVEL SECURITY;
+
+-- Athletes own their rows; assigned coaches can read.
+CREATE POLICY "healthkit_workouts_select_owner_or_coach"
+ON healthkit_workouts FOR SELECT
+TO authenticated
+USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1
+    FROM coach_athletes ca
+    JOIN profiles p ON p.id = auth.uid()
+    WHERE ca.coach_id = auth.uid()
+      AND ca.athlete_id = healthkit_workouts.user_id
+      AND p.role = 'coach'
+  )
+);
+
+CREATE POLICY "healthkit_workouts_insert_owner_only"
+ON healthkit_workouts FOR INSERT
+TO authenticated
+WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "healthkit_workouts_update_owner_only"
+ON healthkit_workouts FOR UPDATE
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "healthkit_workouts_delete_owner_only"
+ON healthkit_workouts FOR DELETE
+TO authenticated
+USING (user_id = auth.uid());
+
+-- Athletes manage their own status; assigned coaches can read.
+CREATE POLICY "healthkit_sync_status_select_owner_or_coach"
+ON healthkit_sync_status FOR SELECT
+TO authenticated
+USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1
+    FROM coach_athletes ca
+    JOIN profiles p ON p.id = auth.uid()
+    WHERE ca.coach_id = auth.uid()
+      AND ca.athlete_id = healthkit_sync_status.user_id
+      AND p.role = 'coach'
+  )
+);
+
+CREATE POLICY "healthkit_sync_status_modify_owner"
+ON healthkit_sync_status FOR ALL
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/20260517000000_healthkit_in_secure_view.sql
+++ b/supabase/migrations/20260517000000_healthkit_in_secure_view.sql
@@ -1,0 +1,110 @@
+-- Extend secure_training_sessions to surface HealthKit-sourced actuals.
+-- Precedence per field: HealthKit (when linked) > Strava (when linked) > manual ts.actual_*.
+-- HealthKit has no is_confirmed gate (coach always sees synced HK data, gated only by RLS).
+
+DROP VIEW IF EXISTS secure_training_sessions;
+CREATE VIEW secure_training_sessions
+WITH (security_invoker = true) AS
+SELECT
+  ts.id,
+  ts.week_plan_id,
+  ts.day_of_week,
+  ts.sort_order,
+  ts.training_type,
+  ts.description,
+  ts.coach_comments,
+  ts.planned_duration_minutes,
+  ts.planned_distance_km,
+  ts.type_specific_data,
+  ts.is_completed,
+  ts.completed_at,
+  CASE
+    WHEN ts.healthkit_workout_id IS NOT NULL AND hk.id IS NOT NULL THEN
+      COALESCE(hk.duration_seconds / 60, ts.actual_duration_minutes)
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.actual_duration_minutes
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN GREATEST(sa.moving_time_seconds, 0) / 60
+        ELSE NULL
+      END
+    ELSE ts.actual_duration_minutes
+  END AS actual_duration_minutes,
+  CASE
+    WHEN ts.healthkit_workout_id IS NOT NULL AND hk.id IS NOT NULL THEN
+      COALESCE(ROUND((hk.distance_meters / 1000.0)::numeric, 2), ts.actual_distance_km)
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.actual_distance_km
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN ROUND((sa.distance_meters / 1000.0)::numeric, 2)
+        ELSE NULL
+      END
+    ELSE ts.actual_distance_km
+  END AS actual_distance_km,
+  CASE
+    -- HealthKit does not provide pace directly; fall back to ts.actual_pace
+    WHEN ts.healthkit_workout_id IS NOT NULL AND hk.id IS NOT NULL THEN ts.actual_pace
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.actual_pace
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN sa.average_pace_per_km
+        ELSE NULL
+      END
+    ELSE ts.actual_pace
+  END AS actual_pace,
+  CASE
+    WHEN ts.healthkit_workout_id IS NOT NULL AND hk.id IS NOT NULL THEN
+      COALESCE(ROUND(hk.average_heartrate)::integer, ts.avg_heart_rate)
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.avg_heart_rate
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN ROUND(sa.average_heartrate)::integer
+        ELSE NULL
+      END
+    ELSE ts.avg_heart_rate
+  END AS avg_heart_rate,
+  CASE
+    WHEN ts.healthkit_workout_id IS NOT NULL AND hk.id IS NOT NULL THEN
+      COALESCE(ROUND(hk.max_heartrate)::integer, ts.max_heart_rate)
+    WHEN ts.strava_activity_id IS NOT NULL THEN
+      CASE
+        WHEN sa.id IS NULL THEN ts.max_heart_rate
+        WHEN wp.athlete_id = auth.uid() OR sa.is_confirmed THEN ROUND(sa.max_heartrate)::integer
+        ELSE NULL
+      END
+    ELSE ts.max_heart_rate
+  END AS max_heart_rate,
+  ts.rpe,
+  CASE
+    WHEN ts.healthkit_workout_id IS NOT NULL AND hk.id IS NOT NULL THEN
+      COALESCE(ROUND(hk.active_energy_kcal)::integer, ts.calories)
+    ELSE ts.calories
+  END AS calories,
+  ts.coach_post_feedback,
+  ts.trainee_notes,
+  ts.strava_activity_id,
+  ts.strava_synced_at,
+  COALESCE(sa.is_confirmed, FALSE) AS is_strava_confirmed,
+  ts.healthkit_workout_id,
+  ts.healthkit_synced_at,
+  hk.source_name AS healthkit_source_name,
+  ts.goal_id,
+  ts.result_distance_km,
+  ts.result_time_seconds,
+  ts.result_pace,
+  ts.created_at,
+  ts.updated_at
+FROM training_sessions ts
+JOIN week_plans wp ON wp.id = ts.week_plan_id
+LEFT JOIN LATERAL (
+  SELECT sa1.*
+  FROM strava_activities sa1
+  WHERE sa1.training_session_id = ts.id
+     OR (ts.strava_activity_id IS NOT NULL AND sa1.strava_id = ts.strava_activity_id)
+  ORDER BY (sa1.training_session_id = ts.id) DESC
+  LIMIT 1
+) sa ON TRUE
+LEFT JOIN healthkit_workouts hk ON hk.id = ts.healthkit_workout_id;
+
+GRANT SELECT ON secure_training_sessions TO authenticated;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What

Two features that let athletes reschedule sessions within a week.

### 1. Drag-and-drop between day columns
Athletes can now drag sessions between columns just like the coach view. Wired unconditionally — athletes own their sessions via RLS regardless of `canSelfPlan`.

### 2. Day navigator in `SessionDetailModal`
Replaces the static date string at the top of the modal with an interactive strip:
- **← / →** arrows step ±1 day within the week (disabled at Mon/Sun boundaries)
- **Middle button** shows current day name + date; tap/click opens a 7-day popover grid (abbr + date number per column)
- Strip turns `text-primary` when the selected day differs from the session's actual day
- On modal close (any method) — if day changed, fires `updateSession({ dayOfWeek })` with full optimistic update + rollback

Works for both athlete and coach views.

## Also

**pnpm v11 config fix** (separate commit):
- `package.json` `pnpm` field removed — v11 no longer reads it
- `pnpm-workspace.yaml` committed with correct `allowBuilds` syntax; `storeDir: .pnpm-store` removed (no pipeline uses the local store)
- `.pnpm-store/` added to `.gitignore`

## Files
| File | Change |
|---|---|
| `app/components/ui/popover.tsx` | New Radix Popover wrapper (`z-[100]` for Dialog compat) |
| `app/lib/context/SessionActionsContext.tsx` | `+onMoveToDay` |
| `app/components/calendar/WeekGrid.tsx` | Thread `onMoveToDay` into context |
| `app/components/training/SessionDetailModal.tsx` | Day navigator strip |
| `app/lib/hooks/useWeekView.ts` | `+handleReorderSession` `+handleMoveToDay` |
| `app/routes/athlete/week.$weekId.tsx` | Wire both to WeekGrid |
| `app/components/calendar/MultiWeekView.tsx` | Wire `onMoveToDay` for coach |
| `pnpm-workspace.yaml` | New — pnpm v11 build allowlist |
| `package.json` | Remove stale `pnpm` field |
| `.gitignore` | Ignore `.pnpm-store/` |